### PR TITLE
Add metaweblog

### DIFF
--- a/recipes/metaweblog
+++ b/recipes/metaweblog
@@ -1,0 +1,1 @@
+(metaweblog :fetcher github :repo "punchagan/metaweblog.el")


### PR DESCRIPTION
This package was part of the org2blog package and has been removed from the repo. Its a dependency of org2log.
