### PR TITLE
Add recipe for multi-eshell

### DIFF
--- a/recipes/multi-eshell
+++ b/recipes/multi-eshell
@@ -1,0 +1,1 @@
+(multi-eshell :fetcher wiki)


### PR DESCRIPTION
Multi-eshell lets one create and manage multiple shells within Emacs and can be used with either ansi-term, shell or eshell.
