### PR TITLE
Check if extracted version list is actually a sequence.

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -442,11 +442,12 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
       ,(aref pkg-info 0)
       ,(aref pkg-info 3)
       ,(aref pkg-info 2)
-      ',(mapcar
-         (lambda (elt)
-           (list (car elt)
-                 (package-version-join (cadr elt))))
-         (aref pkg-info 1)))
+      ',(if (sequencep (aref pkg-info 1))
+            (mapcar
+             (lambda (elt)
+               (list (car elt)
+                     (package-version-join (cadr elt))))
+             (aref pkg-info 1))))
    pkg-file))
 
 (defun pb/read-from-file (file-name)


### PR DESCRIPTION
This is needed becouse package info extraction sometimes returns
symbol (as is the case with emacs-w3m).
