### PR TITLE
ace-jump-buffer recipe

### DIFF
--- a/recipes/ace-jump-buffer
+++ b/recipes/ace-jump-buffer
@@ -1,0 +1,1 @@
+(ace-jump-buffer :repo "waymondo/ace-jump-buffer" :fetcher github)


### PR DESCRIPTION
This is a little global minor mode extension to extend `ace-jump-mode` with a quick buffer switcher.
