### PR TITLE
Looks like paredit was moved.

### DIFF
--- a/recipes/paredit
+++ b/recipes/paredit
@@ -1,4 +1,3 @@
-(paredit :url "http://mumble.net/~campbell/emacs/paredit"
-         :fetcher darcs
+(paredit :url "http://mumble.net/~campbell/git/paredit.git"
+         :fetcher git
          :files ("paredit.el"))
-


### PR DESCRIPTION
It's not available on MELPA right now, because the link in the recipe doesn't point to a darcs repository. But there is a git repository of paredit in the neighbor directory on the site. Should the recipe be changed?
