### PR TITLE
Add recipe for make-color

### DIFF
--- a/recipes/make-color
+++ b/recipes/make-color
@@ -1,0 +1,1 @@
+(make-color :repo "alezost/make-color.el" :fetcher github)


### PR DESCRIPTION
The package provides an alternative way of choosing a color by modifying
it in context.  May be useful for people working on color themes.

Link - http://github.com/alezost/make-color.el

`make recipes/make-color` and `M-x package-install-file` were passed successfully.
