### PR TITLE
Add `color-theme-approximate` package

### DIFF
--- a/recipes/color-theme-approximate
+++ b/recipes/color-theme-approximate
@@ -1,0 +1,4 @@
+(color-theme-approximate
+ :repo "tungd/color-theme-approximate"
+ :fetcher github
+ :files ("*.el"))


### PR DESCRIPTION
This add the [tungd/color-theme-approximate](https://github.com/tungd/color-theme-approximate) package.

This package makes color-theme compatible with terminal Emacs.
