### PR TITLE
rename surround recipe to evil-surround

### DIFF
--- a/recipes/evil-surround
+++ b/recipes/evil-surround
@@ -1,0 +1,1 @@
+(evil-surround :repo "timcharper/evil-surround" :fetcher github)

--- a/recipes/surround
+++ b/recipes/surround
@@ -1,2 +1,0 @@
-(surround :repo "timcharper/evil-surround" :fetcher github)
-


### PR DESCRIPTION
All of the other evil-related recipes (evil-leader, evil-numbers) are prefixed with "evil". Let's prefix this one too.
