### PR TITLE
Add vlf recipe.

### DIFF
--- a/recipes/vlf
+++ b/recipes/vlf
@@ -1,0 +1,2 @@
+(vlf :repo "m00natic/vlfi" :fetcher github
+     :files ("vlf.el"))


### PR DESCRIPTION
In accordance with https://github.com/milkypostman/melpa/issues/986
vlfi package is renamed to vlf.
