### PR TITLE
Shimbun recipe

### DIFF
--- a/recipes/shimbun
+++ b/recipes/shimbun
@@ -1,0 +1,3 @@
+(shimbun :repo "emacsmirror/w3m"
+	 :fetcher github
+	 :files ("shimbun/*.el"))


### PR DESCRIPTION
Add recipe for the shimbun sub-package of emacs-w3m.  Use the
emacsmirror github repository.
