### PR TITLE
update darcsum repo url

### DIFF
--- a/recipes/darcsum
+++ b/recipes/darcsum
@@ -1,2 +1,2 @@
-(darcsum :url "http://joyful.com/repos/darcsum" :fetcher darcs)
+(darcsum :url "http://hub.darcs.net/simon/darcsum" :fetcher darcs)
 


### PR DESCRIPTION
Hi.. I'm the current darcsum maintainer. I've updated the repo url (the old one still works, but this one is more correct). I've also just released version 1.3. If you are able to bump the MELPA package to the latest (tagged "1.3") that would be great. I haven't re-validated the MELPA package myself, but I expect it to work as before. Thanks!
