### PR TITLE
New recipe for linum-relative

### DIFF
--- a/recipes/linum-relative
+++ b/recipes/linum-relative
@@ -1,1 +1,1 @@
-(linum-relative :fetcher wiki)
+(linum-relative :fetcher github :repo "coldnew/linum-relative")


### PR DESCRIPTION
This is a helper function to make linum-mode show relative line number, just like vim's ":set rnu" command.
