### PR TITLE
Add rails-log-mode recipe

### DIFF
--- a/recipes/rails-log-mode
+++ b/recipes/rails-log-mode
@@ -1,0 +1,1 @@
+(rails-log-mode :fetcher github :repo "ananthakumaran/rails-log-mode")


### PR DESCRIPTION
Emacs Major mode for viewing Rails log files

https://github.com/ananthakumaran/rails-log-mode

I'm not affiliated with the package, but I had this response when I inquired about
submitting the recipe: https://github.com/ananthakumaran/rails-log-mode/issues/1
