### PR TITLE
Add fakespace recipe.

### DIFF
--- a/recipes/fakespace
+++ b/recipes/fakespace
@@ -1,0 +1,3 @@
+(fakespace :repo "skeeto/elisp-fakespace"
+           :fetcher github
+           :files ("fakespace.el"))


### PR DESCRIPTION
The fakespace package provides a sort-of `defpackage` that facilitates hiding private symbols from the rest of Emacs.
