### PR TITLE
added thrift-mode

### DIFF
--- a/recipes/thrift-mode
+++ b/recipes/thrift-mode
@@ -1,0 +1,3 @@
+(thrift-mode :fetcher git
+               :url "git://git.apache.org/thrift.git"
+               :files ("contrib/thrift.el"))


### PR DESCRIPTION
This needs a touch up before accepting, but I'm not sure where to look for help.

This recipe successfully compiles, but when I try to `M-x package-install-file` the result, I get:

```
Debugger entered--Lisp error: (error "Packages lacks a file header")
  signal(error ("Packages lacks a file header"))
  error("Packages lacks a file header")
  package-buffer-info()
  package-install-file("~/Desktop/src/melpa/packages/thrift-mode-20090330.2252.el")
  call-interactively(package-install-file record nil)
  command-execute(package-install-file record)
  execute-extended-command(nil "package-install-file")
  call-interactively(execute-extended-command nil nil)
```
