### PR TITLE
add explicit list of files to exclude development-only file

### DIFF
--- a/recipes/solarized-theme
+++ b/recipes/solarized-theme
@@ -1,7 +1,3 @@
 (solarized-theme :repo "bbatsov/solarized-emacs"
                  :fetcher github
-                 :files ("solarized-dark-theme.el"
-                         "solarized-light-theme.el"
-                         "solarized-theme-pkg.el"
-                         "solarized-theme.el"
-                         "solarized.el"))
+                 :files (*.el (:exclude "solarized-theme-utils.el")))


### PR DESCRIPTION
- please check with @bbatsov before merging
- excludes file that users do not need that gives a byte compilation warning
- closes https://github.com/bbatsov/solarized-emacs/pull/93
