### PR TITLE
[#177] Add support for CVS

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ the following form,
  :fetcher [git|github|bzr|hg|darcs|svn|cvs|wiki]
  [:url "<repo url>"]
  [:repo "github-user/repo-name"]
+ [:module "cvs-module"]
  [:files ("<file1>", ...)])
 ```
 
@@ -121,7 +122,7 @@ a lisp symbol that has the same name as the package being specified.
 specifies the URL of the version control repository. *required for
 the `git`, `bzr`, `hg`, `darcs`, `svn` and `cvs` fetchers*
 
-- `:cvs-module`
+- `:module`
 specifies the module of a CVS repository to check out.  Defaults to to
 `package-name`.  Only used with `:fetcher cvs`, and otherwise ignored.
 

--- a/package-build.el
+++ b/package-build.el
@@ -258,7 +258,7 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
   "Check package NAME with config CONFIG out of csv into DIR."
   (with-current-buffer (get-buffer-create "*package-build-checkout*")
     (let ((root (pb/trim (plist-get config :url) ?/))
-          (repo (or (plist-get config :cvs-module) (symbol-name name)))
+          (repo (or (plist-get config :module) (symbol-name name)))
           (bound (goto-char (point-max))))
       (cond
        ((and (file-exists-p (expand-file-name "CVS" dir))


### PR DESCRIPTION
As the title says…

I've just seen, that @gvol did the same in #297, but I pull request my implementation anyway, since there are some differences:
- I identify repositories based on repository root _and_ CVS module, whereas @gvol only uses the root.  
- I added a new metadata `:cvs-module` in case the CVS module differs from the intended name of the package.  @gvol does not support such cases.
- I (hopefully, not sure how date parsing works insite `package-build.el`) parse the time zone offset in CVS timestamps, @gvol does not.

I'll leave to you to decide which implementation should be merged.
