### PR TITLE
Added tested recipe for new emacs package: pungi

### DIFF
--- a/recipes/pungi
+++ b/recipes/pungi
@@ -1,4 +1,1 @@
-(pungi
- :fetcher github
- :repo mgrbyte/pungi
- :files ("*.el" "README" "CHANGES" "Makefile"))
+(pungi :fetcher github :repo "mgrbyte/pungi")


### PR DESCRIPTION
The primary purpose of this package is to integrate the python-mode
package with jedi for ease of developing Python code with Emacs.

The primary features provided are::
- Integration with jedi, in particular enabling jedi:goto-definition to
  work with the Python environment.
- Integration with buildout
- Integration with virtualenv

These features are taken directly from::
  https://gist.github.com/nyergler/6100112

I am the author and maintainer of this small package, and think it may be useful to others who do python development with Emacs, virtualenv and buildout. 

It also allows setting project-local python settings via dir_locals.el.

The code in this package is used as a basis for python development, both personal and work.
