### PR TITLE
add a recipe for tc

### DIFF
--- a/recipes/tc
+++ b/recipes/tc
@@ -1,0 +1,2 @@
+(tc :repo "kozo2/tc" :fetcher github :files
+               ("*.el" "tcode")) 


### PR DESCRIPTION
tc is Japanese direct input method for emacs.
tc enables emacs users to input Japanese characters with T-code or TUT-code.

T-code is a Japanese input method that does NOT use Kana-to-Kanji conversion.
