### PR TITLE
Readd jabber.el

### DIFF
--- a/recipes/jabber
+++ b/recipes/jabber
@@ -1,0 +1,4 @@
+(jabber
+ :url "git://git.code.sf.net/p/emacs-jabber/git"
+ :fetcher git
+ :files ("*.el" "*.texi" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))


### PR DESCRIPTION
The problems with the earlier jabber.el recipe (see issue #201) should be fixed now. It's no longer necessary to run ./configure in order to get a working package. If hexrgb is installed, the installed version is used, otherwise a fallback version contained in the jabber package is used.
