### PR TITLE
rust-mode/cm-mode recipe

### DIFF
--- a/recipes/cm-mode
+++ b/recipes/cm-mode
@@ -1,4 +1,3 @@
 (cm-mode :repo "mozilla/rust"
-         :commit "incoming"
          :fetcher github
          :files ("src/etc/emacs/cm-mode.el"))

--- a/recipes/rust-mode
+++ b/recipes/rust-mode
@@ -1,4 +1,3 @@
 (rust-mode :repo "mozilla/rust"
-           :commit "incoming"
            :fetcher github
            :files ("src/etc/emacs/rust-mode.el"))


### PR DESCRIPTION
cm-mode is a dependency of rust-mode, it resides in the rust repository as well.
