### PR TITLE
Attempt at stable packages for wiki

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -238,13 +238,34 @@ seconds; the server cuts off after 10 requests in 20 seconds.")
             (message "%s is unchanged" filename)
             (cdr stamp-info))
         (message "%s has changed - checking mod time" filename)
+        ;; We get timestamp even for stable packages, because timestamp
+        ;; might get used and because stamp-file is useful anyway.
         (let ((new-timestamp
                (with-current-buffer (pb/with-wiki-rate-limit
                                      (url-retrieve-synchronously wiki-url))
                  (pb/find-parse-time
                   "Last edited \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} [0-9]\\{2\\}:[0-9]\\{2\\} [A-Z]\\{3\\}\\)"))))
           (pb/dump (cons new-content-hash new-timestamp) stamp-file)
-          new-timestamp)))))
+          ;; If package is stable, try to find its version number
+          (if (null package-build-stable)
+              new-timestamp
+            (let ((stable-version-number
+                   (progn
+                     (with-temp-buffer ;; If this turns out to be slow, grep could be used instead.
+                       (insert-file-contents-literally filename)
+                       (goto-char (point-min))
+                       (if (search-forward-regexp "^;;+ +Version: +\\([^ \n\t]+\\) *$" nil t)
+                           (setq stable-version-number (match-string-no-properties 1)))))))
+              ;; If we found a valid number, return it. Otherwise, just use good'ol timestamp.
+              (if (and (stringp stable-version-number)
+                       (ignore-errors (version-to-list stable-version-number)))
+                  ;; If package is multi-file, chances are only 1 of
+                  ;; them will have a version number. So we need this
+                  ;; minor hack. We prepend Z to the version string to
+                  ;; make sure it's sorted before timestamps (in the
+                  ;; checkout-wiki function).
+                  (concat "Z" stable-version-number)
+                new-timestamp))))))))
 
 (defun pb/checkout-wiki (name config dir)
   "Checkout package NAME with config CONFIG from the EmacsWiki into DIR."
@@ -257,7 +278,15 @@ seconds; the server cuts off after 10 requests in 20 seconds.")
           (is-unstable (eq (plist-get config :stability) 'unstable)))
       ;; We build when `package-build-stable' is the oposite of `is-unstable':
       (when (eq (null package-build-stable) is-unstable)  ;XOR
-        (car (nreverse (sort (mapcar 'pb/grab-wiki-file files) 'string-lessp)))))))
+        (let ((version-string
+               (car (nreverse (sort (mapcar 'pb/grab-wiki-file files) 'string-lessp)))))
+          ;; If any of the files contained a version number (and we're
+          ;; building stable) we prepended a Z to each of them (so
+          ;; they wouldn't be overriden by the timestamp of the files
+          ;; without version numbers. Here, we remove this Z.
+          (if (string-match "\\`Z" version-string)
+              (substring version-string 1)
+            version-string))))))
 
 (defun pb/darcs-repo (dir)
   "Get the current darcs repo for DIR."


### PR DESCRIPTION
This is a separate request, as I'm not actually sure it's desirable.
### This implements stable-package building for wiki packages.

A wiki package's stability is determined by a :stability property.  
If this property is absent (which, of course, is the case for all packages right now), is defaults to _stable_. 

I made _"stable"_ the default because packages from the wiki aren't usually considered development versions.

This already includes a previous (separate) commit about checking out tags in git packages.
