### PR TITLE
Adding a recipe for python-info

### DIFF
--- a/recipes/python-info
+++ b/recipes/python-info
@@ -1,0 +1,3 @@
+(python-info
+ :repo "Wilfred/python-info"
+ :fetcher github)


### PR DESCRIPTION
This package includes the Python 2.x manual as an info manual. There's just enough elisp in there to keep Emacs happy that it's a package.
