### PR TITLE
Add cl-lib-highlight recipe.

### DIFF
--- a/recipes/cl-lib-highlight
+++ b/recipes/cl-lib-highlight
@@ -1,0 +1,2 @@
+(cl-lib-highlight :repo "skeeto/cl-lib-highlight"
+                  :fetcher github)


### PR DESCRIPTION
Adds all the missing cl-lib font-lock highlighting. To my great surprise this doesn't seem to exist anywhere else yet, and I was getting tired of waiting for this sort of thing to get added to Emacs itself.

https://github.com/skeeto/cl-lib-highlight

It only took me a couple of hours to put this together, so if there's something better out there don't be afraid to turn this down in favor of that.
