### PR TITLE
Add non-elisp file to gap-mode

### DIFF
--- a/recipes/gap-mode
+++ b/recipes/gap-mode
@@ -1,3 +1,4 @@
 (gap-mode
  :fetcher hg
- :url "https://bitbucket.org/gvol/gap-mode")
+ :url "https://bitbucket.org/gvol/gap-mode"
+ :files ("*.el" "emacs.gaprc"))


### PR DESCRIPTION
I recently added non-elisp file (emacs.gaprc) to gap-mode which should be distributed.  It's not essential to the functioning of gap-mode, but it makes some interaction more robust.

Thanks,
Ivan
