### PR TITLE
Rename flymake-checkers to flycheck

### DIFF
--- a/recipes/flycheck
+++ b/recipes/flycheck
@@ -1,0 +1,1 @@
+(flycheck :repo "lunaryorn/flycheck" :fetcher github)

--- a/recipes/flymake-checkers
+++ b/recipes/flymake-checkers
@@ -1,1 +1,0 @@
-(flymake-checkers :repo "lunaryorn/flymake-checkers" :fetcher github)


### PR DESCRIPTION
Upstream package was renamed, see lunaryorn/flycheck#5.

Follow up to #331.
