### PR TITLE
Adds `elisp-sandbox` recipe

### DIFF
--- a/recipes/elisp-sandbox
+++ b/recipes/elisp-sandbox
@@ -1,0 +1,8 @@
+;; -*- mode: emacs-lisp -*-
+
+(elisp-sandbox
+ :fetcher github
+ :repo "joelmccracken/elisp-sandbox"
+ :commit "master"
+ :files ("elisp-sandbox.el"))
+


### PR DESCRIPTION
elisp-sandbox is package of the sandboxed evaluation code pulled out of fsbot on #emacs. With it users can safely evaluate untrusted emacs lisp code. 

https://github.com/joelmccracken/elisp-sandbox is the package repository

I am its maintainer.

Thanks!
