### PR TITLE
added xcscope recipe

### DIFF
--- a/recipes/xcscope
+++ b/recipes/xcscope
@@ -1,0 +1,3 @@
+(xcscope
+ :fetcher github
+ :repo "dkogan/xcscope.el")


### PR DESCRIPTION
Hi.

This patch contributes the recipe for the 'xcscope.el' package.
This is an emacs frontend to the cscope source cross-referencing
tool.

cscope lives here:     http://cscope.sf.net
xcscope.el lives here: https://github.com/dkogan/xcscope.el

xcscope.el was originally written by somebody else, but I now
maintain it. The original version still exists in the CVS sources
of cscope itself. This copy is stable and not actively
maintained. Before this year, the last change happened in 2002.
There were two commits to the CVS this year, both initiated by
me:

 http://cscope.cvs.sourceforge.net/viewvc/cscope/cscope/contrib/xcscope/xcscope.el?view=log

Since then I did quite a bit of development outside of the CVS,
fixing many bugs and adding some very important (to me) features.

There are multiple emacs interfaces to cscope floating around.
I'm hoping to unify all their strengths into this package, to
make it the one true cscope interface.
