### PR TITLE
Update haskell-mode recipe to include texinfo manual

### DIFF
--- a/recipes/haskell-mode
+++ b/recipes/haskell-mode
@@ -2,4 +2,5 @@
  :repo "haskell/haskell-mode"
  :fetcher github
  :files ("*.el"
+         "haskell-mode.texi"
          "logo.svg"))


### PR DESCRIPTION
Btw, is there a way to honor a `README` file the way http://marmalade-repo.org/ does?
