### PR TITLE
Remove 'find-things-fast' recipe.

### DIFF
--- a/recipes/find-things-fast
+++ b/recipes/find-things-fast
@@ -1,1 +1,0 @@
-(find-things-fast :fetcher github :repo "mamciek/find-things-fast")


### PR DESCRIPTION
Repo seems to be deleted.

/ping @mamciek -- is find-things-fast gone?
