### PR TITLE
Add epc recipe and its required packages

### DIFF
--- a/recipes/concurrent
+++ b/recipes/concurrent
@@ -1,0 +1,4 @@
+(concurrent
+  :repo "kiwanami/emacs-deferred"
+  :fetcher github
+  :files ("concurrent.el"))

--- a/recipes/ctable
+++ b/recipes/ctable
@@ -1,0 +1,4 @@
+(ctable
+  :repo "kiwanami/emacs-ctable"
+  :fetcher github
+  :files ("ctable.el"))

--- a/recipes/epc
+++ b/recipes/epc
@@ -1,0 +1,4 @@
+(epc
+  :repo "kiwanami/emacs-epc"
+  :fetcher github
+  :files ("epc.el" "epcs.el"))


### PR DESCRIPTION
epc is a RPC stack for Emacs Lisp.

Please review.
