### PR TITLE
Add speechd-el

### DIFF
--- a/recipes/speechd-el
+++ b/recipes/speechd-el
@@ -1,0 +1,3 @@
+(speechd-el
+ :url "git://git.freebsoft.org/git/speechd-el"
+ :fetcher git)


### PR DESCRIPTION
Initial recipe for speechd-el.
speechd-el is a client to speech synthesizers and Braille displays.
I'm the maintainer of the package.
Upstream repository is available at git://git.freebsoft.org/git/speechd-el.
