### PR TITLE
Allow custom emacs binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKGDIR  := ./packages
 RCPDIR  := ./recipes
 HTMLDIR := ./html
 WORKDIR := ./working
-EMACS   := emacs
+EMACS   ?= emacs
 
 EVAL := $(EMACS)
 


### PR DESCRIPTION
So that you can run:

``` bash
EMACS="/path/to/emacs" make recipes/foo
```
