### PR TITLE
Added recipe for grass-mode.el.

### DIFF
--- a/recipes/grass-mode
+++ b/recipes/grass-mode
@@ -1,0 +1,3 @@
+(grass-mode
+ :url "https://tws@bitbucket.org/tws/grass-mode.el"
+ :fetcher hg)


### PR DESCRIPTION
Adding a recipe for grass-mode.el
- A brief summary of what the package does.
  This package provides an interface to the GRASS GIS program, similar to how ESS interacts with R/S-Plus.
- Your association with the package
  I am the author of this package, and sole contributor to the code, so far.
- A direct link to the package repository.
  https://bitbucket.org/tws/grass-mode.el/wiki/Home
- Relevant communications with the package maintainer 
  As far as I understand, my package conforms with the package.el format
- Test that the package builds properly via make recipes/<recipe>.
  Confirmed, after changing the makefile from 'EMACS ?= emacs' to 'EMACS := emacs'

~/hacking/melpa$ make recipes/grass-mode 
 • Building recipe grass-mode ...
emacs --no-site-file --batch -l package-build.el --eval "(package-build-archive 'grass-mode)"
Loading /home/tyler/hacking/melpa/json-fix.el (source)...

;;; grass-mode

Fetcher: hg
Source: https://tws@bitbucket.org/tws/grass-mode.el

Cloning https://tws@bitbucket.org/tws/grass-mode.el to /home/tyler/hacking/melpa/working/grass-mode/
Saving file /home/tyler/hacking/melpa/packages/grass-mode-20131019.1537.el...
Wrote /home/tyler/hacking/melpa/packages/grass-mode-20131019.1537.el
Wrote /home/tyler/hacking/melpa/packages/archive-contents
Built in 0.514s, finished at Sat Oct 19 16:26:41 2013
 ✓ Wrote 40K -rw-r--r-- 1 tyler tyler 37K Oct 19 16:26 ./packages/grass-mode-20131019.1537.el 
- Test that the package installs properly via package-install-file.
  Confirmed on Emacs 24.3.50.1:

Compiling file /home/tyler/.emacs.d/elpa/grass-mode-0.1/grass-mode-pkg.el at Sat Oct 19 16:44:13 2013
Entering directory `/home/tyler/.emacs.d/elpa/grass-mode-0.1/'

Compiling file /home/tyler/.emacs.d/elpa/grass-mode-0.1/grass-mode.el at Sat Oct 19 16:44:13 2013

_NB_ This package provides the option to use the w3m.el package. This is not a requirement, just a user-configurable option. As w3m.el is not yet packaged, I can't add it as a package.el requirement. Users must install it themselves from external sources. Consequently, if you don't have w3m.el installed on your system, you get a few warnings about w3m functions during package-install-file, but no errors.
