### PR TITLE
Add nrepl-ritz

### DIFF
--- a/recipes/nrepl-ritz
+++ b/recipes/nrepl-ritz
@@ -1,0 +1,3 @@
+(nrepl-ritz :repo "pallet/ritz"
+            :fetcher github
+            :files ("src/main/elisp/nrepl-ritz.el"))


### PR DESCRIPTION
nrepl-ritz provides a debugger for nrepl.el that uses ritz
