### PR TITLE
change recipes from :url to :repo

### DIFF
--- a/recipes/scheme-here
+++ b/recipes/scheme-here
@@ -1,1 +1,1 @@
-(scheme-here :fetcher github :url "https://github.com/judevc/scheme-here.git")
+(scheme-here :fetcher github :repo "judevc/scheme-here")


### PR DESCRIPTION
Hi, sorry to bother. 
  The version and source of 'scheme-here on milkbox didn't work properly. I don't if I need to change the :url to :repo in the recipe.  
  Thanks
