### PR TITLE
Add gandalf theme

### DIFF
--- a/recipes/gandalf-theme
+++ b/recipes/gandalf-theme
@@ -1,0 +1,3 @@
+(gandalf-theme
+ :fetcher github
+ :repo "ptrv/gandalf-theme-emacs")


### PR DESCRIPTION
Port of the `overtone/emacs-live` theme with the same name, which uses `deftheme`
https://github.com/overtone/emacs-live/blob/master/packs/dev/colour-pack/lib/gandalf.el
