### PR TITLE
Added git-link recipe

### DIFF
--- a/recipes/git-link
+++ b/recipes/git-link
@@ -1,0 +1,3 @@
+(git-link
+ :fetcher github
+ :repo "sshaw/git-link")


### PR DESCRIPTION
`git-link`  creates a URL representing the current buffer's location on GitHub, Bitbucket, ... at the current line number or active region.

https://github.com/sshaw/git-link

I am the author.
