### PR TITLE
Include setup.py in jedi.el package

### DIFF
--- a/recipes/jedi
+++ b/recipes/jedi
@@ -1,3 +1,3 @@
 (jedi :fetcher github
       :repo "tkf/emacs-jedi"
-      :files ("jedi*" "Makefile" "requirements.txt"))
+      :files ("jedi*" "Makefile" "setup.py"))


### PR DESCRIPTION
Note that requirements.txt is not needed anymore because it was removed
from emacs-jedi package sometime ago.

Required by https://github.com/tkf/emacs-jedi/pull/144

Note that this patch is safe to pull since setup.py is already there in master.  But maybe MELPA does not care about missing files in repository anyway?
