### PR TITLE
Add gitconfig-mode

### DIFF
--- a/recipes/gitconfig-mode
+++ b/recipes/gitconfig-mode
@@ -1,0 +1,1 @@
+(gitconfig-mode :repo "lunaryorn/gitconfig-mode" :fetcher github)


### PR DESCRIPTION
I was surprise to see that there is no mode to edit `.gitconfig` files, so I wrote [my own](/lunaryorn/gitconfig-mode).  You may want to add it to the repository.
