### PR TITLE
add "gongo/emacs-toml" recipe

### DIFF
--- a/recipes/emacs-toml
+++ b/recipes/emacs-toml
@@ -1,0 +1,1 @@
+(emacs-toml :fetcher github :repo "gongo/emacs-toml" :files ("toml.el"))


### PR DESCRIPTION
[emacs-toml](https://github.com/gongo/emacs-toml) is a library for parsing TOML (Tom's Obvious, Minimal Language).

eg:

``` lisp
(require 'toml)
(toml:read-from-string "\
key1 = \"foo\"
key2 = \"bar\"
key3 = \"333\"")

;; => '(("key3" . "333") ("key2" . "bar") ("key1" . "foo"))
```
