### PR TITLE
Add flymake-checkers

### DIFF
--- a/recipes/git-commit-mode
+++ b/recipes/git-commit-mode
@@ -1,3 +1,1 @@
-(git-commit-mode :repo "lunaryorn/git-modes"
-                 :fetcher github
-                 :files ("git-commit-mode.el"))
+(flymake-checkers :repo "lunaryorn/flymake-checkers" :fetcher github)


### PR DESCRIPTION
[flymake-checkers](https://github.com/lunaryorn/flymake-checkers) provides additional syntax checkers for flymake.

Currently there are checkers for Emacs Lisp, Python, Ruby, CoffeeScript and LaTeX.
