### PR TITLE
Add magit-find-file recipe

### DIFF
--- a/recipes/magit-find-file
+++ b/recipes/magit-find-file
@@ -1,0 +1,1 @@
+(magit-find-file :repo "bradleywright/magit-find-file.el" :fetcher github)


### PR DESCRIPTION
This is a recipe that allows one to use the functionality of `git ls-files` inside a completing-read function as a replacement for `find-file`. It's like [technomancy/find-file-in-project](https://github.com/technomancy/find-file-in-project) but exclusively uses Git.

The Magit dependency is just because it's some of my [personal utilities](https://github.com/bradleywright/emacs-d/blob/master/init-utils.el) ripped out into a separate package.

[I'm the maintainer](https://github.com/bradleywright/magit-find-file.el).

It's also my first Emacs package, so criticism etc. accepted gratefully.
