### PR TITLE
Add edts recipe

### DIFF
--- a/recipes/edts
+++ b/recipes/edts
@@ -1,0 +1,41 @@
+(edts
+ :fetcher github
+ :repo   "tjarvstrand/edts"
+ :branch "melpa-package"
+ :files  ("*.el"
+          "COPYING"
+          "COPYING.LESSER"
+          "Makefile"
+          "README.md"
+          "start"
+
+          ("elisp/edts"                 "elisp/edts/*.el")
+          (:exclude                     "elisp/edts/*-test.el")
+
+          ("lib/edts"                   "lib/edts/Makefile")
+          ("lib/edts"                   "lib/edts/rebar")
+          ("lib/edts"                   "lib/edts/rebar.config")
+          ("lib/edts/priv"              "lib/edts/priv/app.config")
+          ("lib/edts/priv"              "lib/edts/priv/dispatch.conf")
+          ("lib/edts/src"               "lib/edts/src/*")
+
+          ("plugins/edts_debug"         "plugins/edts_debug/*.el")
+          (:exclude                     "plugins/edts_debug/*-test.el")
+          ("plugins/edts_debug"         "plugins/edts_debug/Makefile")
+          ("plugins/edts_debug"         "plugins/edts_debug/rebar")
+          ("plugins/edts_debug"         "plugins/edts_debug/rebar.config")
+          ("plugins/edts_debug/src"     "plugins/edts_debug/src/*")
+
+          ("plugins/edts_dialyzer"      "plugins/edts_dialyzer/*.el")
+          (:exclude                     "plugins/edts_dialyzer/*-test.el")
+          ("plugins/edts_dialyzer"      "plugins/edts_dialyzer/Makefile")
+          ("plugins/edts_dialyzer"      "plugins/edts_dialyzer/rebar")
+          ("plugins/edts_dialyzer"      "plugins/edts_dialyzer/rebar.config")
+          ("plugins/edts_dialyzer/src"  "plugins/edts_dialyzer/src/*")
+
+          ("plugins/edts_xref"          "plugins/edts_xref/*.el")
+          (:exclude                     "plugins/edts_xref/*-test.el")
+          ("plugins/edts_xref"          "plugins/edts_xref/Makefile")
+          ("plugins/edts_xref"          "plugins/edts_xref/rebar")
+          ("plugins/edts_xref"          "plugins/edts_xref/rebar.config")
+          ("plugins/edts_xref/src"      "plugins/edts_xref/src/*")))


### PR DESCRIPTION
https://github.com/tjarvstrand/edts
https://travis-ci.org/tjarvstrand/edts/builds/22904550

I am the maintainer of this package.

The Erlang Development Tool Suite (EDTS) is a package of useful development tools for working with the Erlang programming language in Emacs. It bundles a number of useful external packages, together with specialized Erlang plugins for them, and its own features to create a complete and efficient development environment that is easy to set up.

The reason for not using the master branch is that the melpa-package branch contains installation instructions and enables a check whether EDTS was installed as a package or not. I don't want to put these things into the master branch before the package is actually available in melpa. As soon as the package is available, I will merge the melpa-package and submit a new pull request with a recipe pointing to master.
