### PR TITLE
New receipes for ivs-edit, tools for editing Ideographic Variation Seque...

### DIFF
--- a/recipes/ivs-edit
+++ b/recipes/ivs-edit
@@ -1,0 +1,3 @@
+(ivs-edit :repo "kawabata/ivs-edit"
+          :fetcher github
+          :files ("ivs-edit.el" "IVD_Sequences.txt" "jp-old-style.txt"))


### PR DESCRIPTION
New receipes for ivs-edit, tools for editing Ideographic Variation Sequence (defined in Unicode Technical Standard #37).
It currently works only with X-Windows (with `libotf' linked) and MacOS X 
(with Yamamoto Mituharu patch) version 24.3 (or later) Emacsen.
