### PR TITLE
Add recipe for org-contrib

### DIFF
--- a/recipes/org-contrib
+++ b/recipes/org-contrib
@@ -1,0 +1,4 @@
+(org-contrib
+ :url "git://orgmode.org/org-mode.git"
+ :fetcher git
+ :files ("contrib/lisp/*.el" "contrib/babel/langs/*.el"))


### PR DESCRIPTION
This adds a recipe for packaging all contributed elisp files in org-mode's contrib directory. Since the files in contrib/ is not distributed with Emacs, nor in the org-mode-package in GNU ELPA, I wanted a simple way to install them without building yet another org-mode package.

I suppose that this package can be considered somewhat controversial due to its size and the number of elisp files (>50) involved. 
