### PR TITLE
Add gap-mode

### DIFF
--- a/recipes/gap-mode
+++ b/recipes/gap-mode
@@ -1,0 +1,3 @@
+(gap-mode
+ :fetcher hg
+ :url "https://bitbucket.org/gvol/gap-mode")


### PR DESCRIPTION
First, thanks for MELPA.  I love it!

GAP is a computer algebra system.  Right now the emacs support bundled with it is quite old.  Moreover, they are debating whether to remove from the distribution entirely and simply point people to the latest version.  Having it on melpa would make it much easier for people to get the latest code, especially since many of GAP's users are not programmers, and aren't comfortable installing manually from bitbucket etc.

Thanks,
Ivan
