### PR TITLE
Add planet-theme recipe

### DIFF
--- a/recipes/planet-theme
+++ b/recipes/planet-theme
@@ -1,0 +1,1 @@
+(planet-theme :fetcher github :repo "cmack/emacs-planet-theme")


### PR DESCRIPTION
- Adds `planet-theme`, a dark theme based on the color scheme of an old Gmail theme called "Planets"
- I (cmack) am the author and maintainer
- [direct emacs-planet-theme link](http://github.com/cmack/emacs-planet-theme)
- I have tested by making and installing per the instructions in README.md, and have no warnings or errors
