### PR TITLE
update dash-at-point recipe to refer the original repository.

### DIFF
--- a/recipes/dash-at-point
+++ b/recipes/dash-at-point
@@ -1,1 +1,1 @@
-(dash-at-point :fetcher github :repo "Kapeli/dash-at-point")
+(dash-at-point :fetcher github :repo "stanaka/dash-at-point")


### PR DESCRIPTION
I, the original author of dast-at-point, update dast-at-point for add hints for new docsets and corresponding major modes. So the recipe should refer the original repository to follow this update.
