### PR TITLE
Recipe for elfeed-web

### DIFF
--- a/recipes/elfeed-web
+++ b/recipes/elfeed-web
@@ -1,0 +1,3 @@
+(elfeed-web :repo "skeeto/elfeed"
+            :fetcher github
+            :files (("." "web/*")))


### PR DESCRIPTION
This is an AngularJS web interface for Elfeed, an Emacs web feed (RSS, Atom) reader. This PR depends on the skeeto/elfeed recipe PR since it's useless without that recipe.

https://github.com/skeeto/elfeed

This is distributed separately because I don't want the core package to depend on the web server package.

I've tested that the package builds and installs properly.
