### PR TITLE
Add reporters path to Ecukes recipe.

### DIFF
--- a/recipes/ecukes
+++ b/recipes/ecukes
@@ -1,2 +1,2 @@
 (ecukes :repo "rejeep/ecukes" :fetcher github
-        :files ("ecukes*" "templates" "bin"))
+        :files ("ecukes*" "templates" "bin" "reporters"))


### PR DESCRIPTION
Hi,

I'm about to release a new version of Ecukes and there's a new directory with Elisp files called `reporters` that must be included.
