### PR TITLE
Add a recipe for typed-clojure-mode

### DIFF
--- a/recipes/typed-clojure-mode
+++ b/recipes/typed-clojure-mode
@@ -1,4 +1,4 @@
 (typed-clojure-mode
  :fetcher git
  :url "https://github.com/typedclojure/typed-clojure-mode"
- :files ("typed-clojure.el"))
+ :files ("typed-clojure-mode.el"))


### PR DESCRIPTION
Typed-clojure-mode defines a minor mode for editing typed
Clojure code with bindings for common routines for refactoring
types. 

It can be found here: https://github.com/typedclojure/typed-clojure-mode

@ambrosebs and I authored it, and @ambrosebs is maintaining it.
