### PR TITLE
Add package ido-complete-space-or-hyphen

### DIFF
--- a/recipes/ido-complete-space-or-hyphen
+++ b/recipes/ido-complete-space-or-hyphen
@@ -1,0 +1,1 @@
+(ido-complete-space-or-hyphen :repo "doitian/ido-complete-space-or-hyphen" :fetcher github)


### PR DESCRIPTION
Make ido completes like built-in M-x does, useful when use smex or use ido to
complete other hyphen separated choices
## Example

`(ido-completing-read "test: " '("ido-foo-bar" "ido-space" "ido-test"))`

```
| Key Sequence | Result |
|--------------+--------|
| i            | "i"    |
| SPACE        | "ido-" |
```

`(ido-completing-read "test: " '("ido foo-bar" "ido space" "ido test"))`

```
| Key Sequence | Result |
|--------------+--------|
| i            | "i"    |
| SPACE        | "ido " |
```

`(ido-completing-read "test: " '("ido-foo-bar" "ido-space" "idotest"))`

```
| Key Sequence | Result |
|--------------+--------|
| i            | "i"    |
| SPACE        | "ido"  |
| SPACE        | "ido-" |
```

When HYPHEN can be inserted and SPACE cannot, insert HYPHEN when user enter SPACE.

`(ido-completing-read "test: " '("ido-foo-bar" "ido-space" "ido test"))`

```
| Key Sequence | Result                           |
|--------------+----------------------------------+
| i            | "i"                              |
| SPACE        | "ido"                            |
| SPACE        | "ido"  Completion popup is shown |
| SPACE        | "ido "                           |
```

If both HYPHEN and SPACE can be inserted, SPACE first brings the completion
popup window, if user types SPACE again, then SPACE itself is inserted.
