### PR TITLE
add up to date version of the elixir-mode

### DIFF
--- a/recipes/elixir-mode
+++ b/recipes/elixir-mode
@@ -1,4 +1,3 @@
 (elixir-mode
  :fetcher github
- :repo "secondplanet/elixir-mode"
- :files ("elixir-mode.el"))
+ :repo "elixir-lang/emacs-elixir")


### PR DESCRIPTION
hi,

The original `elixir-mode` repository is not up-to-date with the current version of the elixir language.
There is a active maintained and continued developed repository under the elixir-lang organization.

cheers

Sam

/cc @purcell
