### PR TITLE
Remove obsolete Prelude packages

### DIFF
--- a/recipes/prelude-c
+++ b/recipes/prelude-c
@@ -1,1 +1,0 @@
-(prelude-c :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-c.el"))

--- a/recipes/prelude-clojure
+++ b/recipes/prelude-clojure
@@ -1,1 +1,0 @@
-(prelude-clojure :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-clojure.el"))

--- a/recipes/prelude-coffee
+++ b/recipes/prelude-coffee
@@ -1,1 +1,0 @@
-(prelude-coffee :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-coffee.el"))

--- a/recipes/prelude-common-lisp
+++ b/recipes/prelude-common-lisp
@@ -1,1 +1,0 @@
-(prelude-common-lisp :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-common-lisp.el"))

--- a/recipes/prelude-css
+++ b/recipes/prelude-css
@@ -1,1 +1,0 @@
-(prelude-css :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-css.el"))

--- a/recipes/prelude-emacs-lisp
+++ b/recipes/prelude-emacs-lisp
@@ -1,1 +1,0 @@
-(prelude-emacs-lisp :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-emacs-lisp.el"))

--- a/recipes/prelude-erlang
+++ b/recipes/prelude-erlang
@@ -1,1 +1,0 @@
-(prelude-erlang :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-erlang.el"))

--- a/recipes/prelude-haskell
+++ b/recipes/prelude-haskell
@@ -1,1 +1,0 @@
-(prelude-haskell :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-haskell.el"))

--- a/recipes/prelude-js
+++ b/recipes/prelude-js
@@ -1,1 +1,0 @@
-(prelude-js :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-js.el"))

--- a/recipes/prelude-latex
+++ b/recipes/prelude-latex
@@ -1,1 +1,0 @@
-(prelude-latex :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-latex.el"))

--- a/recipes/prelude-lisp
+++ b/recipes/prelude-lisp
@@ -1,1 +1,0 @@
-(prelude-lisp :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-lisp.el"))

--- a/recipes/prelude-mediawiki
+++ b/recipes/prelude-mediawiki
@@ -1,1 +1,0 @@
-(prelude-mediawiki :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-mediawiki.el"))

--- a/recipes/prelude-perl
+++ b/recipes/prelude-perl
@@ -1,1 +1,0 @@
-(prelude-perl :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-perl.el"))

--- a/recipes/prelude-programming
+++ b/recipes/prelude-programming
@@ -1,1 +1,0 @@
-(prelude-programming :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-programming.el"))

--- a/recipes/prelude-python
+++ b/recipes/prelude-python
@@ -1,1 +1,0 @@
-(prelude-python :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-python.el"))

--- a/recipes/prelude-ruby
+++ b/recipes/prelude-ruby
@@ -1,1 +1,0 @@
-(prelude-ruby :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-ruby.el"))

--- a/recipes/prelude-scala
+++ b/recipes/prelude-scala
@@ -1,1 +1,0 @@
-(prelude-scala :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-scala.el"))

--- a/recipes/prelude-scheme
+++ b/recipes/prelude-scheme
@@ -1,1 +1,0 @@
-(prelude-scheme :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-scheme.el"))

--- a/recipes/prelude-scss
+++ b/recipes/prelude-scss
@@ -1,1 +1,0 @@
-(prelude-scss :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-scss.el"))

--- a/recipes/prelude-xml
+++ b/recipes/prelude-xml
@@ -1,1 +1,0 @@
-(prelude-xml :repo "bbatsov/prelude-modules" :fetcher github :files ("prelude-xml.el"))


### PR DESCRIPTION
I've reworked Prelude a while ago and it's no longer based around the concept of modules as packages. At this point all `prelude*` packages can be safely removed.
