### PR TITLE
Add chruby.el recipe

### DIFF
--- a/recipes/chruby
+++ b/recipes/chruby
@@ -1,0 +1,1 @@
+(chruby :repo "plexus/chruby.el" :fetcher github)


### PR DESCRIPTION
The package is actually called "chruby.el", as opposed to the (Ruby) package "Chruby", hence the suffix on the recipe file.

https://github.com/plexus/chruby.el/issues/3
