### PR TITLE
Add recipes/esh-buf-stack

### DIFF
--- a/recipes/esh-buf-stack
+++ b/recipes/esh-buf-stack
@@ -1,0 +1,1 @@
+(esh-buf-stack :repo "tom-tan/esh-buf-stack" :fetcher github)


### PR DESCRIPTION
This library adds a buffer stack feature to Eshell.
It is inspired by the buffer stack in Zsh.
