### PR TITLE
Fix w3m recipe to use official development cvs repository.

### DIFF
--- a/recipes/w3m
+++ b/recipes/w3m
@@ -1,2 +1,3 @@
-(w3m :repo "emacsmirror/w3m"
-     :fetcher github)
+(w3m :url ":pserver:anonymous@cvs.namazu.org:/storage/cvsroot"
+     :module "emacs-w3m"
+     :fetcher cvs)


### PR DESCRIPTION
This has to be merged after https://github.com/milkypostman/melpa/pull/855
