### PR TITLE
Add melpa-upstream-visit recipe.

### DIFF
--- a/recipes/melpa-upstream-visit
+++ b/recipes/melpa-upstream-visit
@@ -1,0 +1,2 @@
+(melpa-upstream-visit :repo "laynor/melpa-upstream-visit" :fetcher github)
+


### PR DESCRIPTION
Hi, please add this recipe to melpa.
This package contains some kludges to open a melpa-hosted package's homepage with browse-url. 

Suggestions on how to better do this are welcome, currently it fetches the melpa recipe from github - with a http request - and tries to guess the homepage from the recipe list.
