### PR TITLE
Adding sunrise-commander

### DIFF
--- a/recipes/sunrise-commander
+++ b/recipes/sunrise-commander
@@ -1,0 +1,4 @@
+(sunrise-commander
+ :repo "escherdragon/sunrise-commander"
+ :fetcher github
+ :files ("sunrise-commander.el"))


### PR DESCRIPTION
The Sunrise Commmander is an double-pane file manager for Emacs

I am not package owner nor maintainer. I just like th package :)
This is just one file from that repository. It is packaged as intended by the author as you can see here: 
http://joseito.republika.pl/sunrise-commander/
Rest of the files in the repo are extensions in seperate packages

https://github.com/escherdragon/sunrise-commander
http://www.emacswiki.org/emacs/Sunrise_Commander
