### PR TITLE
Add frame-restore.el

### DIFF
--- a/recipes/frame-restore
+++ b/recipes/frame-restore
@@ -1,0 +1,1 @@
+(frame-restore :repo "lunaryorn/frame-restore.el" :fetcher github)


### PR DESCRIPTION
frame-restore.el is a little library to save and restore the size and position
of the Emacs frame.

I use it mostly to remember the fullscreen state of my Emacs.

See https://github.com/lunaryorn/frame-restore.el
