### PR TITLE
Add recipe for mocker.el

### DIFF
--- a/recipes/mocker
+++ b/recipes/mocker
@@ -1,0 +1,2 @@
+(mocker :repo "sigma/mocker.el" :fetcher github
+        :files ("mocker.el"))


### PR DESCRIPTION
[mocker.el](https://github.com/sigma/mocker.el) is a maintained, unit-tested and more powerful alternative to el-mock.
