### PR TITLE
magit: include magit.texi to trigger build of magit.info.

### DIFF
--- a/recipes/magit
+++ b/recipes/magit
@@ -7,8 +7,7 @@
 	       "magit-compat.el"
 	       "magit-key-mode.el"
 	       "magit-wip.el"
-	       "magit.info"
-	       "dir"
+	       "magit.texi"
 	       "AUTHORS.md"
 	       "README.md"))
 


### PR DESCRIPTION
This also removes the magit.info and dir files.
