### PR TITLE
Add ruby-additional, elisp files in the CRuby distribution.

### DIFF
--- a/recipes/ruby-additional
+++ b/recipes/ruby-additional
@@ -1,0 +1,9 @@
+(ruby-additional
+ :fetcher svn
+ :url "http://svn.ruby-lang.org/repos/ruby/trunk/misc/"
+ :files ("rdoc-mode.el"
+         "ruby-additional.el"
+         "ruby-electric.el"
+         "ruby-style.el"
+         "rubydb2x.el"
+         "rubydb3x.el"))


### PR DESCRIPTION
- ruby-mode.el is excluded because the one bundled with Emacs 24 should be considered the main line and ruby-additional.el is a patch to make it work like the one in the CRuby repo.
- inf-ruby.el is excluded because there is a better fork in MELPA.
- ruby-electric.el is included because the one in the Ruby repo has its own changes separate from the one in MELPA, which I did not know about when I was working on the former.
