### PR TITLE
split magit into multiple packages

### DIFF
--- a/recipes/magit
+++ b/recipes/magit
@@ -1,2 +1,14 @@
-(magit :repo "magit/magit" :fetcher github)
+(magit :fetcher github
+       :repo "magit/magit"
+       :files ("magit.el"
+	       "magit-bisect.el"
+	       "magit-blame.el"
+	       "magit-cherry.el"
+	       "magit-compat.el"
+	       "magit-key-mode.el"
+	       "magit-wip.el"
+	       "magit.info"
+	       "dir"
+	       "AUTHORS.md"
+	       "README.md"))
 

--- a/recipes/magit-stgit
+++ b/recipes/magit-stgit
@@ -1,0 +1,3 @@
+(magit-stgit :fetcher github
+	     :repo "magit/magit"
+	     :files ("magit-stgit.el"))

--- a/recipes/magit-svn
+++ b/recipes/magit-svn
@@ -1,0 +1,3 @@
+(magit-svn :fetcher github
+	   :repo "magit/magit"
+	   :files ("magit-svn.el"))

--- a/recipes/magit-topgit
+++ b/recipes/magit-topgit
@@ -1,0 +1,3 @@
+(magit-topgit :fetcher github
+	      :repo "magit/magit"
+	      :files ("magit-topgit.el"))


### PR DESCRIPTION
Split (most) Magit libraries that depend on external binaries or scripts into separate packages.

I suggested this move at https://github.com/magit/magit/issues/845 as well as on the Magit mailing list. There were no objections and very little feedback. (Of topic: Are my uses of _at_ and _on_ correct here?)

The `magit` recipe lists `magit.info` and `dir` in `:files` but the files are not part of the tarball. What am I doing wrong?

Also included are `AUTHORS.md` (because we mention it in the library headers) and `README.md` (because the header `magit.el` isn't good enough yet. Most importantly it does not link to the FAQ on the wiki, which I will fix. But considering that we also have to include `AUTHORS.md` do you recommend against adding `README.md' in the tarball. I will fix the Commentary eventually.)

The `magit-flow.el` library that was previously part of the `magit` package, is intentionally not part of any package at this point. It is not very useful in its current form.
