### PR TITLE
Add a recipe for scf-mode

### DIFF
--- a/recipes/scf-mode
+++ b/recipes/scf-mode
@@ -1,0 +1,1 @@
+(scf-mode :repo "lewang/scf-mode" :fetcher github)


### PR DESCRIPTION
scf-mode is a wonderful little minor mode that can abbreviate long paths in grep-mode (and other similar modes).
