### PR TITLE
Add recipe for sphinx-doc

### DIFF
--- a/recipes/sphinx-doc
+++ b/recipes/sphinx-doc
@@ -1,0 +1,3 @@
+(sphinx-doc 
+ :fetcher github 
+ :repo "naiquevin/sphinx-doc.el")


### PR DESCRIPTION
[sphinx-doc.el](https://github.com/naiquevin/sphinx-doc.el) is a minor mode for generating and inserting "Sphinx-friendly" docstrings for Python functions and methods from their definitions. The structure of the docstrings is as per the requirement of the [Sphinx documentation generator](http://sphinx-doc.org/). Please see the gif demo in the readme of the repo.

I am the author of this package. I have tested building and installing it as per the melpa docs.

Thanks.
