### PR TITLE
Add mu4e-maildirs-extension recipe

### DIFF
--- a/recipes/mu4e-maildirs-extension
+++ b/recipes/mu4e-maildirs-extension
@@ -1,0 +1,1 @@
+(mu4e-maildirs-extension :repo "agpchil/mu4e-maildirs-extension" :fetcher github)


### PR DESCRIPTION
I've been asked to submit another of my packages in MELPA. This one show mu4e maildirs summary in mu4e main view.

The package can be found in: https://github.com/agpchil/mu4e-maildirs-extension
