### PR TITLE
Add helm-perldoc recipe

### DIFF
--- a/recipes/helm-perldoc
+++ b/recipes/helm-perldoc
@@ -1,0 +1,1 @@
+(helm-perldoc :fetcher "github" :repo "syohex/emacs-helm-perldoc")


### PR DESCRIPTION
`helm-perldoc` provides functions which displays documentation and source code
of Perl modules with helm interface. Please see this patch.

https://github.com/syohex/emacs-helm-perldoc
