### PR TITLE
Add keydef

### DIFF
--- a/recipes/keydef
+++ b/recipes/keydef
@@ -1,0 +1,3 @@
+(keydef
+ :repo "emacsmirror/keydef"
+ :fetcher github)


### PR DESCRIPTION
The macro keydef provides a simplified interface to define-key that
smoothly handles a number of common complications.
