### PR TITLE
Add insfactor

### DIFF
--- a/recipes/insfactor
+++ b/recipes/insfactor
@@ -1,0 +1,3 @@
+(insfactor :fetcher github
+           :repo "duelinmarkers/insfactor.el"
+           :commit "origin/release")


### PR DESCRIPTION
Insfactor is a Clojure lib for inspection of project code (providing `find-usages` within a leiningen project). insfactor.el is the client that makes insfactor useful for Emacs users.

I'm the author/maintainer.

Repo: http://github.com/duelinmarkers/insfactor.el (see also http://github.com/duelinmarkers/insfactor).

I think it's package.el-compatible, but it's my first emacs package, so I may not have gotten it quite right.
