### PR TITLE
Add erc-terminal-notifier

### DIFF
--- a/recipes/erc-terminal-notifier
+++ b/recipes/erc-terminal-notifier
@@ -1,0 +1,1 @@
+(erc-terminal-notifier :repo "julienXX/erc-terminal-notifier.el" :fetcher github)


### PR DESCRIPTION
This is a little package I created to send ERC nickname mentions to OSX Notification Center.
