### PR TITLE
Recipe for pier-mode

### DIFF
--- a/recipes/pier-mode
+++ b/recipes/pier-mode
@@ -1,0 +1,3 @@
+(pier-mode
+ :repo "DamienCassou/pier-cl"
+ :fetcher github)


### PR DESCRIPTION
Summary: Emacs Major mode for Pier-formatted text files.

Association with the package: I am the maintainer.

Repository: https://github.com/DamienCassou/pier-cl

Communication with package maintainer: none, the package was already
ready.

Tests: the package builds and installs properly.
