### PR TITLE
Add dedukti-mode

### DIFF
--- a/recipes/dedukti-mode
+++ b/recipes/dedukti-mode
@@ -1,0 +1,1 @@
+(dedukti-mode :fetcher github :repo "rafoo/dedukti-mode")


### PR DESCRIPTION
Hello,

I am the author of a simple (generic) major mode for Dedukti files and I would like to contribute with it to the list of packages available on the MELPA repository.

This mode does syntax hilighting using generic-mode + font-lock and adds regexps matching positions in error messages using compilation-error-regexp-alist from the compile package.

Dedukti is a type checker for the lambda-Pi-claculus modulo, a logical framework developed in my research team. It is available at https://www.rocq.inria.fr/deducteam/Dedukti/.
Both Dedukti and the major mode are free softwares under the CeCILL-B license.

The package is distributed on github : https://github.com/rafoo/dedukti-mode

`make recipes/dedukti-mode` and `package-install-file <RET> ~/git/melpa/packages/dedukti-mode-20131112.1058.el` work without warning on my machine.

Thank you for hosting and maintaining the MELPA Archive, I find it very useful!

Raphaël
