### PR TITLE
Move flycheck-d-unittest to Flycheck

### DIFF
--- a/recipes/flycheck-d-unittest
+++ b/recipes/flycheck-d-unittest
@@ -1,1 +1,1 @@
-(flycheck-d-unittest :repo "tom-tan/flycheck-d-unittest" :fetcher github)
+(flycheck-d-unittest :repo "flycheck/flycheck-d-unittest" :fetcher github)


### PR DESCRIPTION
flycheck-d-unittest is now in the Flycheck organization.
This pull request moves the repository of flycheck-d-unittest from `tom-tan/flycheck-d-unittest` to `flycheck/flycheck-d-unittest`.
