### PR TITLE
Add recipe for helm-gtags.el

### DIFF
--- a/recipes/helm-gtags
+++ b/recipes/helm-gtags
@@ -1,0 +1,4 @@
+(helm-gtags
+ :repo "syohex/emacs-helm-gtags"
+ :fetcher github
+ :files ("helm-gtags.el"))


### PR DESCRIPTION
helm-gtags.el is GNU GLOBAL helm interface.
