### PR TITLE
Moved zf-mode to php+-mode

### DIFF
--- a/recipes/php+-mode
+++ b/recipes/php+-mode
@@ -1,0 +1,4 @@
+(php+-mode
+ :fetcher github
+ :repo "echosa/phpplus-mode"
+ :files ("*.el"))

--- a/recipes/zf-mode
+++ b/recipes/zf-mode
@@ -1,4 +1,0 @@
-(zf-mode
- :fetcher github
- :repo "echosa/zf-mode"
- :files ("*.el" "ZFMode"))


### PR DESCRIPTION
zf-mode has been renamed to php+-mode (phpplus-mode on github). I have removed the the zf-mode recipe and added the phpplus-mode recipe. The ZFMode folder is no longer a part of php+-mode, and thus has been removed from the files list.
