### PR TITLE
Recipe for css-eldoc

### DIFF
--- a/recipes/css-eldoc
+++ b/recipes/css-eldoc
@@ -1,3 +1,3 @@
 (css-eldoc :fetcher github
         :repo "zenozeng/css-eldoc"
-        :files ("css-ac-dict" "*.el"))
+        :files ("css-eldoc.el" "css-eldoc-hash-table.el"))


### PR DESCRIPTION
Recipe for [css-eldoc](https://github.com/zenozeng/css-eldoc) which uses eldoc to add hinting in the echo area while writing css.

There is an el-get recipe, but I don't use that so instead of vendoring css-eldoc I figured I'd write a recipe instead.

Package builds, installs, and works just fine.
