### PR TITLE
don't fetch debug/test files for yasnippet

### DIFF
--- a/recipes/yasnippet
+++ b/recipes/yasnippet
@@ -1,4 +1,4 @@
 (yasnippet :repo "capitaomorte/yasnippet"
            :fetcher github
-           :files ("*.el" "snippets"))
+           :files ("yasnippet.el" "dropdown-list.el" "snippets"))
 


### PR DESCRIPTION
The recipe for yasnippet should not fetch and build debug/test files.
Install succeeds without this patch, but there is a glut of error messages likely to confuse the user.
