### PR TITLE
Add recipe for workgroups

### DIFF
--- a/recipes/workgroups
+++ b/recipes/workgroups
@@ -1,0 +1,1 @@
+(workgroups :repo "tlh/workgroups.el" :fetcher github)


### PR DESCRIPTION
Workgroups is a window configuration management package for GNU Emacs.
