### PR TITLE
Update password-store repository

### DIFF
--- a/recipes/password-store
+++ b/recipes/password-store
@@ -1,1 +1,3 @@
-(password-store :repo "svend/emacs-password-store" :fetcher github)
+(password-store :fetcher git
+                :url "http://git.zx2c4.com/password-store"
+                :files ("contrib/emacs/*.el"))


### PR DESCRIPTION
The password-store Emacs package is now in the upstream password-store
repository under contrib/emacs.

http://lists.zx2c4.com/pipermail/password-store/2014-April/000809.html
http://lists.zx2c4.com/pipermail/password-store/2014-April/000810.html
