### PR TITLE
add go-eldoc recipe

### DIFF
--- a/recipes/go-eldoc
+++ b/recipes/go-eldoc
@@ -1,0 +1,1 @@
+(go-eldoc :repo "syohex/emacs-go-eldoc" :fetcher github)


### PR DESCRIPTION
`go-eldoc.el` provides eldoc for go language.
Please see this patch.

https://github.com/syohex/emacs-go-eldoc
