### PR TITLE
bbdb2erc

### DIFF
--- a/recipes/bbdb2erc
+++ b/recipes/bbdb2erc
@@ -1,0 +1,2 @@
+(bbdb2erc :repo "unhammer/bbdb2erc" :fetcher github)
+


### PR DESCRIPTION
requires bbdb and erc, shows if bbdb contact is online in an erc server
