### PR TITLE
Add recipe for py-isort

### DIFF
--- a/recipes/py-isort
+++ b/recipes/py-isort
@@ -1,0 +1,3 @@
+(py-isort
+ :repo "paetzke/py-isort.el"
+ :fetcher github)


### PR DESCRIPTION
 Hello,

py-isort provides functionality to apply isort to Python source code in the current buffer.
- I'm the author of the package.
- Package repo: https://github.com/paetzke/py-isort.el 

`$ make recipes/py-isort` and `package-install-file` worked.

Thanks
