### PR TITLE
Include NEWS file in haskell-mode recipe

### DIFF
--- a/recipes/haskell-mode
+++ b/recipes/haskell-mode
@@ -3,4 +3,5 @@
  :fetcher github
  :files ("*.el"
          "haskell-mode.texi"
+         "NEWS"
          "logo.svg"))


### PR DESCRIPTION
A new `M-x haskell-mode-view-news` (inspired by `M-x view-emacs-news`) that will be committed shortly, will require the NEWS file to be available.
