### PR TITLE
Auto-complete repository changed.

### DIFF
--- a/recipes/auto-complete
+++ b/recipes/auto-complete
@@ -1,3 +1,3 @@
-(auto-complete :repo "m2ym/auto-complete" :fetcher github :files
+(auto-complete :repo "auto-complete/auto-complete" :fetcher github :files
                ("*.el" "dict"))
 

--- a/recipes/popup
+++ b/recipes/popup
@@ -1,4 +1,4 @@
-(popup :repo "m2ym/popup-el"
+(popup :repo "auto-complete/popup-el"
        :fetcher github
        :files ("popup.el"))
 


### PR DESCRIPTION
The repository has moved to [auto-complete organization](https://github.com/auto-complete).
