### PR TITLE
Fix the naquadah-theme URL

### DIFF
--- a/recipes/naquadah-theme
+++ b/recipes/naquadah-theme
@@ -1,1 +1,1 @@
-(naquadah-theme :repo "sdegutis/naquadah-theme.el" :fetcher github)
+(naquadah-theme :url "git://git.naquadah.org/naquadah-theme.git" :fetcher git)


### PR DESCRIPTION
I'm the original author of naquadah-theme, and I would really like that I can
use the original theme and not a fork of it.
