### PR TITLE
Add an EmacSQL recipe.

### DIFF
--- a/recipes/emacsql
+++ b/recipes/emacsql
@@ -1,0 +1,3 @@
+(emacsql :repo "skeeto/emacsql"
+         :fetcher github
+         :files ("*.el" "README.md" "sqlite"))


### PR DESCRIPTION
https://github.com/skeeto/emacsql

My intention is to provide a high-quality, reliable database that other packages can depend on (i.e. in the spirit of SQLite itself). On several occasions I've really needed something like this (Elfeed) and ended up having to hack together my own database. Note that the package includes SQLite binaries (`release` branch) that speak a custom protocol with Emacs. The official sqlite3 command shell [is inadequate for this purpose](http://sqlite.1065341.n5.nabble.com/Command-line-shell-not-flushing-stderr-when-interactive-td73340.html) for several reasons making it unreliable, which is why similar Emacs packages fall short. I wasn't able to find any sort of ELPA package policy regarding native binaries so this is forging some new ground.
