### PR TITLE
Fix package name in bind-key recipe

### DIFF
--- a/recipes/bind-key
+++ b/recipes/bind-key
@@ -1,4 +1,4 @@
-(use-package
+(bind-key
     :fetcher github
     :repo "jwiegley/use-package"
     :files ("bind-key.el"))


### PR DESCRIPTION
The bind-key recipe appears to have the wrong package name. It shows up on [travis-ci build](https://travis-ci.org/milkypostman/melpa/builds/6575435) of the commit that introduced the recipe. I've correct the package name so it matches the recipe name.
