### PR TITLE
Delete recipe for fetchmacs

### DIFF
--- a/recipes/fetchmacs
+++ b/recipes/fetchmacs
@@ -1,1 +1,0 @@
-(fetchmacs :fetcher github :repo "gempesaw/fetchmacs")


### PR DESCRIPTION
Fetchnotes no longer has a public facing API, so the fetchmacs project has been obsolete for a few months. I'll add it back in if they open up access again. In the meantime, this project is completely useless.
