### PR TITLE
remove magit-{cherry,compat}.el from magit

### DIFF
--- a/recipes/magit
+++ b/recipes/magit
@@ -3,8 +3,6 @@
        :files ("magit.el"
 	       "magit-bisect.el"
 	       "magit-blame.el"
-	       "magit-cherry.el"
-	       "magit-compat.el"
 	       "magit-key-mode.el"
 	       "magit-wip.el"
 	       "magit.texi"


### PR DESCRIPTION
The files `magit-cherry.el' and`magit-compat.el'
have both been merged into `magit.el'.
