### PR TITLE
Rename ac-nrepl-compliment to ac-cider-compliment

### DIFF
--- a/recipes/ac-cider-compliment
+++ b/recipes/ac-cider-compliment
@@ -1,0 +1,1 @@
+(ac-cider-compliment :fetcher github :repo "alexander-yakushev/ac-cider-compliment")

--- a/recipes/ac-nrepl-compliment
+++ b/recipes/ac-nrepl-compliment
@@ -1,1 +1,0 @@
-(ac-nrepl-compliment :fetcher github :repo "alexander-yakushev/ac-nrepl-compliment")


### PR DESCRIPTION
Package ac-nrepl-compliment which was added in #1381 was renamed to ac-cider-compliment, as nrepl was renamed to CIDER not so long ago.
