### PR TITLE
Added gist's new deps

### DIFF
--- a/recipes/gh
+++ b/recipes/gh
@@ -1,0 +1,1 @@
+(gh :url "https://github.com/sigma/gh.el.git" :fetcher git)

--- a/recipes/logito
+++ b/recipes/logito
@@ -1,0 +1,1 @@
+(logito :url "https://github.com/sigma/logito.git" :fetcher git)

--- a/recipes/pcache
+++ b/recipes/pcache
@@ -1,0 +1,1 @@
+(pcache :url "https://github.com/sigma/pcache.git" :fetcher git)

--- a/recipes/tabulated-list
+++ b/recipes/tabulated-list
@@ -1,0 +1,2 @@
+(tabulated-list :url "https://github.com/sigma/tabulated-list.el" :fetcher git)
+


### PR DESCRIPTION
The gist package was recently updated and its latest version depends on a few packages that weren't in MELPA already - gh, pcache, logito and tabulated-list. 
