### PR TITLE
Add efire recipe

### DIFF
--- a/recipes/efire
+++ b/recipes/efire
@@ -1,0 +1,1 @@
+(efire :fetcher github :repo "capitaomorte/efire")


### PR DESCRIPTION
Hi @milkypostman, I want to add this recipe to MELPA, but don't you merge it yet, since I'm having some trouble testing it. 

It's supposed to depend on another package already contribted to MELPA, [`circe`](https://github.com/jorgenschaefer/circe). The version of `circe` is, for now irrelevant. I don't know how to write the `Package-Requires:` header, I cannot find examples for this use case:

Its now:

```
;; Version: 0.1
;; Package-Requires: ((circe "0"))
;; Author: João Távora <joaotavora@gmail.com>
;; Keywords: convenience, tools
;; URL: https://github.com/capitaomorte/efire
```

I think I saw the "0" technique somewhere. Unfortunately, if I follow the instructions in your homepage for testing an installation from the package file made by `make recipes/efire`, a clean `emacs -Q` run will always try to find the `circe-0` package as the dependency to [efire](https://github.com/capitaomorte/efire).
