### PR TITLE
Add clang-format

### DIFF
--- a/recipes/clang-format
+++ b/recipes/clang-format
@@ -1,0 +1,3 @@
+(clang-format
+ :repo "kljohann/clang-format.el"
+ :fetcher github)


### PR DESCRIPTION
https://github.com/kljohann/turnip.el

> This package allows to filter code through clang-format to fix its formatting. clang-format is a tool that formats C/C++/Obj-C code according to a set of style options, see Clang-Format Style Options. Note that clang-format 3.3 or newer is required.

I did not find anything similar on melpa yet and have been missing this since switching from vim. :)
byte-compiling, making the package, `package-install-from-file` and `checkdoc` produce no errors for me.
