### PR TITLE
Change repo location of ido-ubiquitous

### DIFF
--- a/pkglist
+++ b/pkglist
@@ -74,7 +74,7 @@
   :fetcher git
   :files ("idle-highlight-mode.el"))
  (ido-ubiquitous
-  :url "git://github.com/technomancy/ido-ubiquitous.git"
+  :url "git://github.com/DarwinAwardWinner/ido-ubiquitous.git"
   :fetcher git
   :files ("ido-ubiquitous.el"))
  (inf-ruby


### PR DESCRIPTION
The repo that is use now is not "mainstream". It contains outdated code that does not work with newest Emacs 24.

Please read this:
https://github.com/technomancy/ido-ubiquitous/issues/10
It explains everything
