### PR TITLE
Add nummm-mode recipe

### DIFF
--- a/recipes/nummm-mode
+++ b/recipes/nummm-mode
@@ -1,0 +1,1 @@
+(nummm-mode :repo "agpchil/nummm-mode" :fetcher github)


### PR DESCRIPTION
This is a package I wrote to display the number of minor modes instead of their names in mode-line.
The package can be found in my repo: https://github.com/agpchil/nummm-mode
