### PR TITLE
parenface recipe

### DIFF
--- a/recipes/parenface
+++ b/recipes/parenface
@@ -1,3 +1,1 @@
-(parenface
- :repo "emacsmirror/parenface"
- :fetcher github)
+(parenface :fetcher github :repo "grettke/parenface")


### PR DESCRIPTION
This package, parenface, fontifies round, curly, and square brackets in Emacs. The version in emacsmirror is older and lacks this new functionality. This packages used to be called parenface-plus,
but purcell worked with us on another package with that naming style to make it conform-ant.

My association with this package is as a maintainerwho likes it a lot.

https://github.com/grettke/parenface

The package builds correctly:

```
gcr@pegasi:~/git/github-grettke/melpa$ emacs --version
GNU Emacs 24.3.1

gcr@pegasi:~/git/github-grettke/melpa$ make recipes/parenface
 • Building recipe parenface ...
/usr/bin/timeout -k 60 600 emacs --no-site-file --batch -l package-build.el --eval "(package-build-archive 'parenface)"

parenface

Fetcher: github
Source: grettke/parenface

Cloning git://github.com/grettke/parenface.git to /home/gcr/git/github-grettke/melpa/working/parenface/
/home/gcr/git/github-grettke/melpa/working/parenface/parenface-pkg.el -> /tmp/parenface8446TnU/parenface-20140303.2052/parenface-pkg.el
/home/gcr/git/github-grettke/melpa/working/parenface/parenface.el -> /tmp/parenface8446TnU/parenface-20140303.2052/parenface.el
/home/gcr/git/github-grettke/melpa/working/parenface/test-load.el -> /tmp/parenface8446TnU/parenface-20140303.2052/test-load.el
File: /tmp/parenface8446TnU/parenface-20140303.2052/parenface-pkg.el
File: /home/gcr/git/github-grettke/melpa/packages/parenface-20140303.2052.entry
Built in 0.014s, finished at Mon Mar  3 21:34:43 2014
 ✓ Wrote 4.0K -rw-r--r-- 1 gcr gcr  85 Mar  3 21:34 ./packages/parenface-20140303.2052.entry
 12K -rw-r--r-- 1 gcr gcr 10K Mar  3 21:34 ./packages/parenface-20140303.2052.tar 
 Sleeping for 0 ...
sleep 0

Leaving directory `/home/gcr/.emacs.d/.cask/24.3.1/elpa/parenface-20140303.2052'
```

The package installs properly:

```
Compiling file /home/gcr/.emacs.d/.cask/24.3.1/elpa/parenface-20140303.2052/parenface-pkg.el at Mon Mar  3 21:36:45 2014
Entering directory `/home/gcr/.emacs.d/.cask/24.3.1/elpa/parenface-20140303.2052/'

Compiling file /home/gcr/.emacs.d/.cask/24.3.1/elpa/parenface-20140303.2052/parenface.el at Mon Mar  3 21:36:45 2014
parenface.el:87:63:Warning: reference to free variable
    `arc-font-lock-keywords-2'
parenface.el:87:63:Warning: assignment to free variable
    `arc-font-lock-keywords-2'

Compiling file /home/gcr/.emacs.d/.cask/24.3.1/elpa/parenface-20140303.2052/test-load.el at Mon Mar  3 21:36:46 2014
emacs --no-init-file

(let ((default-directory "~/.emacs.d/.cask/24.3.1/elpa/"))
  (normal-top-level-add-subdirs-to-load-path))
(eval-after-load 'parenface
  (progn
    (set-face-foreground 'parenface-paren-face "red")
    (set-face-foreground 'parenface-bracket-face "red")
    (set-face-foreground 'parenface-curly-face "red")))
(require 'parenface)
```
