### PR TITLE
Add ede-compdb recipe.

### DIFF
--- a/recipes/ede-compdb
+++ b/recipes/ede-compdb
@@ -1,0 +1,1 @@
+(ede-compdb :repo "randomphrase/ede-compdb" :fetcher github)


### PR DESCRIPTION
This is a recipe for the [ede-compdb](/randomphrase/ede-compdb) package.

EDE-compdb is a library that enables the Emacs Development Environment (EDE), to be used with a compilation database, as provided by build tools such as CMake or Ninja. This enables CEDET to be automatically configured for use to support parsing, navigation, completion, and so on. This is especially useful for C and C++ projects which are otherwise quite tricky to configure for use with CEDET and other libraries.

I am the maintainer.
