### PR TITLE
add dummyparens recipe

### DIFF
--- a/recipes/dummyparens
+++ b/recipes/dummyparens
@@ -1,0 +1,1 @@
+(dummyparens :fetcher github :repo "snosov1/dummyparens")


### PR DESCRIPTION
This is a simple mode I've been using for auto-pairing. There's quite a few out there like autopair, smartparens, built-in electric-pair, but neither does what I think it should. 

Electric-pair doesn't support wrapping. Smartparens and autopair are too invasive for such simple functionality. They also have bugs and corner cases (conflicting with some modes, like term, latex, html). And I think it's ridiculous when you want the "just-insert-the-closing-pair-for-me" behavior.
