### PR TITLE
Fix google-this

### DIFF
--- a/recipes/google-this
+++ b/recipes/google-this
@@ -1,1 +1,1 @@
-(google-this :repo "Bruce-Connor/emacs-google-this" :fetcher github)
+(google-this :repo "Bruce-Connor/emacs-google-this" :fetcher github :files ("google-this.el"))


### PR DESCRIPTION
I hadn't noticed that the default was to take ALL .el files (despite
this being exlained in the readme), so the testing files were being
included in the build.

This fix Specifies a file to use.
