### PR TITLE
* recipes/escreen: terminal multiplexer a la GNU Screen

### DIFF
--- a/recipes/escreen
+++ b/recipes/escreen
@@ -1,0 +1,1 @@
+(escreen :repo "emacsmirror/escreen" :fetcher github)


### PR DESCRIPTION
I am not the original author of this package, as indicated by the emacsmirror origin.
