### PR TITLE
Add the manual source of Flycheck

### DIFF
--- a/recipes/flycheck
+++ b/recipes/flycheck
@@ -1,2 +1,2 @@
 (flycheck :repo "lunaryorn/flycheck" :fetcher github
-          :files ("flycheck.el" "doc/dir" "doc/flycheck.info"))
+          :files ("flycheck.el" "doc/flycheck.texi"))


### PR DESCRIPTION
Remove the pre-build manual, and instead add the source file to let MELPA build the manual.

I am not sure whether this is actually required, so part of my reason for opening this PR is also to know whether I can now remove the generated manual from my Flycheck repository.
