### PR TITLE
Update visible-mark recipe

### DIFF
--- a/recipes/visible-mark
+++ b/recipes/visible-mark
@@ -1,1 +1,3 @@
-(visible-mark :fetcher wiki)
+(visible-mark
+ :url "https://gitlab.com/iankelling/visible-mark.git"
+ :fetcher git)


### PR DESCRIPTION
- recipes/visible-mark: Change from abandoned emacswiki source to
  maintained git repo

I am a new maintainer moving to a git repo from emacswiki source last
updated 2008. New source contains multiple bug fixes and improvements
while keeping compatibility with the old version.
