### PR TITLE
add ac-ispell

### DIFF
--- a/recipes/ac-ispell
+++ b/recipes/ac-ispell
@@ -1,0 +1,1 @@
+(ac-ispell :fetcher github :repo "syohex/emacs-ac-ispell")


### PR DESCRIPTION
`ac-ispell` provides ispell/aspell completion source for `auto-complete`.
Please see this patch.

https://github.com/syohex/emacs-ac-ispell
