### PR TITLE
malabar-mode 1.5.1

### DIFF
--- a/recipes/malabar-mode
+++ b/recipes/malabar-mode
@@ -3,7 +3,7 @@
 	:fetcher git
 	:files (
 		("." "src/main/lisp/*")
-		"pom.xml"
+		("pom" "src/main/pom/*")
 		))
 		
 


### PR DESCRIPTION
malabar-mode:
malabar-mode extends java-mode with hooks into Maven that make it easy to compile files on the fly and execute Maven build commands.

I am the current maintainer.

https://github.com/m0smith/malabar-mode
