### PR TITLE
Fix portability problem with #!/usr/bin/env (issue #203)

### DIFF
--- a/buildpkg
+++ b/buildpkg
@@ -1,4 +1,5 @@
-#!/usr/bin/env emacs --script
+#!/bin/sh 
+:;exec emacs --script "$0" "$@"
 
 (add-to-list 'load-path (file-name-directory load-file-name))
 

--- a/migrate
+++ b/migrate
@@ -1,4 +1,5 @@
-#!/usr/bin/env emacs --script
+#!/bin/sh 
+:;exec emacs --script "$0" "$@"
 
 (defun read-from-file (file-name)
   "read one lisp expression from a file"

--- a/missing.el
+++ b/missing.el
@@ -1,4 +1,5 @@
-#!/usr/bin/env emacs --script
+#!/bin/sh 
+:;exec emacs --script "$0" "$@"
 
 (defun difference (left right)
   "compare two lists"


### PR DESCRIPTION
Passing the `--script` option to emacs doesn't work as expected on Linux, since the shebang is evaluated as `#!/usr/bin/env "emacs --script"`.
