### PR TITLE
Add recipe for helm-bibtex

### DIFF
--- a/recipes/helm-bibtex
+++ b/recipes/helm-bibtex
@@ -1,0 +1,1 @@
+(helm-bibtex :fetcher github :repo "tmalsburg/helm-bibtex")


### PR DESCRIPTION
Helm-bibtex is a helm plugin for searching Bibtex entries. It displays the matching entries in a nicely formatted list and provides some convenient functions for managing a bibliography.  For more details and a screenshot see https://github.com/tmalsburg/helm-bibtex
