### PR TITLE
Adding a :files key to the clojure-cheatsheet recipe.

### DIFF
--- a/recipes/clojure-cheatsheet
+++ b/recipes/clojure-cheatsheet
@@ -1,1 +1,3 @@
-(clojure-cheatsheet :fetcher github :repo "clojure-emacs/clojure-cheatsheet")
+(clojure-cheatsheet :fetcher github
+					:repo "clojure-emacs/clojure-cheatsheet"
+					:files ("clojure-cheatsheet.el"))


### PR DESCRIPTION
I'm about to push a test-case file - clojure-cheatsheet-tests.el - to
github, but it shouldn't be picked up for the end-user.
