### PR TITLE
Change molokai-theme repository

### DIFF
--- a/recipes/molokai-theme
+++ b/recipes/molokai-theme
@@ -1,2 +1,3 @@
-(molokai-theme :repo "2029061" :fetcher github)
-
+(molokai-theme :repo "alloy-d/color-theme-molokai"
+               :fetcher github
+               :files ("molokai-theme.el"))


### PR DESCRIPTION
Now original repository provides Emacs 24 theme engine version.
([gist version](https://gist.github.com/milkypostman/2029061) is a bit diffrent from original version)

Please check this patch.
