### PR TITLE
Geiser recipe

### DIFF
--- a/recipes/geiser
+++ b/recipes/geiser
@@ -1,0 +1,9 @@
+(geiser
+  :fetcher github
+  :repo "jaor/geiser"
+  :files ("elisp/*.el"
+          "elisp/geiser-version.el.in"
+          "doc/*.texi"
+          ("bin" "bin/geiser-racket.sh")
+          ("scheme" ("racket" "scheme/racket/*")
+                    ("guile" "scheme/guile/*"))))


### PR DESCRIPTION
Recipe for [Geiser](http://geiser.nongnu.org), an collection of Emacs
modes and utilities for interacting with Scheme and Racket.

Following up discussion at issue jaor/geiser#13
