### PR TITLE
Update smooth-scrolling to point to new canonical repo

### DIFF
--- a/recipes/smooth-scrolling
+++ b/recipes/smooth-scrolling
@@ -1,1 +1,1 @@
-(smooth-scrolling :repo "jbondeson/smooth-scrolling" :fetcher github)
+(smooth-scrolling :repo "aspiers/smooth-scrolling" :fetcher github)


### PR DESCRIPTION
The smooth-scrolling repository was transferred to Adam Spiers and now 
resides at aspiers/smoothscrolling on github.
