### PR TITLE
Use master branch in elnode recipe.

### DIFF
--- a/recipes/elnode
+++ b/recipes/elnode
@@ -1,5 +1,4 @@
 (elnode
  :fetcher github
  :repo "nicferrier/elnode"
- :commit "origin/melpa"
  :files ("*"))


### PR DESCRIPTION
Is there any reason we still use the unmaintained `melpa` branch for elnode?

//cc @nicferrier
