### PR TITLE
emacs24-inkpot

### DIFF
--- a/emacs24-inkpot
+++ b/emacs24-inkpot
@@ -1,0 +1,3 @@
+(emacs24-inkpot 
+:repo "https://github.com/siovan/emacs24-inkpot.git"
+:fetcher github) 


### PR DESCRIPTION
Added a port of the vim color theme inkpot for use with emacs 24
