### PR TITLE
magit recipe: add magit-popup.el

### DIFF
--- a/recipes/magit
+++ b/recipes/magit
@@ -4,6 +4,7 @@
 	       "magit-bisect.el"
 	       "magit-blame.el"
 	       "magit-key-mode.el"
+	       "magit-popup.el"
 	       "magit-wip.el"
 	       "magit.texi"
 	       "AUTHORS.md"


### PR DESCRIPTION
This file will replace magit-key-mode.el.  To prevent users ending up
with a Melpa version that misses both files due to timing issues, I am
adding this file now, then (probably tomorrow) push the commit with the
rename to Magit's repository, and then come back here and remove
magit-key-mode.el.
