### PR TITLE
Add git-commit

### DIFF
--- a/recipes/git-commit
+++ b/recipes/git-commit
@@ -1,0 +1,1 @@
+(git-commit :repo "rafl/git-commit-mode" :fetcher github)


### PR DESCRIPTION
[git-commit](https://github.com/rafl/git-commit-mode) is a mode to edit Git commit messages conforming to the [guidelines established by Tim Pope](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
