### PR TITLE
New (actually very old) package ggo-mode

### DIFF
--- a/recipes/ggo-mode
+++ b/recipes/ggo-mode
@@ -1,2 +1,2 @@
-(ggo-mode :fetcher github :repo "5619356")
+(ggo-mode :fetcher github :repo "mkjunker/ggo-mode")
 


### PR DESCRIPTION
I tested this using the instructions on Windows 7 with NT Emacs and got a complaint that the version field wasn't present.  package-install-from-buffer worked fine, however.

I also tested using Linux Mint, and it worked fine.
