### PR TITLE
Add miniedit recipe

### DIFF
--- a/recipes/miniedit
+++ b/recipes/miniedit
@@ -1,0 +1,2 @@
+(miniedit :repo "emacsmirror/miniedit"
+          :fetcher github)


### PR DESCRIPTION
- recipes/miniedit: New recipe: Enhanced editing for minibuffer fields

I don't maintain the package, I just find it really handy for editing things like M-: (eval-expression), replace-regexp, etc. I've installed it locally, replaced my manually-downloaded .el with it, and tested that it continues to work.

Package repository: https://github.com/emacsmirror/miniedit
