### PR TITLE
Add a recipe for rhtml-mode

### DIFF
--- a/recipes/rhtml-mode
+++ b/recipes/rhtml-mode
@@ -1,0 +1,1 @@
+(rhtml-mode :repo "eschulte/rhtml" :fetcher github)


### PR DESCRIPTION
I'd love to see rhtml-mode on MELPA. It compiles fine locally, but doing `package-install-file` fails with:

```
Leaving directory `/home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035'

Compiling file /home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035/rhtml-erb.el at Wed Apr 10 14:31:01 2013
Entering directory `/home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035/'

In rhtml-erb-delim-type:
rhtml-erb.el:101:30:Warning: `(match\? (regex) (eq (string-match regex
    start-delim) 0))' is a malformed function

In rhtml-erb-middle-offset:
rhtml-erb.el:120:54:Warning: reference to free variable `sgml-basic-offset'
rhtml-erb.el:169:1:Error: Symbol's value as variable is void: rhtml-erb-block-open-re

Compiling file /home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035/rhtml-fonts.el at Wed Apr 10 14:31:01 2013

In rhtml-activate-fontification:
rhtml-fonts.el:52:9:Warning: `font-lock-syntactic-keywords' is an obsolete
    variable (as of 24.1); use `syntax-propertize-function' instead.

In rhtml-fontify-erb-block:
rhtml-fonts.el:61:38:Warning: reference to free variable
    `erb-type-to-delim-face'
rhtml-fonts.el:62:37:Warning: reference to free variable `erb-type-to-face'

In rhtml-fontify-region:
rhtml-fonts.el:93:22:Warning: reference to free variable
    `rhtml-erb-open-delim'
rhtml-fonts.el:96:21:Warning: reference to free variable
    `rhtml-erb-close-delim'

In end of data:
rhtml-fonts.el:177:23:Warning: the function `rhtml-erb-regions' is not known
    to be defined.

Compiling file /home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035/rhtml-mode-pkg.el at Wed Apr 10 14:31:01 2013

Compiling file /home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035/rhtml-mode.el at Wed Apr 10 14:31:01 2013

In rhtml-mode:
rhtml-mode.el:49:4:Warning: misplaced interactive spec: `(interactive)'

In rhtml-dashize:
rhtml-mode.el:93:20:Warning: `delete-backward-char' used from Lisp code
That command is designed for interactive use only

In end of data:
rhtml-mode.el:106:1:Warning: the function `toggle-buffer' is not known to be
    defined.

Compiling file /home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035/rhtml-navigation.el at Wed Apr 10 14:31:01 2013

In rhtml-find-action:
rhtml-navigation.el:22:17:Warning: `beginning-of-buffer' used from Lisp code
That command is designed for interactive use only

In end of data:
rhtml-navigation.el:59:1:Warning: the function `rails-root' is not known to be
    defined.

Compiling file /home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035/rhtml-ruby-hook.el at Wed Apr 10 14:31:01 2013

In end of data:
rhtml-ruby-hook.el:93:27:Warning: the function `insert-from-buffer' is not
    known to be defined.

Compiling file /home/wilfred/.emacs.d/elpa/rhtml-mode-20120128.2035/rhtml-sgml-hacks.el at Wed Apr 10 14:31:01 2013
```

I believe this is because of this code:

```
(defconst rhtml-erb-block-open-re
  (concat "[A-Za-z_)][ ]+do[ ]+\\(?:|[A-Za-z_, ]*|\\)?[ ]*" rhtml-erb-tag-close-re))

(defconst rhtml-erb-brace-block-open-re
  (concat "[ ]+{[ ]+\\(?:|[A-Za-z_, ]*|\\)?[ ]*" rhtml-erb-tag-close-re)
  "Slightly less strictive to allow for \"hash = {\n\".")

(defmacro rhtml-erb-block-open-p ()
  "Guess if a Ruby fragment opens a block with do.
Returns `block' or `brace-block' on success."
  `(re-search-forward ,rhtml-erb-block-open-re nil t))

(defmacro rhtml-erb-brace-block-open-p ()
  "Guess if a Ruby fragment opens a brace block (with {)
Returns `block' or `brace-block' on success."
  `(re-search-forward ,rhtml-erb-brace-block-open-re nil t))
```

The macro is referencing a variable which may not be defined yet. Any ideas how I can modify the recipe? The following makes it compile as expected:

```
(add-to-list 'load-path "~/.emacs.d/third-party-lisp/rhtml")
(require 'rhtml-mode)
(byte-recompile-directory "/home/wilfred/.emacs.d/third-party-lisp/rhtml" 0 t)
```
