### PR TITLE
New recipe: dired-imenu

### DIFF
--- a/recipes/dired-imenu
+++ b/recipes/dired-imenu
@@ -1,0 +1,3 @@
+(dired-imenu :fetcher github
+             :repo "DamienCassou/dired-imenu"
+             :files ("dired-imenu.el"))


### PR DESCRIPTION
`dired-imenu` integrates `imenu` in `dired` so you can easily jump to
any file and directory in the current buffer (to rename it, change its
permissions...)
- Association with the package: maintainer
- Link to the package repository: https://github.com/DamienCassou/dired-imenu
- Test that the package builds properly via make recipes: done
- Test that the package installs properly via package-install-file: done
