### PR TITLE
Please add zotelo recipe

### DIFF
--- a/recipes/zotelo
+++ b/recipes/zotelo
@@ -1,0 +1,1 @@
+(zotelo :repo "vitoshka/zotelo" :fetcher github)


### PR DESCRIPTION
Package.el seems not to recognize ;;;;Commentary  field. I cannot make it work locally in any fashion. Some of the packages (not from MELPA) have the commentary in the description.  When I try to build those packages (with the working commentary)  by changing file name and package name, commentary is not recognized. Any ideas of what is going on?
