### PR TITLE
Add a recipe for rubocop.el

### DIFF
--- a/recipes/rubocop
+++ b/recipes/rubocop
@@ -1,0 +1,3 @@
+(rubocop :repo "bbatsov/rubocop-emacs" 
+         :fetcher github
+         :files ("rubocop.el"))    


### PR DESCRIPTION
Add a recipe for [rubocop.el](https://github.com/bbatsov/rubocop-emacs).
