### PR TITLE
add tangotango theme

### DIFF
--- a/recipes/tangotango-theme
+++ b/recipes/tangotango-theme
@@ -1,0 +1,4 @@
+(tangotango-theme
+ :repo "juba/color-theme-tangotango"
+ :files ("tangotango-theme.el")
+ :fetcher github)


### PR DESCRIPTION
This is a tricky one to package, since the repo itself includes two separate files, one for Emacs 23 with color-theme, and one for Emacs 24. I've opted for packaging only the Emacs 24 file. Also, I believe this is a more complete version of the already packaged tango-2-theme.

Let me know if I've missed anything.
