### PR TITLE
Update flycheck-color-mode-line location

### DIFF
--- a/recipes/flycheck-color-mode-line
+++ b/recipes/flycheck-color-mode-line
@@ -1,1 +1,1 @@
-(flycheck-color-mode-line :repo "syl20bnr/flycheck-color-mode-line" :fetcher github)
+(flycheck-color-mode-line :repo "flycheck/flycheck-color-mode-line" :fetcher github)


### PR DESCRIPTION
flycheck-color-mode-line moved into the Flycheck organization.
