### PR TITLE
Add recipe for feature-mode package

### DIFF
--- a/recipes/feature-mode
+++ b/recipes/feature-mode
@@ -1,0 +1,4 @@
+(feature-mode
+ :repo "michaelklishin/cucumber.el"
+ :fetcher github
+ :files ("*.el" "i18n.yml" "snippets" "support"))


### PR DESCRIPTION
A mode for working with Cucumber/Gherkin `*.feature` files.

I'm new to all of this, so this might be a stupid question, but I get the following error message when I try to active `feature-mode` by opening a file or manually with `M-x feature-mode`:

```
call-interactively: Cannot open load file: feature-mode/feature-mode
```

If I add `(require 'feature-mode)` to my init config it works fine though. I was under the impression that the autoload stuff would take care of this. I've also noticed the same thing with the fill-column-indicator package I recently submitted too.
