### PR TITLE
Add bracketed-paste

### DIFF
--- a/recipes/bracketed-paste
+++ b/recipes/bracketed-paste
@@ -1,0 +1,1 @@
+(bracketed-paste :fetcher github :repo "hchbaw/bracketed-paste.el")


### PR DESCRIPTION
This package provides Bracketed Paste Mode within emacs -nw.
I'm an author of the package. https://github.com/hchbaw/bracketed-paste.el

Please take a look sometime.
