### PR TITLE
Include missing files for Jedi.el

### DIFF
--- a/recipes/jedi
+++ b/recipes/jedi
@@ -1,3 +1,3 @@
 (jedi :fetcher github
       :repo "tkf/emacs-jedi"
-      :files ("jedi*"))
+      :files ("jedi*" "Makefile" "requirements.txt"))


### PR DESCRIPTION
requirements.txt is used to specify version of Python packages.
Makefile can be used for setting up Python requirements.
