### PR TITLE
request to add `gnus-spotlight' recipe.

### DIFF
--- a/recipes/gnus-spotlight
+++ b/recipes/gnus-spotlight
@@ -1,0 +1,1 @@
+(gnus-spotlight :fetcher wiki)


### PR DESCRIPTION
`gnus-spotlight' is a tool to use Macintosh "spotlight" feature to locate and create Gnus search group.  
This is quite useful, so with the permission of the author, I've uploaded it to EmacsWiki and create a recipe for it.
Currently, it works with MacOS 10.5 to 10.8.
I appreciate it it could be included in MELPA package.
Regards,
