### PR TITLE
add workaround for package-desc-vers for emacs from trunk

### DIFF
--- a/melpa.el
+++ b/melpa.el
@@ -82,7 +82,9 @@ if non-nil."
   (when (and package-filter-function
              (funcall package-filter-function
                       (car package)
-                      (package-desc-vers (cdr package))
+                      (if (fboundp 'package-desc-version)
+                          (package--ac-desc-version (cdr package))
+                        (package-desc-vers (cdr package)))
                       archive))
     ad-do-it))
 


### PR DESCRIPTION
package-desc-vers no longer exists in emacs trunk. This commit fix that issue.
The idea borrowed from here:) https://github.com/purcell/emacs.d/commit/c0039e29f4ad12956a94cf8467ebc7b5c279857b
