### PR TITLE
Add debugger code for node.js.

### DIFF
--- a/recipes/realgud
+++ b/recipes/realgud
@@ -6,6 +6,7 @@
             ("realgud/debugger/gdb"       "realgud/debugger/gdb/*.el")
             ("realgud/debugger/gub"       "realgud/debugger/gub/*.el")
             ("realgud/debugger/kshdb"     "realgud/debugger/kshdb/*.el")
+            ("realgud/debugger/nodejs"    "realgud/debugger/nodejs/*.el")
             ("realgud/debugger/pdb"       "realgud/debugger/pdb/*.el")
             ("realgud/debugger/perldb"    "realgud/debugger/perldb/*.el")
             ("realgud/debugger/pydb"      "realgud/debugger/pydb/*.el")


### PR DESCRIPTION
In preparation to support realgud debugger handling for node.js. I tested this with `make recipes/realgud` and looked at the resulting tar file. 

Right now, the node.js code is in a branch on realgud. I believe this has to be the case before this change or a change like this (see issue #1602) or else melpa installs will fail when trying to require the new code that's not in the tar file. 

Thanks.
