### PR TITLE
Fix slime recipe to include lib directory

### DIFF
--- a/recipes/slime
+++ b/recipes/slime
@@ -1,3 +1,3 @@
 (slime :repo "slime/slime"
        :fetcher github
-       :files ("*.el" "*.lisp" "*.asd" "contrib" "doc/*.texi" "doc/*.info" "doc/dir" "ChangeLog"))
+       :files ("*.el" "*.lisp" "*.asd" "lib" "contrib" "doc/*.texi" "doc/*.info" "doc/dir" "ChangeLog"))


### PR DESCRIPTION
With latest SLIME recipe, the following error will be occured when loading `slime`

```
(file-error "Cannot open load file" "no such file or directory" "lib/hyperspec")
```
