### PR TITLE
Fix vlfi recipe to include just one file.

### DIFF
--- a/recipes/vlfi
+++ b/recipes/vlfi
@@ -1,1 +1,2 @@
-(vlfi :repo "m00natic/vlfi" :fetcher github)
+(vlfi :repo "m00natic/vlfi" :fetcher github
+      :files ("vlfi.el"))


### PR DESCRIPTION
In accordance with https://github.com/milkypostman/melpa/issues/986
additional file has been added (vlf.el) to the vlfi repository that
better not be included in what becomes a dummy error package.
