### PR TITLE
Add fringe-current-line

### DIFF
--- a/recipes/fringe-current-line
+++ b/recipes/fringe-current-line
@@ -1,0 +1,1 @@
+(fringe-current-line :fetcher github :repo "kyanagi/fringe-current-line")


### PR DESCRIPTION
fringe-current-line is a package to indicate current line on the fringe.
I'm a maintainer.
https://github.com/kyanagi/fringe-current-line
