### PR TITLE
Correctly link to gists for github recipes

### DIFF
--- a/html/index.erb
+++ b/html/index.erb
@@ -30,7 +30,7 @@
 
     source_url =
       case source
-      when 'github' then "https://github.com/#{recipe['repo']}"
+      when 'github' then recipe['repo'].include?('/') ? "https://github.com/#{recipe['repo']}" : "https://gist.github.com/#{recipe['repo']}"
       when 'wiki'   then recipe.key?('files') ? nil : "http://www.emacswiki.org/emacs/#{pkgname}.el"
       end
 


### PR DESCRIPTION
This should fix the link on melpa.milkbox.net for recipes like molokai-theme.

I don't have access to power at the moment, so I don't have the battery life to actually run this and verify that it works! But it seems intuitive enough.

These recipes should get working github links on the website now:

```
~/sauce/melpa/recipes (gist-links δ) » ack -C3 github * | grep repo | grep -v '/'
ir_black-theme:1:(ir_black-theme :repo "2029034" :fetcher github)
molokai-theme:1:(molokai-theme :repo "2029061" :fetcher github)
pastels-on-dark-theme:1:(pastels-on-dark-theme :repo "1974259" :fetcher github)
tango-2-theme:1:(tango-2-theme :repo "2024464" :fetcher github)
```
