### PR TITLE
Replace melpa script with Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+SHELL   := /bin/bash
+PKGDIR  := ./packages
+HTMLDIR := ./html
+WORKDIR := ./working
+
+.PHONY: clean build index html
+.FORCE:
+
+all: build index
+
+build:
+	emacs --batch -l package-build.el --eval "(package-build-all)"
+
+html:
+	$(MAKE) -C $(HTMLDIR)
+
+index: html
+
+clean-working:
+	rm -rf $(WORKDIR)/*
+
+clean-packages:
+	rm -rfv $(PKGDIR)/*
+
+clean: clean-working clean-packages
+
+recipes/%: .FORCE
+	-rm -vf $(PKGDIR)/$(notdir $@)-*
+	@echo
+	./buildpkg $(notdir $@)

--- a/html/Makefile
+++ b/html/Makefile
@@ -1,0 +1,13 @@
+SHELL  := /bin/bash
+
+.PHONY: all clean
+all: index.html
+
+index.md: index.erb
+	erb index.erb > index.md
+
+index.html: index.md
+	pandoc --template=template.html --css=style.css -s --mathml -t html --smart index.md > index.html
+
+clean:
+	-rm -v index.md index.html


### PR DESCRIPTION
Adds two Makefiles that basically do what the `melpa` bash script does in a more elegant and less verbose manner. Provides the following targets: 
- `all clean clean-working build clean-packages html index recipes/%`

`make recipies/yaml-mode` is just a shortcut for `./buildpkg yaml-mode`

The free shell completion from switching to a Makefile is also nice. 
