### PR TITLE
recipe for palimpsest (minor mode)

### DIFF
--- a/recipes/palimpsest
+++ b/recipes/palimpsest
@@ -1,0 +1,3 @@
+(palimpsest 
+ :fetcher github
+ :repo "danielsz/Palimpsest")  


### PR DESCRIPTION
- A brief summary of what the package does

This minor mode for Emacs provides several strategies to remove text without permanently deleting it. Namely, it provides the following capabilities:

Send selected text to the bottom of the file
Send selected text to a trash file 
- Your association with the package

I am the author and maintainer
- A direct link to the package repository.

https://github.com/danielsz/Palimpsest
