### PR TITLE
add python-pylint recipe

### DIFF
--- a/recipes/python-pylint
+++ b/recipes/python-pylint
@@ -1,3 +1,4 @@
 (python-pylint
- :url "git://gist.github.com/302848.git"
- :fetcher git)
+ :url "http://hg.logilab.org/pylint"
+ :fetcher hg
+ :files ("elisp/pylint.el"))


### PR DESCRIPTION
https://gist.github.com/3094248
http://www.logilab.org/project/pylint

I think this is far better than the elisp file that comes with pylint.  
