### PR TITLE
fix gather.el recipe to point the newest version

### DIFF
--- a/recipes/gather
+++ b/recipes/gather
@@ -1,1 +1,1 @@
-(gather :fetcher github :repo "mhayashi1120/Emacs-Lisp" :files ("gather.el"))
+(gather :fetcher github :repo "mhayashi1120/Emacs-gather" :files ("gather.el"))


### PR DESCRIPTION
Please fix the recipe to point the newest version.
