### PR TITLE
Replace git-commit with git-commit-mode

### DIFF
--- a/recipes/git-commit
+++ b/recipes/git-commit
@@ -1,1 +1,0 @@
-(git-commit :repo "rafl/git-commit-mode" :fetcher github)

--- a/recipes/git-commit-mode
+++ b/recipes/git-commit-mode
@@ -1,0 +1,1 @@
+(git-commit-mode :repo "lunaryorn/git-commit-mode" :fetcher github)


### PR DESCRIPTION
Following up my previous pull request #318, I propose to replace the git-commit package with my own [git-commit-mode](/lunaryorn/git-commit-mode) package. 

Sorry for the hassle, but having using git-commit a bit now, I found more issues beyond the byte-compilation failure.  I've forked git-commit and fixed the most pressing of these.   Most notable differences to the original package are:
- The file name and the provided feature match the mode name for the sake of consistency with other packages.
- Message buffers from `emacsclient` are closed properly on `C-c C-c`.
- Highlighting for notes of the form `[foo@example.com: Some message]` is removed.  I have never seen anyone using such notes, and do not consider them special enough to deserve a dedicated highlighting.  However, I will probably add highlighting for Github specific notes (i.e. `[Fix #5]`), since these have widespread use, and the format is understood by many other hosting services like BitBucket, too.
- `git-commit-mode` derives from `text-mode` now so that `text-mode-hook`s are run.
- `auto-fill-mode` is enabled, and `fill-column` set to 72 according to the guidelines of @tpope.
- Faces used inherit from standard font lock faces for color theme compliance.

Since @rafl hasn't even reacted on the simple pull request that fixes byte compilation for over three months now, I did not bother to send a pull request with these changes.  Instead, I consider myself maintainer of this package now, and will continue to maintain my own fork, until @rafl works on his package again, and merges my changes.
