### PR TITLE
add recipe for rbenv.el

### DIFF
--- a/recipes/rbenv
+++ b/recipes/rbenv
@@ -1,0 +1,1 @@
+(rbenv :repo "senny/rbenv.el" :fetcher github)


### PR DESCRIPTION
I created rbenv.el a small package to manage to configure Emacs to use your rbenv ruby versions. This PR adds a simple recipe to install the package.

https://github.com/senny/rbenv.el
