### PR TITLE
Adding darkburn theme

### DIFF
--- a/recipes/darkburn-theme
+++ b/recipes/darkburn-theme
@@ -1,0 +1,3 @@
+(darkburn-theme :repo "gorauskas/darkburn-theme"
+                :fetcher github
+                :files ("darkburn-theme.el"))


### PR DESCRIPTION
Darkburn theme is a color theme for Emacs 24. Based on the Zenburn theme by B. Batsov.  I am the maintainer: Jonas Gorauskas jgorauskas@gmail.com.  Official repo at https://github.com/gorauskas/darkburn-theme 
