### PR TITLE
adding a recipe for ez-query-replace

### DIFF
--- a/recipes/ez-query-replace
+++ b/recipes/ez-query-replace
@@ -1,0 +1,3 @@
+(ez-query-replace
+ :repo "Wilfred/ez-query-replace.el"
+ :fetcher github)


### PR DESCRIPTION
Package summary:

> ez-query-replace is a simple wrapper around `query-replace' that adds a default search term, and allows you to conveniently replay old replacements.
