### PR TITLE
* recipes/ncl-mode: new package ncl-mode

### DIFF
--- a/recipes/ncl-mode
+++ b/recipes/ncl-mode
@@ -1,0 +1,4 @@
+(ncl-mode
+ :repo "yyr/ncl-mode"
+ :fetcher github
+ :files ("*.el"))


### PR DESCRIPTION
I am familiar with how packaging works., Please review this.

I have a initializing script called ncl-mode-load.el,  snippets for yasnippet and auto-completion dictionary in addition to the major-mode.

would it be possible tell to elpa to load that initializing script?
