### PR TITLE
Add new package osx-pseudo-daemon

### DIFF
--- a/recipes/osx-pseudo-daemon
+++ b/recipes/osx-pseudo-daemon
@@ -1,0 +1,1 @@
+(osx-pseudo-daemon :repo "DarwinAwardWinner/osx-pseudo-daemon" :fetcher github)


### PR DESCRIPTION
Here's the mode help text:

Emulate daemon mode in OSX by hiding Emacs when you kill the last GUI frame.

On OSX, if you use Cocoa Emacs' daemon mode and then close all
GUI frames, the Emacs app on your dock becomes nonfunctional
until you open a new GUI frame using emacsclient on the command
line. This is obviously suboptimal. This package makes it so that
whenever you close the last GUI frame, a new frame is created and
the Emacs app is hidden, thus approximating the behvaior of
daemon mode while keeping the Emacs dock icon functional. To
actually quit instead of hiding Emacs, use CMD+Q (or Alt+Q if you
swapped Alt & Command keys).

This mode has no effect unless Emacs is running on OSX with the
Cocoa GUI, so it is safe to enable it unconditionally on all
platforms.
