### PR TITLE
removed some es- prefixes

### DIFF
--- a/recipes/auto-auto-indent
+++ b/recipes/auto-auto-indent
@@ -1,0 +1,3 @@
+(auto-auto-indent
+ :repo "sabof/auto-auto-indent"
+ :fetcher github)

--- a/recipes/edit-color-stamp
+++ b/recipes/edit-color-stamp
@@ -1,0 +1,4 @@
+(edit-color-stamp
+ :repo "sabof/edit-color-stamp"
+ :fetcher github
+ :files ("*.el" ("qt_color_picker" "qt_color_picker/*.pro" "qt_color_picker/*.cpp")))

--- a/recipes/es-auto-auto-indent
+++ b/recipes/es-auto-auto-indent
@@ -1,3 +1,0 @@
-(es-auto-auto-indent
- :repo "sabof/es-auto-auto-indent"
- :fetcher github)

--- a/recipes/es-edit-color-stamp
+++ b/recipes/es-edit-color-stamp
@@ -1,4 +1,0 @@
-(es-edit-color-stamp
- :repo "sabof/es-edit-color-stamp"
- :fetcher github
- :files ("*.el" ("qt_color_picker" "qt_color_picker/*.pro" "qt_color_picker/*.cpp")))

--- a/recipes/es-shift-text
+++ b/recipes/es-shift-text
@@ -1,3 +1,0 @@
-(es-shift-text
- :repo "sabof/es-shift-text"
- :fetcher github)

--- a/recipes/shift-text
+++ b/recipes/shift-text
@@ -1,0 +1,3 @@
+(shift-text
+ :repo "sabof/shift-text"
+ :fetcher github)


### PR DESCRIPTION
I wanted to rename some of my libraries (the github location and the package name). I would prefer if existing users had to upgrade manually and not deal with errors after an update. I don't know whether it matters what gets renamed first -- the recipe, or the repo, since github creates redirects for renamed repositories.
