### PR TITLE
recipes: fix the color-theme recipe

### DIFF
--- a/recipes/color-theme
+++ b/recipes/color-theme
@@ -1,1 +1,3 @@
-(color-theme :url "http://bzr.savannah.gnu.org/r/color-theme/trunk" :fetcher bzr)
+(color-theme :url "http://bzr.savannah.gnu.org/r/color-theme/trunk"
+             :fetcher bzr
+             :files ("*.el" "themes"))


### PR DESCRIPTION
The current recipe failed to include the theme directory, which the
color-theme looks at by default when not customized.  In a normal Emacs
startup, the errors was quietly ignored, but part of your configuration
wouldn't work.  Fix this by including the themes/ directory, and
hopefully make installing this package a better experience for new
users.
