### PR TITLE
Add recipe for ruby-electric package

### DIFF
--- a/recipes/ruby-electric
+++ b/recipes/ruby-electric
@@ -1,0 +1,1 @@
+(ruby-electric :repo "qoobaa/ruby-electric" :fetcher github)


### PR DESCRIPTION
I know there's a ruby-end package, but I use ruby-electric to insert end blocks, and to pair the pipe `|` character, as auto-pair doesn't do it. And there might be others who use ruby-electric too :)
