### PR TITLE
Add modern Python-mode from Github.

### DIFF
--- a/recipes/python-mode
+++ b/recipes/python-mode
@@ -1,0 +1,1 @@
+(python-mode :fetcher github :repo "fgallina/python.el")


### PR DESCRIPTION
Modern & maintained version of python-mode. Marmalade has a dated version and I don't see another Python mode in MELPA.
