### PR TITLE
Add debpaste recipe

### DIFF
--- a/recipes/debpaste
+++ b/recipes/debpaste
@@ -1,0 +1,1 @@
+(debpaste :repo "alezost/debpaste.el" :fetcher github)


### PR DESCRIPTION
The package is Emacs client for http://paste.debian.net/.

Link - https://github.com/alezost/debpaste.el.

`make recipes/debpaste` and `M-x package-install-file` were successful.
