### PR TITLE
Added parse-csv, simple parser from CSV to list

### DIFF
--- a/recipes/parse-csv
+++ b/recipes/parse-csv
@@ -1,0 +1,1 @@
+(parse-csv :fetcher github :repo "mrc/el-csv" :files ("parse-csv.el"))


### PR DESCRIPTION
This package "parse-csv" is a simple parser of strings with CSV to s-expressions.

It's a port of Edward Marco Baringer's csv.lisp, with his permission.

I'm the author and current maintainer.

The official repo is http://github.com/mrc/el-csv which is the source used in this recipe.
