### PR TITLE
Add recipe for calmer-forest-theme.

### DIFF
--- a/recipes/calmer-forest-theme
+++ b/recipes/calmer-forest-theme
@@ -1,0 +1,1 @@
+(calmer-forest-theme :repo "caldwell/calmer-forest-theme" :fetcher github)


### PR DESCRIPTION
Calmer forest theme for Emacs 24. Based on an old color-theme.el theme called "calm forest".
