### PR TITLE
Split flx into 2 separate package

### DIFF
--- a/recipes/flx
+++ b/recipes/flx
@@ -1,1 +1,3 @@
-(flx :fetcher github :repo "lewang/flx")
+(flx :repo "lewang/flx"
+     :fetcher github
+     :files ("flx.el"))

--- a/recipes/flx-ido
+++ b/recipes/flx-ido
@@ -1,0 +1,3 @@
+(flx-ido :repo "lewang/flx"
+         :fetcher github
+         :files ("flx-ido.el"))


### PR DESCRIPTION
The flx repository actually contains two packages - `flx` and
`flx-ido` (which depends on `flx`). The `flx` is meant to be used by
various front-ends so it makes perfect sense to be distributed
separately from the `ido` front-end.
