### PR TITLE
Add recipe for py-autopep8

### DIFF
--- a/recipes/py-autopep8
+++ b/recipes/py-autopep8
@@ -1,0 +1,3 @@
+(py-autopep8
+ :repo "paetzke/py-autopep8.el"
+ :fetcher github)


### PR DESCRIPTION
Hello,

 py-autopep8 can be used to beautify a Python buffer by using the external autopep8 tool.
- I'm the author of the package.
- Package repo: https://github.com/paetzke/py-autopep8.el

`$ make recipes/py-autopep8` and `package-install-file` worked.

Thanks
