### PR TITLE
Add recipe `elscreen-mew`

### DIFF
--- a/recipes/elscreen-mew
+++ b/recipes/elscreen-mew
@@ -1,0 +1,1 @@
+(elscreen-mew :repo "masutaka/elscreen-mew" :fetcher github)


### PR DESCRIPTION
`elscreen-mew.el` is elscreen.el Add-On for Mew.
Mew http://mew.org/ is a mail reader for Emacs.
