### PR TITLE
New receipes for japanese-holidays

### DIFF
--- a/recipes/japanese-holidays
+++ b/recipes/japanese-holidays
@@ -1,3 +1,2 @@
 (japanese-holidays :repo "emacs-jp/japanese-holidays"
-                   :fetcher github
-                   :files ("japanese-holidays.el"))
+                   :fetcher github)


### PR DESCRIPTION
Request to add new recipe.  This adds Japanese holidays to Emacs calendar.
Originally, this file was very old.  Removed obsolete variable and function names.
