### PR TITLE
Add text-translator receipe

### DIFF
--- a/recipes/text-translator
+++ b/recipes/text-translator
@@ -1,0 +1,2 @@
+(text-translator :fetcher bzr :url "lp:~khiker/+junk/text-translator"
+                 :files ("*.el"))


### PR DESCRIPTION
Add development version of `text-translator`.

For information about `text-translator`, See the following URL.
http://www.emacswiki.org/emacs/TextTranslator
