### PR TITLE
added `projector.el` recipe

### DIFF
--- a/recipes/projector
+++ b/recipes/projector
@@ -1,0 +1,1 @@
+(projector :repo "waymondo/projector.el" :fetcher github)


### PR DESCRIPTION
adding a recipe for `projector.el` - a lightweight Emacs library for managing project/repository-aware shell and shell command buffers
