### PR TITLE
add ac-etags

### DIFF
--- a/recipes/ac-etags
+++ b/recipes/ac-etags
@@ -1,0 +1,1 @@
+(ac-etags :fetcher github :repo "syohex/emacs-ac-etags")


### PR DESCRIPTION
`ac-etags` provides `etags`, `ctags` completion source for auto-complete.
Please see this patch.

https://github.com/syohex/emacs-ac-etags
