### PR TITLE
Add recipe: helm-hayoo

### DIFF
--- a/recipes/helm-hayoo
+++ b/recipes/helm-hayoo
@@ -1,0 +1,1 @@
+(helm-hayoo :repo "markus1189/helm-hayoo" :fetcher github)


### PR DESCRIPTION
I'm the maintainer, wrote a custom helm source to search
[hayoo](http://holumbus.fh-wedel.de/hayoo/hayoo.html) (haskell api) from helm.  This is my first offical
package.

I am not totally sure about the version bounds, they might be too
restrictive and I don't know why the commentary section is not shown
in the package description, any ideas?

Link to repo: https://github.com/markus1189/helm-hayoo

Best,
Markus
