### PR TITLE
Bind default-directory to working-dir on checkout.

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -178,8 +178,9 @@ CONFIG, if any, or `package-build-default-files-spec' otherwise."
     (pb/message "Fetcher: %s" repo-type)
     (unless (eq 'wiki repo-type)
       (pb/message "Source: %s\n" (or (plist-get config :repo) (plist-get config :url))))
-    (funcall (intern (format "pb/checkout-%s" repo-type))
-             package-name config working-dir)))
+    (let ((default-directory working-dir))
+      (funcall (intern (format "pb/checkout-%s" repo-type))
+               package-name config working-dir))))
 
 (defvar pb/last-wiki-fetch-time 0
   "The time at which an emacswiki URL was last requested.


### PR DESCRIPTION
I ran `package-build-checkout` with the `default-directory` set as a git repo I was working on, which resulted in a not so nice `git reset --hard` on that repo.

Note that I have not tested this myself, I would hate to loose my changes again. I would prefer to write a test for it instead, but it seems useless since nothing else is tested here.
