### PR TITLE
yasnippet no longer bundles dropdown-list

### DIFF
--- a/recipes/yasnippet
+++ b/recipes/yasnippet
@@ -1,4 +1,4 @@
 (yasnippet :repo "capitaomorte/yasnippet"
            :fetcher github
-           :files ("yasnippet.el" "dropdown-list.el" "snippets"))
+           :files ("yasnippet.el" "snippets"))
 


### PR DESCRIPTION
dropdown-list is an optional dependency distributed from
the Emacswiki and is already available from melpa.
