### PR TITLE
Point recipe directly to github repo

### DIFF
--- a/recipes/outline-magic
+++ b/recipes/outline-magic
@@ -1,1 +1,1 @@
-(outline-magic :fetcher wiki)
+(outline-magic :repo "tj64/outline-magic" :fetcher github)


### PR DESCRIPTION
[UNTESTED]

I tried to install with the original recipe fetching from Wiki
but the outline-magic.el file that was fetched contained illegal
read syntax in the first line:
# REDIRECT OutlineMagic

On EmacsWiki, there is a link to the above github repo
