### PR TITLE
Add org-present recipe

### DIFF
--- a/recipes/org-present
+++ b/recipes/org-present
@@ -1,0 +1,1 @@
+(org-present :fetcher github :repo "rlister/org-present")


### PR DESCRIPTION
This adds the recipe for [org-present](https://github.com/rlister/org-present).
