### PR TITLE
Add dired-k recipe

### DIFF
--- a/recipes/dired-k
+++ b/recipes/dired-k
@@ -1,0 +1,1 @@
+(dired-k :fetcher github :repo "syohex/emacs-dired-k")


### PR DESCRIPTION
`dired-k` provides highlighting dired buffer like [k](https://github.com/supercrabtree/k) zsh script.

https://github.com/syohex/emacs-dired-k
