### PR TITLE
Official slime repository is moved to github

### DIFF
--- a/recipes/slime
+++ b/recipes/slime
@@ -1,3 +1,3 @@
-(slime :repo "antifuchs/slime"
+(slime :repo "slime/slime"
        :fetcher github
        :files ("*.el" "*.lisp" "*.asd" "contrib" "doc/*.texi" "ChangeLog"))


### PR DESCRIPTION
See also
- http://article.gmane.org/gmane.lisp.slime.devel/11212 (Now this link is not connected)
- http://xach.livejournal.com/321531.html
