### PR TITLE
Update ruby-block to fork on github

### DIFF
--- a/recipes/ruby-block
+++ b/recipes/ruby-block
@@ -1,1 +1,1 @@
-(ruby-block :fetcher wiki)
+(ruby-block :fetcher github :repo "juszczakn/ruby-block")


### PR DESCRIPTION
I've forked ruby-block from it's emacswiki page and made some changes to fix the highlighting when the cursor is behind an end. I know forks are discouraged, however this file hasn't seriously been updated on emacswiki for two years now, and it seems like emacswiki is discouraged. 

If this isn't the case, then I updated the emacswiki page as well, the changes should be there regardless. 
