### PR TITLE
Fix flymake-checkers recipe [#331]

### DIFF
--- a/recipes/flymake-checkers
+++ b/recipes/flymake-checkers
@@ -1,0 +1,1 @@
+(flymake-checkers :repo "lunaryorn/flymake-checkers" :fetcher github)

--- a/recipes/git-commit-mode
+++ b/recipes/git-commit-mode
@@ -1,1 +1,3 @@
-(flymake-checkers :repo "lunaryorn/flymake-checkers" :fetcher github)
+(git-commit-mode :repo "lunaryorn/git-modes"
+                 :fetcher github
+                 :files ("git-commit-mode.el"))


### PR DESCRIPTION
Follow up to #331, restores git-commit-mode recipe and puts a proper flymake-checkers recipe in place.  Sorry :|
