### PR TITLE
Support for haskdogs-emacs package

### DIFF
--- a/recipes/haskdogs-emacs
+++ b/recipes/haskdogs-emacs
@@ -1,0 +1,5 @@
+(haskdogs-emacs
+ :repo "ifigueroap/haskdogs-emacs"
+ :fetcher github
+ :files ("haskdogs-emacs.el"
+         "generate-haskdogs.sh"))


### PR DESCRIPTION
Hi,

I forked the hasktags-emacs repo, and changed it so it uses the haskdogs program to generate tags for Haskell files.
I want to submit a simple recipe to install this new package.

Thanks
