### PR TITLE
LiveScript highlighting support for emacs

### DIFF
--- a/recipes/lsc-mode
+++ b/recipes/lsc-mode
@@ -1,0 +1,1 @@
+(lsc-mode :fetcher github :repo "drozzy/lsc-mode")


### PR DESCRIPTION
The current package does not provide the ability to highlight LiveScript, so I found another one that does and decided to contribute it to melpa.
I renamed it "lsc-mode" to avoid name collision.

Source of my repo:
https://github.com/drozzy/lsc-mode
