### PR TITLE
Add rdf-prefix recipe

### DIFF
--- a/recipes/rdf-prefix
+++ b/recipes/rdf-prefix
@@ -1,0 +1,1 @@
+(rdf-prefix :fetcher github :repo "simenheg/rdf-prefix" )


### PR DESCRIPTION
The intention of this package is to simplify a common task in the work of RDF developers: remembering and looking up URI prefixes.

I'm the maintainer.

Package repo: https://github.com/simenheg/rdf-prefix.
