### PR TITLE
Update haskell-mode recipe to include "logo.svg"

### DIFF
--- a/recipes/haskell-mode
+++ b/recipes/haskell-mode
@@ -1,2 +1,5 @@
-(haskell-mode :repo "haskell/haskell-mode" :fetcher github)
-
+(haskell-mode
+ :repo "haskell/haskell-mode"
+ :fetcher github
+ :files ("*.el"
+         "logo.svg"))


### PR DESCRIPTION
`haskell-mode` uses "logo.svg" for some process icon.  The updated recipe includes this file along with all the `*.el` files from before.
