### PR TITLE
Add a recipe for py-gnitset, a Python testing mode

### DIFF
--- a/recipes/py-gnitset
+++ b/recipes/py-gnitset
@@ -1,0 +1,1 @@
+(py-gnitset :fetcher github :repo "quodlibetor/py-gnitset")


### PR DESCRIPTION
py-gnitset is an Emacs interface to "any" Python testing tool, with more
features and compatibility than the already existing Python testing
interfaces. You can read more about it on the github page:
https://github.com/quodlibetor/py-gnitset

I'm the author/maintainer of py-gnitset.
