### PR TITLE
Added x-dict recipe.

### DIFF
--- a/recipes/x-dict
+++ b/recipes/x-dict
@@ -1,0 +1,1 @@
+(x-dict :fetcher github :repo "emacsmirror/x-dict")


### PR DESCRIPTION
Description: 
The x-dict package is an Emacs interface for the x-dict tool which provides command line access to the online dictionaries LEO and dict.cc.

Affiliation:
I don't maintain this package. I would like to be able to install it from MELPA.

Repository URL:
https://github.com/emacsmirror/x-dict

Comment:
Package added as is from repository URL.
