### PR TITLE
Add dummy-h-mode recipe

### DIFF
--- a/recipes/dummy-h-mode
+++ b/recipes/dummy-h-mode
@@ -1,0 +1,1 @@
+(dummy-h-mode :fetcher wiki)


### PR DESCRIPTION
This mode tries to figure out which mode (c-mode, c++-mode or objc-mode) emacs should use when opening a .h file.
