### PR TITLE
Recipe for flycheck-dmd-dub

### DIFF
--- a/recipes/flycheck-dmd-dub
+++ b/recipes/flycheck-dmd-dub
@@ -1,0 +1,1 @@
+(flycheck-dmd-dub :repo "atilaneves/flycheck-dmd-dub" :fetcher github)


### PR DESCRIPTION
[Flycheck](https://github.com/flycheck/flycheck) extension to automatically read [dub](https://github.com/rejectedsoftware/dub) json files and set the include paths for the D compiler automatically. Provides syntax highlighting via flycheck for any D project using dub for package dependencies. Emacs package located at [flycheck-dmd-dub](https://github.com/atilaneves/flycheck-dmd-dub).
