### PR TITLE
header-button: new upstream repository

### DIFF
--- a/recipes/header-button
+++ b/recipes/header-button
@@ -1,1 +1,1 @@
-(header-button :repo "tarsius/header-button" :fetcher github)
+(header-button :repo "emacsattic/header-button" :fetcher github)


### PR DESCRIPTION
This package is (not quite) obsolete (yet).  It is not available from
my github account (tarsius) anymore only from the emacsattic.  If
there are any bugs I will still fix them, at least until Emacs-24.4 is
released.
