### PR TITLE
add magit-log-edit

### DIFF
--- a/recipes/magit-log-edit
+++ b/recipes/magit-log-edit
@@ -1,0 +1,1 @@
+(magit-log-edit :fetcher github :repo "magit/magit-log-edit")


### PR DESCRIPTION
This is the old pre-`git-commit-mode` commit mode. We are making this available as an alternative, because there are people who are deeply troubled by the short comings of the new mode and because I cannot take their (justified but often misguided) complains any longer. Please merge soon.
