### PR TITLE
add recipe for logalimacs

### DIFF
--- a/recipes/logalimacs
+++ b/recipes/logalimacs
@@ -1,1 +1,3 @@
-(logalimacs :repo "logaling/logalimacs" :fetcher github)
+(logalimacs :repo "logaling/logalimacs"
+            :fetcher github
+            :files ("logalimacs.el"))


### PR DESCRIPTION
Logalimacs is support tool for translation project.
It is front-end program to use logaling-command of Ruby gem at Emacs.
URL: http://logaling.github.com/logalimacs/
(Sorry, however document of the English not been prepared yet)
