### PR TITLE
Add recipe for nrepl-tracing.

### DIFF
--- a/recipes/nrepl-tracing
+++ b/recipes/nrepl-tracing
@@ -1,0 +1,2 @@
+(nrepl-tracing :repo "clojure-emacs/nrepl-tracing"
+                 :fetcher github)


### PR DESCRIPTION
Please add nrepl-tracing to melpa.

An extension of nrepl. Let's you easily trace clojure code.

I am the maintainer of this extension.

Link: http://github.com/clojure-emacs/nrepl-tracing
