### PR TITLE
php-boris boris php repl as commint buffer 

### DIFF
--- a/recipes/php-boris
+++ b/recipes/php-boris
@@ -1,0 +1,1 @@
+(php-boris :repo "tomterl/php-boris" :fetcher github)


### PR DESCRIPTION
This is a major mode that allows to run boris inside emacs. Version 0.0.1, alpha.

Tested as required; building, fetching und running works as expected.
