### PR TITLE
Add underwater-theme.el recipe

### DIFF
--- a/recipes/underwater-theme.el
+++ b/recipes/underwater-theme.el
@@ -1,0 +1,1 @@
+(underwater-theme :repo "jmdeldin/underwater-theme.el" :fetcher github)


### PR DESCRIPTION
Hello,

This recipe adds my Emacs 24 theme: https://github.com/jmdeldin/underwater-theme.el

I've tested on Emacs 24.1.1 on OS X 10.7.4 with `buildpkg` and `package-install-from-file`.

Thanks!
