### PR TITLE
Github repository was changed

### DIFF
--- a/recipes/google-translate
+++ b/recipes/google-translate
@@ -1,1 +1,1 @@
-(google-translate :fetcher github :repo "manzyuk/google-translate")
+(google-translate :fetcher github :repo "atykhonov/google-translate")


### PR DESCRIPTION
Github repository for google-translate was changed due to a fact that original repository (manzyuk/google-translate) is obsolete.

The author Oleksandr Manzyuk has provided appropriate comments.

Please take a look at: https://github.com/manzyuk/google-translate
