### PR TITLE
Add recipe for aurel

### DIFF
--- a/recipes/aurel
+++ b/recipes/aurel
@@ -1,0 +1,1 @@
+(aurel :repo "alezost/aurel" :fetcher github)


### PR DESCRIPTION
The package for getting [AUR packages](https://aur.archlinux.org/).
I think it may be useful for Arch users.

Link - https://github.com/alezost/aurel

`make recipes/make-color` and `M-x package-install-file` were passed successfully.
