### PR TITLE
Add recipe `cake-inflector`

### DIFF
--- a/recipes/cake-inflector
+++ b/recipes/cake-inflector
@@ -1,0 +1,1 @@
+(cake-inflector :fetcher github :repo "k1LoW/emacs-cake-inflector")


### PR DESCRIPTION
`cake-inflector.el` is lazy porting CakePHP inflector.php to el.

I want to add `cake.el` and `cake2.el`. but they required `cake-inflector.el`.
