### PR TITLE
Fsharp-mode

### DIFF
--- a/recipes/fsharp-mode
+++ b/recipes/fsharp-mode
@@ -1,4 +1,4 @@
 (fsharp-mode
  :fetcher github
  :repo "fsharp/fsharpbinding"
- :files ("emacs/fsharp.el" "emacs/fsharp-font.el" "emacs/fsharp-indent.el" "emacs/inf-fsharp.el" "emacs/fsharp-mode-pkg.el"))
+ :files ("emacs/fsharp-mode.el" "emacs/fsharp-mode-font.el" "emacs/fsharp-mode-indent.el" "emacs/inf-fsharp-mode.el" "emacs/fsharp-mode-pkg.el"))


### PR DESCRIPTION
Hi, this pull request actually has to wait for this other one :)
https://github.com/fsharp/fsharpbinding/pull/69

(I discovered that the home of that mode is now under the F# community itself... so I really think that somebody should be able of take care of it, and thus inside the recipe it doesn't point anymore to my fork)

Thanks again for your help btw!
