### PR TITLE
Added control-mode

### DIFF
--- a/recipes/control-mode
+++ b/recipes/control-mode
@@ -1,0 +1,1 @@
+(control-mode :fetcher "github" :repo "stephendavidmarsh/control-mode")


### PR DESCRIPTION
This pull adds a recipe for control-mode, a package I authored.

Description:

Control mode is a global minor mode for Emacs that provides a "control" mode, similar in purpose to vim's "normal" mode. Unlike the various vim emulation modes, the key bindings in Control mode are derived from the key bindings already setup, usually by making the control key unnecessary, e.g. "Ctrl-f" becomes "f". This provides the power of a mode dedicated to controlling the editor without needing to learn or maintain new key bindings. See https://github.com/stephendavidmarsh/control-mode
