### PR TITLE
Add region-bindings-mode to recipes

### DIFF
--- a/recipes/region-bindings-mode
+++ b/recipes/region-bindings-mode
@@ -1,0 +1,3 @@
+(region-bindings-mode
+ :fetcher github
+ :repo "jcriner/region-bindings-mode")


### PR DESCRIPTION
Adds a simple, but useful, minor mode to Emacs for adding an active-region-only keymap.
