### PR TITLE
Rename org-mac-link-grabber to org-mac-link to correspond to changes ups...

### DIFF
--- a/recipes/org-mac-link
+++ b/recipes/org-mac-link
@@ -1,0 +1,4 @@
+(org-mac-link
+ :fetcher git
+ :url "git://orgmode.org/org-mode.git"
+ :files ("contrib/lisp/org-mac-link.el"))

--- a/recipes/org-mac-link-grabber
+++ b/recipes/org-mac-link-grabber
@@ -1,4 +1,0 @@
-(org-mac-link-grabber
- :fetcher git
- :url "git://orgmode.org/org-mode.git"
- :files ("contrib/lisp/org-mac-link-grabber.el"))


### PR DESCRIPTION
...tream.

http://orgmode.org/cgit.cgi/org-mode.git/commit/contrib/lisp?id=76dc3eb0af3ed715ddfbabc11a1443234f0542bd

Trying to cleanup nonbuilding packages... just want to check on these.
