### PR TITLE
Add recipe for scala-mode2

### DIFF
--- a/recipes/scala-mode2
+++ b/recipes/scala-mode2
@@ -1,0 +1,3 @@
+(scala-mode2
+ :repo "hvesalai/scala-mode2"
+ :fetcher github)


### PR DESCRIPTION
scala-mode2 is an improved scala-mode for emacs. It is losely based on the
original, but has been completely rewritten for scala 2.9 (and 2.10)

The related issue on the project itself is here:
https://github.com/hvesalai/scala-mode2/issues/33

Signed-off-by: Gary Pamparà gpampara@gmail.com
