### PR TITLE
Point Tuareg recipe to Github

### DIFF
--- a/recipes/tuareg
+++ b/recipes/tuareg
@@ -1,1 +1,1 @@
-(tuareg :fetcher svn :url "svn://svn.forge.ocamlcore.org/svn/tuareg/trunk")
+(tuareg :fetcher github :repo "ocaml/tuareg")


### PR DESCRIPTION
Tuareg seems to be on Github now, see https://github.com/ocaml/tuareg.

It's some commits ahead of the previous repo at [Ocaml Forge](https://forge.ocamlcore.org/projects/tuareg/), but I'm not sure whether it's really the official repo now.  I opened an issue at https://github.com/ocaml/tuareg/issues/2, asking about the state of Tuareg's repo.  

I've opened this PR to make you aware of the issue, but I don't think it should be merged yet, before anyone comments on https://github.com/ocaml/tuareg/issues/2.
