### PR TITLE
Only package rspec-mode.el

### DIFF
--- a/recipes/rspec-mode
+++ b/recipes/rspec-mode
@@ -1,2 +1,2 @@
-(rspec-mode :repo "pezra/rspec-mode" :fetcher github)
+(rspec-mode :repo "pezra/rspec-mode" :fetcher github :files ("rspec-mode.el"))
 


### PR DESCRIPTION
This removes the totally unnecessary `rspec-mode-expectations.el`, which depends on a third-party package that is not present in any ELPA.
