### PR TITLE
Added support for color-theme-solarized

### DIFF
--- a/recipes/color-theme-solarized
+++ b/recipes/color-theme-solarized
@@ -1,0 +1,1 @@
+(color-theme-solarized :repo "sellout/emacs-color-theme-solarized" :fetcher github)


### PR DESCRIPTION
This is the official repo as used by Solarized itself. It's Emacs 23/24 compatible.
