### PR TITLE
Remove the leading blank line in the readmes

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -447,9 +447,12 @@ The file is written to `package-build-working-dir'."
       ;; Adapted from `describe-package-1'.
       (goto-char (point-min))
       (save-excursion
-        (when (re-search-forward "^;;; Commentary:\n+" nil t)
+        (when (re-search-forward "^;;; Commentary:\n" nil t)
           (replace-match ""))
         (while (re-search-forward "^\\(;+ ?\\)" nil t)
+          (replace-match ""))
+        (goto-char (point-min))
+        (when (re-search-forward "\\`\\( *\n\\)+" nil t)
           (replace-match "")))
       (delete-trailing-whitespace)
       (let ((coding-system-for-write buffer-file-coding-system))


### PR DESCRIPTION
The code we lifted from `describe-package-1` doesn't strip the empty line after the ";;; Commentary:" when it's present.

GNU ELPA don't seem to have this problem.
