### PR TITLE
Split dash in two: dash.el and dash-functional.el

### DIFF
--- a/recipes/dash
+++ b/recipes/dash
@@ -1,1 +1,1 @@
-(dash :fetcher github :repo "magnars/dash.el")
+(dash :fetcher github :repo "magnars/dash.el" :files ("dash.el"))

--- a/recipes/dash-functional
+++ b/recipes/dash-functional
@@ -1,0 +1,1 @@
+(dash-functional :fetcher github :repo "magnars/dash.el" :files ("dash-functional.el"))


### PR DESCRIPTION
This way we can depend on Emacs 24 in dash-functional, while keeping Emacs 23 support in dash core.
