### PR TITLE
Add demangle-mode.

### DIFF
--- a/recipes/demangle-mode
+++ b/recipes/demangle-mode
@@ -1,0 +1,3 @@
+(demangle-mode
+ :fetcher github
+ :repo "liblit/demangle-mode")


### PR DESCRIPTION
`demangle-mode` is an Emacs minor mode that automatically demangles C++ symbols. I am the maintainer of this package. Its official repository is https://github.com/liblit/demangle-mode. I have tested that the package builds properly via `make recipes/demangle-mode`, installs properly via `package-install-file`, and runs properly once installed.
