### PR TITLE
Add pretty-mode-plus.

### DIFF
--- a/recipes/pretty-mode-plus
+++ b/recipes/pretty-mode-plus
@@ -1,0 +1,1 @@
+(pretty-mode-plus :fetcher github :repo "akatov/pretty-mode-plus")


### PR DESCRIPTION
Redisplay parts of the buffer as pretty symbols.

I'm the former maintainer and now contributor, @akatov is the current maintainer.

https://github.com/akatov/pretty-mode-plus

https://github.com/akatov/pretty-mode-plus/issues/20

Tested 'make recipes/<recipe>' and did a package-install-file on it. It had previously lived on Marmalade successfully.
