### PR TITLE
Add a Recipe for bbcode-mode

### DIFF
--- a/recipes/bbcode-mode
+++ b/recipes/bbcode-mode
@@ -1,0 +1,3 @@
+(bbcode-mode
+ :fetcher "github"
+ :repo "ejmr/bbcode-mode")


### PR DESCRIPTION
This adds bbcode-mode to MELPA, which can be useful for the hardcore Emacs fanatics who go so far as to write forum posts in Emacs, considering how many Internet forums use BBCode.
