### PR TITLE
Adding a recipe for mon-css-color

### DIFF
--- a/recipes/mon-css-color
+++ b/recipes/mon-css-color
@@ -1,0 +1,1 @@
+(mon-css-color :fetcher wiki)


### PR DESCRIPTION
This package highlights colours in CSS files. A picture best describes the behaviour:

![screenshot from 2013-08-22 12 04 54](https://f.cloud.github.com/assets/70800/1008123/9c583030-0b1a-11e3-8dc8-ced0600d0e53.png)
