### PR TITLE
Add recipe for fill-column-indicator package

### DIFF
--- a/recipes/fill-column-indicator
+++ b/recipes/fill-column-indicator
@@ -1,3 +1,1 @@
-(fill-column-indicator :fetcher github
-                       :repo "alpaker/Fill-Column-Indicator"
-                       :files ("fill-column-indicator.el"))
+(fill-column-indicator :repo "alpaker/Fill-Column-Indicator" :fetcher github)


### PR DESCRIPTION
Another minor-mode I can't live without.

More info on the project page: [alpaker/Fill-Column-Indicator](https://github.com/alpaker/Fill-Column-Indicator)
