### PR TITLE
remove magit-inotify recipe

### DIFF
--- a/recipes/magit-inotify
+++ b/recipes/magit-inotify
@@ -1,4 +1,0 @@
-(magit-inotify
- :repo "magit/magit"
- :fetcher github
- :files ("contrib/magit-inotify.el"))


### PR DESCRIPTION
The author of `magit-inotify.el` has created a new library `magit-filenotify.el` which supersedes the former.  `magit-inotify.el` will be removed from the Magit repository very soon.

I just added this recently, and now it is obsolete already :-|
