### PR TITLE
Add recipe for pcmpl-git

### DIFF
--- a/recipes/pcmpl-git
+++ b/recipes/pcmpl-git
@@ -1,0 +1,1 @@
+(pcmpl-git :fetcher github :repo "leoliu/pcmpl-git-el" :files ("*.el" "git-options"))


### PR DESCRIPTION
Available at https://github.com/leoliu/pcmpl-git-el

I've sent a [PR](https://github.com/leoliu/pcmpl-git-el/pull/1) to @leoliu to alter the default location where the `git-options` file is expected to be, which would enable the subcommand option completion to work out of the box when installed via MELPA.

Even without that being fixed upstream, however, the core of the completion works (eg, `git a<TAB>` offers completions as expected), so I see no reason not to get this into MELPA now. =)
