### PR TITLE
Add gitignore-mode

### DIFF
--- a/recipes/gitignore-mode
+++ b/recipes/gitignore-mode
@@ -1,0 +1,3 @@
+(gitignore-mode :repo "lunaryorn/git-modes"
+                :fetcher github
+                :files ("gitignore-mode.el"))


### PR DESCRIPTION
`gitignore-mode` is a simple mode for `.gitignore` files with basic font locking.
