### PR TITLE
Add flycheck-mercury

### DIFF
--- a/recipes/flycheck-mercury
+++ b/recipes/flycheck-mercury
@@ -1,0 +1,1 @@
+(flycheck-mercury :fetcher github :repo "flycheck/flycheck-mercury")


### PR DESCRIPTION
[flycheck-mercury](https://github.com/flycheck/flycheck-mercury) provides a syntax checker for the [Mercury language](http://mercurylang.org/).

I added this recipe using Github's web interface, so I did **not** test it.  However, it's just like the flycheck-hdevtools recipe, so I'm fairly confident that it works :)
