### PR TITLE
Add ir-black-theme.el recipe

### DIFF
--- a/recipes/ir-black-theme.el
+++ b/recipes/ir-black-theme.el
@@ -1,0 +1,1 @@
+(ir-black-theme :repo "jmdeldin/ir-black-theme.el" :fetcher github)


### PR DESCRIPTION
Hello,

Although an ir_black theme already exists in MELPA, I have another one that supports magit diffs and org-mode: https://github.com/jmdeldin/ir-black-theme.el

Thanks!
