### PR TITLE
add recipe for connection

### DIFF
--- a/recipes/connection
+++ b/recipes/connection
@@ -1,0 +1,3 @@
+(connection :repo "myrkr/dictionary-el"
+	    :fetcher github
+	    :files ("connection.el" "connection-pkg.el"))


### PR DESCRIPTION
connection supports TCP-based client connections, needed by the dictionary package
