### PR TITLE
Take over rainbow-delimiters.

### DIFF
--- a/recipes/rainbow-delimiters
+++ b/recipes/rainbow-delimiters
@@ -1,2 +1,2 @@
-(rainbow-delimiters :fetcher github :repo "jlr/rainbow-delimiters")
+(rainbow-delimiters :fetcher github :repo "Fanael/rainbow-delimiters")
 


### PR DESCRIPTION
The original upstream seems to be moribund, with the latest activity happening in March, not even responding to bug reports since.

I'm willing to maintain the package for the time being. I promise not to break the API compatibility too soon.

I'm loath to rename my fork, because it would necessitate introducing new faces in all the color themes that support the package.
