### PR TITLE
fuel, the official major mode for editing Factor source code

### DIFF
--- a/recipes/fuel
+++ b/recipes/fuel
@@ -1,0 +1,4 @@
+(fuel
+ :fetcher github
+ :repo "mcandre/fuel"
+ :files ("fuel-1.0/fu.el"))


### PR DESCRIPTION
fuel comes with [Factor](http://factorcode.org/); I just pulled it out in order to add it to package managers, in case anyone wants to edit Factor code without necessarily installing Factor and manually linking to fu.el.
