### PR TITLE
Remove redundant data from rubocop recipe

### DIFF
--- a/recipes/rubocop
+++ b/recipes/rubocop
@@ -1,3 +1,2 @@
-(rubocop :repo "bbatsov/rubocop-emacs" 
-         :fetcher github
-         :files ("rubocop.el"))    
+(rubocop :repo "bbatsov/rubocop-emacs"
+         :fetcher github)


### PR DESCRIPTION
The title says it all. Thanks for the feedback, @purcell.
