### PR TITLE
added recipe for orgmode-octopress

### DIFF
--- a/recipes/orgmode-octopress
+++ b/recipes/orgmode-octopress
@@ -1,0 +1,1 @@
+(orgmode-octopress :repo "craftkiller/orgmode-octopress"  :fetcher github)


### PR DESCRIPTION
Summary: This is an exporter for Emacs Org-Mode to Octopress Markdown

I am not associated with this package at all, I just like it and think that it may be useful to others.   

Upstream: https://github.com/craftkiller/orgmode-octopress 

Test: the package builds and can be install  
