### PR TITLE
Add recipe to Cask.

### DIFF
--- a/recipes/cask
+++ b/recipes/cask
@@ -1,0 +1,1 @@
+(cask :repo "rejeep/cask.el" :fetcher github)


### PR DESCRIPTION
The Carton project is renamed to Cask so here's a new recipe for that. Do you think we should leave the Carton recipe for a period of time before removing it?
