### PR TITLE
Add color-identifiers-mode

### DIFF
--- a/recipes/color-identifiers-mode
+++ b/recipes/color-identifiers-mode
@@ -1,0 +1,3 @@
+(color-identifiers-mode
+ :fetcher github
+ :repo "ankurdave/color-identifiers-mode")


### PR DESCRIPTION
Color Identifiers is a minor mode for Emacs that highlights each source code identifier uniquely based on its name. It is inspired by a [post by Evan Brooks](https://medium.com/p/3a6db2743a1e/).

I am the author, and development is on GitHub at https://github.com/ankurdave/color-identifiers-mode.

Thanks!
