### PR TITLE
delete mc-jump

### DIFF
--- a/recipes/mc-jump
+++ b/recipes/mc-jump
@@ -1,1 +1,0 @@
-(mc-jump :fetcher github :repo "zk-phi/mc-jump")


### PR DESCRIPTION
I found "iy-go-to-char", which is already available at MELPA, also works with multiple-cursors, and is even better in functionality.
