### PR TITLE
add recipe for colemak-evil

### DIFF
--- a/recipes/colemak-evil
+++ b/recipes/colemak-evil
@@ -1,0 +1,4 @@
+(colemak-evil
+ :repo "patbl/colemak-evil"
+ :fetcher github
+ :files ("colemak-evil.el"))


### PR DESCRIPTION
Colemak is an alternative keyboard layout, and [Colemak Evil](https://github.com/patbl/colemak-evil) is a set of remappings that makes using Evil's Vim-like keybindings in Emacs more pleasant. Colemak Evil is based on [a set of remappings for Vim](http://forum.colemak.com/viewtopic.php?id=50) used by the creator of Colemak. It's a rather small niche, but someone else suggested that it be added to Melpa, so at least a couple of people would benefit.

I'm the maintainer.
