### PR TITLE
Web: link to github and emacswiki

### DIFF
--- a/html/index.erb
+++ b/html/index.erb
@@ -13,11 +13,13 @@
 <%
   require 'json'
   archive_json = JSON.parse(File.open("../archive.json").read)
+  recipe_json  = JSON.parse(File.open("../recipes.json").read)
 
-  headers = ["Package", "Version", "Description", "Source"]
+  headers = ["Package", "Version", "Description", "Recipe", "Source"]
 
   data = archive_json.keys.sort.map do |pkgname|
     versions, deps, descr, pkgtype = archive_json[pkgname]
+    recipe = recipe_json[pkgname]
     version = versions.join('.')
     pkgurl = "packages/#{pkgname}-#{version}." + (pkgtype == "single" ? "el" : "tar")
     recipe_url = "https://github.com/milkypostman/melpa/blob/master/recipes/#{pkgname}"
@@ -25,10 +27,17 @@
     if descr =~ /(.*?)(\s*-\*-.*?)?\s*\[source:\s*(\w+)\]\s*/
       descr, source = $1, $3
     end
-    ["<a name=\"#{pkgname}\"></a>[#{pkgname}](#{pkgurl})", version, descr, "[#{source}](#{recipe_url})"]
+
+    case source
+    when 'github' then source_url = "https://github.com/#{recipe['repo']}"
+    when 'wiki'   then source_url = recipe.key?('files') ? nil : "http://www.emacswiki.org/emacs/#{pkgname}.el"
+    else source_url = nil
+    end
+
+    ["<a name=\"#{pkgname}\"></a>[#{pkgname}](#{pkgurl})", version, descr, "[recipe](#{recipe_url})", source_url ? "[#{source}](#{source_url})" : ""]
   end
 
-  colwidth = [0,0,0, 9]
+  colwidth = [0,0,0,0, 9]
 
   data.map do |row|
     row.to_enum(:each_with_index).map do |e,i|


### PR DESCRIPTION
Adds an additional column to the table on http://melpa.milkbox.net
which provides a link directly to the github or emacswiki page for
a recipe.

My main gripe with using both `package-list-packages` and the web
UI is the extra effort required just to go check out a project's
README or similar. This should now be easier for the vast majority
of recipes in MELPA.

For emacswiki pages, only those recipes whose file matches the name
of the recipe are linked (ie, if the recipe uses :files, then no
link will be generated). This is Not Perfect(tm), but not bad either.

A screenshot of a local copy:

![link-to-source](https://f.cloud.github.com/assets/510/30215/246439da-4e40-11e2-8b1f-de6be81da785.png)
