### PR TITLE
[all] renamed emacs extension, because mtgox was shutted down

### DIFF
--- a/recipes/btc-ticker
+++ b/recipes/btc-ticker
@@ -1,0 +1,1 @@
+(btc-ticker :fetcher github :repo "niedbalski/emacs-btc-ticker")

--- a/recipes/mtgox
+++ b/recipes/mtgox
@@ -1,1 +1,0 @@
-(mtgox :fetcher github :repo "niedbalski/emacs-mtgox")


### PR DESCRIPTION
Extension renamed because mtgox has been shut down.
