### PR TITLE
Add grandshell-theme recipe

### DIFF
--- a/recipes/grandshell-theme
+++ b/recipes/grandshell-theme
@@ -1,0 +1,1 @@
+(grandshell-theme :repo "steckerhalter/grandshell-theme" :fetcher github)


### PR DESCRIPTION
the theme depends on color.el

maybe that needs some tweaking? i thought I was trying a previous emacs24 version that didn't include color.el, can that be?
