### PR TITLE
add shell-current-directory recipe

### DIFF
--- a/recipes/shell-current-directory
+++ b/recipes/shell-current-directory
@@ -1,0 +1,3 @@
+(shell-current-directory
+ :fetcher github
+ :repo "metaperl/shell-current-directory")


### PR DESCRIPTION
A brief summary of what the package does: Open a shell relative to the working directory.

My association with the package: contributor and current maintainer.

Here is [a direct link to the package repository](https://github.com/metaperl/shell-current-directory)

Test that the package builds properly via make recipes/<recipe>? YES

Test that the package installs properly via package-install-file? YES
