### PR TITLE
Fix URLs for git modes

### DIFF
--- a/recipes/git-commit-mode
+++ b/recipes/git-commit-mode
@@ -1,1 +1,3 @@
-(git-commit-mode :repo "lunaryorn/git-commit-mode" :fetcher github)
+(git-commit-mode :repo "lunaryorn/git-commit-mode"
+                 :fetcher github
+                 :files ("git-commit-mode.el"))

--- a/recipes/gitconfig-mode
+++ b/recipes/gitconfig-mode
@@ -1,1 +1,3 @@
-(gitconfig-mode :repo "lunaryorn/gitconfig-mode" :fetcher github)
+(gitconfig-mode :repo "lunaryorn/git-modes"
+                :fetcher github
+                :files ("gitconfig-mode.el"))


### PR DESCRIPTION
Sorry to bug you again: I've moved my `gitconfig-mode` and `gitcommit-mode` packages into a single [git-modes](/lunaryorn/git-modes) repository to ease maintenance.  This pull request updates the URL of the corresponding recipes accordingly.
