### PR TITLE
Move to forked Puppet Mode

### DIFF
--- a/recipes/puppet-mode
+++ b/recipes/puppet-mode
@@ -1,1 +1,1 @@
-(puppet-mode :fetcher github :repo "puppetlabs/puppet-syntax-emacs")
+(puppet-mode :fetcher github :repo "lunaryorn/puppet-mode")


### PR DESCRIPTION
As discussed in lunaryorn/puppet-mode#5, a pull-request to use @bbatsov and mine fork of Puppet Mode, as upstream is obviously abandoned.

Crossreferencing lunaryorn/puppet-mode#9 for the sake of convenience.
