### PR TITLE
add zotxt recipe

### DIFF
--- a/recipes/zotxt
+++ b/recipes/zotxt
@@ -1,0 +1,3 @@
+(zotxt :fetcher hg
+       :url "https://bitbucket.org/egh/zotxt-emacs"
+       :files ("elisp/*.el"))


### PR DESCRIPTION
adds a recipe for zotxt: http://bitbucket.org/egh/zotxt-emacs
