### PR TITLE
es-windows

### DIFF
--- a/recipes/es-windows
+++ b/recipes/es-windows
@@ -1,0 +1,1 @@
+(es-windows :fetcher github :repo "sabof/es-windows")


### PR DESCRIPTION
Meant as a project-explorer dependency, potentially useful in other contexts. Just like switch-window, but you can a) select internal windows b) split windows 
