### PR TITLE
rm tern-ido-complete (moved to ido-at-point)

### DIFF
--- a/recipes/tern
+++ b/recipes/tern
@@ -1,1 +1,1 @@
-(tern :fetcher github :repo "marijnh/tern" :files ("emacs/tern.el" "emacs/tern-ido-complete.el"))
+(tern :fetcher github :repo "marijnh/tern" :files ("emacs/tern.el"))


### PR DESCRIPTION
Hi,

Since `tern-ido-complete.el` was [removed from Tern](https://github.com/marijnh/tern/pull/223), please update this recipe.
