### PR TITLE
Add a recipe for minibuffer-complete-cycle.

### DIFF
--- a/recipes/minibuffer-complete-cycle
+++ b/recipes/minibuffer-complete-cycle
@@ -1,0 +1,1 @@
+(minibuffer-complete-cycle :repo "knu/minibuffer-complete-cycle" :fetcher github)


### PR DESCRIPTION
This is my fork of minibuffer-complete-cycle, which original version no longer works with Emacs 24.

https://github.com/knu/minibuffer-complete-cycle
