### PR TITLE
Change evm recipe repo.

### DIFF
--- a/recipes/evm
+++ b/recipes/evm
@@ -1,1 +1,1 @@
-(evm :repo "rejeep/evm" :fetcher github)
+(evm :repo "rejeep/evm.el" :fetcher github)


### PR DESCRIPTION
There are now two repositories: `evm` and `evm.el`. Use `evm.el`, which is the one that contains the Emacs Lisp code.

Note: I could not try the build locally with `make recipes/evm` because I don't have the `timeout` command available.
