### PR TITLE
Add pydoc-info

### DIFF
--- a/recipes/pydoc-info
+++ b/recipes/pydoc-info
@@ -1,0 +1,1 @@
+(pydoc-info :fetcher hg :url "https://bitbucket.org/jonwaltman/pydoc-info")


### PR DESCRIPTION
pydoc-info is an Emacs package for searching and browsing the new
Python documentation in the Info browser.

I don't have any association with the package, I just want to use though melpa to keep my emacs configuration simple.

The package repository is at https://bitbucket.org/jonwaltman/pydoc-info/

I didn't contact the package maintainer, but there is an [open issue](https://bitbucket.org/jonwaltman/pydoc-info/issue/5/add-pydoc-info-to-a-elpa-repository) filed by another user to get this package, also the maintainer added ELPA support some time ago according to the commit history, so pydoc-info doesn't require modifications to be built.

I've been using the package built locally for a day and I haven't had any problems.
