### PR TITLE
Include helper script in flymake-perlcritic

### DIFF
--- a/pkglist
+++ b/pkglist
@@ -73,7 +73,8 @@
   :fetcher wiki)
  (flymake-perlcritic
   :url "https://github.com/illusori/emacs-flymake-perlcritic.git"
-  :fetcher git)
+  :fetcher git
+  :files ("*.el" "bin/flymake_perlcritic"))
  (full-ack
   :url "https://github.com/nschum/full-ack.git"
   :fetcher git)


### PR DESCRIPTION
Sorry, here's a clean single-commit pull request -- again, this adds in a helper shell script that flymake-perlcritic depends on for proper working. 
