### PR TITLE
New package: p4.el

### DIFF
--- a/recipes/p4
+++ b/recipes/p4
@@ -1,5 +1,3 @@
 (p4
  :fetcher github
- :repo "gareth-rees/p4.el"
- :commit "origin/release"
- :files ("p4.el"))
+ :repo "gareth-rees/p4.el")


### PR DESCRIPTION
Here's a recipe for [p4.el](https://github.com/gareth-rees/p4.el), an integration between Emacs and the Perforce version control system.

I've specified `:commit "origin/release"` in the recipe so that users pick up only the snapshots on the `release` branch (rather than the `master` branch, which gets broken from time to time). However, I notice that this isn't the norm: the only other recipe specifying a branch is `recipe/elnode`. So if you'd prefer that MELPA track the `master` branch, let me know.
