### PR TITLE
org-trello arborescence simplification

### DIFF
--- a/recipes/org-trello
+++ b/recipes/org-trello
@@ -1,3 +1,3 @@
 (org-trello :fetcher github
             :repo "ardumont/org-trello"
-            :files ("org-trello.el" "org-trello-pkg.el" "lib"))
+            :files ("org-trello.el" "org-trello-pkg.el"))


### PR DESCRIPTION
Code has been inlined because there was trouble at installation time, so no more "lib/" folder.
Sorry about that.

Cheers,
@ardumont
