### PR TITLE
object-registry has moved to the emacsattic

### DIFF
--- a/recipes/object-registry
+++ b/recipes/object-registry
@@ -1,1 +1,1 @@
-(object-registry :repo "tarsius/object-registry" :fetcher github)
+(object-registry :repo "emacsattic/object-registry" :fetcher github)


### PR DESCRIPTION
I am deprecating `object-registry`. I haven't released the successor `registries` yet and will keep maintaining it for now. But I have already moved it to the Emacsattic. This patch changes the `:repo` accordingly.
