### PR TITLE
Add pkg-info

### DIFF
--- a/recipes/pkg-info
+++ b/recipes/pkg-info
@@ -1,0 +1,1 @@
+(pkg-info :repo "lunaryorn/pkg-info.el" :fetcher github)


### PR DESCRIPTION
pkg-info is a package to query information about packages.

See lunaryorn/flycheck#197
