### PR TITLE
Recipe for iregister package

### DIFF
--- a/recipes/iregister
+++ b/recipes/iregister
@@ -1,0 +1,1 @@
+(iregister :fetcher github :repo "atykhonov/iregister.el")


### PR DESCRIPTION
iregister.el --- Interactive register commands for Emacs.

iregister is a package which is built on top of register.el and adds to its functionality interactivity.
I'm the author and maintainer.

_Direct link:_ https://github.com/atykhonov/iregister.el

_Test that the package builds properly via make recipes/<recipe>:_ passed.

_Test that the package installs properly via package-install-file:_ passed.
