### PR TITLE
Add recipe for org-pandoc.

### DIFF
--- a/recipes/org-pandoc
+++ b/recipes/org-pandoc
@@ -1,0 +1,2 @@
+(org-pandoc :repo "robtillotson/org-pandoc"
+            :fetcher github)


### PR DESCRIPTION
Hello, this pull request is to add my newly committed package 'org-pandoc', found at https://github.com/robtillotson/org-pandoc .  It is an org-mode (8.0+) exporter which postprocesses its output using Pandoc with the aim of creating ePub books, including support for setting ePub stylesheets, metadata, etc. from emacs so it is possible to export an entire book from a single Org file.

Thanks.
