### PR TITLE
Add "dir" and "*.info" to the default :files spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ specifies the module of a CVS repository to check out.  Defaults to to
 `package-name`.  Only used with `:fetcher cvs`, and otherwise ignored.
 
 - `:files`
-optional property specifying the explicit files used to build the
-package. Automatically populated by matching all `.el` files in the
-root of the repository. This is necessary when there are multiple
+optional property specifying the elisp and info files used to build the
+package. Automatically populated by matching all `.el`, `.info` and `dir` files in the
+root of the repository. This option necessary when there are multiple
 `.el` files in the repository but the package should only be built
-from a subset. *Any file specifed at any path in the repository is
+from a subset. For example, elisp test files should not normally be packaged.
+*Any file specifed at any path in the repository is
 copied to the root of the package.* More complex options are
 available, submit an
 [Issue](https://github.com/milkypostman/melpa/issues) if the specified

--- a/package-build.el
+++ b/package-build.el
@@ -616,15 +616,15 @@ file path and DEST is the relative path to which it should be copied."
                                  (concat prefix (car entry)))
          (mapcar (lambda (f)
                    (cons f (concat prefix (file-name-nondirectory f))))
-                 (or (file-expand-wildcards entry)
-                     (error "No matching file(s) found in %s: %s"
-                            dir
-                            entry)))))
+                 (file-expand-wildcards entry))))
      specs)))
 
 (defun pb/expand-config-file-list (dir config)
   "In DIR, expand the :files for CONFIG using 'pb/expand-file-specs."
-  (pb/expand-file-specs dir (or (plist-get config :files) (list "*.el"))))
+  (let* ((patterns (or (plist-get config :files) '("*.el" "dir" "*.info")))
+         (files (pb/expand-file-specs dir patterns)))
+    (or files
+        (error "No matching file(s) found in %s: %s" dir patterns))))
 
 (defun pb/expand-source-file-list (dir config)
   "Shorthand way to expand paths in DIR for source files listed in CONFIG."

--- a/recipes/ebib
+++ b/recipes/ebib
@@ -1,4 +1,3 @@
 (ebib
  :fetcher github
- :repo "joostkremers/ebib"
- :files ("ebib.el" "ebib.info" "dir"))
+ :repo "joostkremers/ebib")

--- a/recipes/extend-dnd
+++ b/recipes/extend-dnd
@@ -1,4 +1,3 @@
 (extend-dnd
  :fetcher github
- :repo "mlf176f2/extend-dnd"
- :files ("extend-dnd.el" "dir" "extend-dnd.info"))
+ :repo "mlf176f2/extend-dnd")

--- a/recipes/org-outlook
+++ b/recipes/org-outlook
@@ -1,4 +1,3 @@
 (org-outlook
  :repo "mlf176f2/org-outlook.el"
- :fetcher github
- :files ("org-outlook.el" "dir" "org-outlook.info"))
+ :fetcher github)

--- a/recipes/org-readme
+++ b/recipes/org-readme
@@ -1,1 +1,1 @@
-(org-readme :fetcher github :repo "mlf176f2/org-readme" :files ("org-readme.el" "dir" "org-readme.info"))
+(org-readme :fetcher github :repo "mlf176f2/org-readme")

--- a/recipes/pandoc-mode
+++ b/recipes/pandoc-mode
@@ -1,4 +1,3 @@
 (pandoc-mode
  :fetcher github
- :repo "joostkremers/pandoc-mode"
- :files ("pandoc-mode.el" "pandoc-mode.info" "dir"))
+ :repo "joostkremers/pandoc-mode")

--- a/recipes/sicp
+++ b/recipes/sicp
@@ -1,4 +1,2 @@
 (sicp :repo "webframp/sicp-info"
-      :fetcher github
-      :files ("sicp.info"
-              "dir"))
+      :fetcher github)

--- a/recipes/tabbar-ruler
+++ b/recipes/tabbar-ruler
@@ -1,4 +1,3 @@
 (tabbar-ruler
  :fetcher github
- :repo "mlf176f2/tabbar-ruler.el"
- :files ("tabbar-ruler.el" "dir" "tabbar-ruler.info"))
+ :repo "mlf176f2/tabbar-ruler.el")

--- a/recipes/writeroom-mode
+++ b/recipes/writeroom-mode
@@ -1,4 +1,3 @@
 (writeroom-mode
  :fetcher github
- :repo "joostkremers/writeroom-mode"
- :files ("writeroom-mode.el" "writeroom-mode.info" "dir"))
+ :repo "joostkremers/writeroom-mode")


### PR DESCRIPTION
This relates to #561, which is concerned with getting `info` files into packages where they are available.

Since most packages do not have `dir` or `*.info` files, this required changing the behaviour when a wildcard entry in `:file` expands to an empty file list. Previously, an error would be raised in this case; now, an error is raised only when the _entire_ `:files` spec expands to an empty file list.

The slight danger, then, is that certain build failures due to upstream reorganisation of files might be less obvious.

Comments welcomed!
