### PR TITLE
Added package+

### DIFF
--- a/recipes/package+
+++ b/recipes/package+
@@ -1,0 +1,4 @@
+(package+
+ :fetcher github
+ :repo "zenspider/package"
+ :files ("package+.el"))


### PR DESCRIPTION
package+.el extends package.el with a number of functions (many of which I intend to submit upstream) to help you manage your packages easier. Specifically it provides the ability to declare a package-manifest that'll install or remove packages as necessary.

This is my package, it is located at https://github.com/zenspider/package

I've tested this with make recipes/package+ and it worked once I moved my own timeout script out of my ~/bin

Thanks
