### PR TITLE
add git-gutter-fringe recipe

### DIFF
--- a/recipes/git-gutter-fringe
+++ b/recipes/git-gutter-fringe
@@ -1,0 +1,4 @@
+(git-gutter-fringe
+ :repo "syohex/emacs-git-gutter-fringe"
+ :fetcher github
+ :files ("git-gutter-fringe.el"))


### PR DESCRIPTION
[git-gutter-fringe](https://github.com/syohex/emacs-git-gutter-fringe) is fringe version of [git-gutter.el](https://github.com/syohex/emacs-git-gutter).

`git-gutter.el` does not work with `linum-mode` but `git-gutter-fringe` can work with `linum-mode`.

Please check this patch.
