### PR TITLE
Recipe for isend-mode

### DIFF
--- a/recipes/isend-mode
+++ b/recipes/isend-mode
@@ -1,0 +1,4 @@
+(isend-mode
+ :fetcher git
+ :url     "https://github.com/ffevotte/isend-mode.el"
+ :files   ("isend-mode.el"))


### PR DESCRIPTION
`isend-mode` is an Emacs extension allowing interaction with code interpreters in `term` buffers. Some language-specific modes (e.g. `python.el`) already provide similar features; `isend-mode` does the same in a language-agnostic way.

This is my first recipe; please do not hesitate to tell me if anything is wrong with it.
