### PR TITLE
racket-mode: Set files to *.el

### DIFF
--- a/recipes/racket-mode
+++ b/recipes/racket-mode
@@ -1,2 +1,2 @@
 (racket-mode :repo "greghendershott/racket-mode" :fetcher github
-             :files ("racket-mode.el" "*.rkt"))
+             :files ("*.el" "*.rkt"))


### PR DESCRIPTION
Although I've added just one additional new file,
`racket-keywords-and-builtins.el`, I'm too lazy to type that here.

Seriously: I reckon specifying *.el is "future proof", in the same way
it was recommended to just specify *.rkt. However if that's not good
practice, let me know and I'll update the PR to enumerate the *.el files
instead.
