### PR TITLE
Add recipe for cl-lib

### DIFF
--- a/recipes/cl-lib
+++ b/recipes/cl-lib
@@ -1,0 +1,1 @@
+(cl-lib :fetcher github :repo "emacsmirror/cl-lib")


### PR DESCRIPTION
Builds have been failing left and right the last couple of days because ELPA has been highly unreliable.  Thankfully, I am only depending on cl-lib from ELPA.  

Package builds and installs fine.
