### PR TITLE
Recipe for reveal-in-finder (Reveal the current file in the OS X Finder)

### DIFF
--- a/recipes/reveal-in-finder
+++ b/recipes/reveal-in-finder
@@ -1,0 +1,3 @@
+(reveal-in-finder :repo "kaz-yos/elisp" 
+		  :fetcher github
+		  :files ("reveal-in-finder.el"))


### PR DESCRIPTION
A brief summary of what the package does.

What this does:
If M-x reveal-in-finder is invoked in a file-associated buffer, it will open the folder enclosing the file in the OS X Finder. It will also select the file the buffer is associated with within the folder.

If M-x reveal-in-finder is invoked in a buffer not associated with a file, it will open the folder defined in the default-directory variable.  In a dired buffer, this should open the current folder in the OS X Finder.

Your association with the package (e.g., are you the maintainer? have you contributed? do you just like the package a lot?).

This is an improved version of the "open-finder" found at the URL below.
http://stackoverflow.com/questions/20510333/in-emacs-how-to-show-current-file-in-finder

A direct link to the package repository.
https://github.com/kaz-yos/elisp/blob/master/reveal-in-finder.el
It consists of a single file in a mixed repository (currently only one .el file).

Relevant communications with the package maintainer (e.g., package.el compatibility changes that you have submitted).
I am the maintainer.

Test that the package builds properly via make recipes/<recipe>.
Using OS X 10.9.1 and emacs 24.3.1, it built properly as seen below..

MBP17-Early2011:melpa kazuki$ make recipes/reveal-in-finder
 • Building recipe reveal-in-finder ...
emacs --no-site-file --batch -l package-build.el --eval "(package-build-archive 'reveal-in-finder)"

;;; reveal-in-finder

Fetcher: github
Source: kaz-yos/elisp
 _omitted_
 Sleeping for 0 ...
sleep 0

Test that the package installs properly via package-install-file.
Using package-install-file and the file generated as
~/path/melpa/packages/reveal-in-finder-20140204.2304.el
it installed without problem and is functioning locally.
