### PR TITLE
Add Recipe for tup-mode

### DIFF
--- a/recipes/tup-mode
+++ b/recipes/tup-mode
@@ -1,0 +1,3 @@
+(tup-mode
+ :fetcher github
+ :repo "ejmr/tup-mode")


### PR DESCRIPTION
This patch adds tup-mode to the list of recipes, available from https://github.com/ejmr/tup-mode.
