### PR TITLE
add "gongo/airplay" recipe

### DIFF
--- a/recipes/airplay
+++ b/recipes/airplay
@@ -1,0 +1,1 @@
+(airplay :fetcher github :repo "gongo/airplay-el")


### PR DESCRIPTION
airplay-el is a client for AirPlay Server.

eg.

``` lisp
(require 'airplay)

(airplay/image:view "appletv.jpg")
(airplay/video:play "https://dl.dropbox.com/u/2532139/IMG_0381XXX.m4v")
```
