### PR TITLE
Add immutant-server package

### DIFF
--- a/recipes/immutant-server
+++ b/recipes/immutant-server
@@ -1,0 +1,1 @@
+(immutant-server :fetcher github :repo "leathekd/immutant-server.el")


### PR DESCRIPTION
Adds my immutant-server.el package to melpa.

From the readme in [the repo](https://github.com/leathekd/immutant-server.el):

> immutant-server.el provides a way to run Immutant from within Emacs. It captures the console output, colorizes it, and offers some tools to help navigate through it.
