### PR TITLE
add recipe for link

### DIFF
--- a/recipes/link
+++ b/recipes/link
@@ -1,0 +1,3 @@
+(link :repo "myrkr/dictionary-el"
+      :fetcher github
+      :files ("link.el" "link-pkg.el"))


### PR DESCRIPTION
link implements clickable text-based links where a text property
are used to hold all information.

needed by the dictionary package
