### PR TITLE
add recipe for evil-god-state

### DIFF
--- a/recipes/evil-god-state
+++ b/recipes/evil-god-state
@@ -1,0 +1,2 @@
+(evil-god-state :fetcher github
+                :repo "gridaphobe/evil-god-state")


### PR DESCRIPTION
[evil-god-state](https://github.com/gridaphobe/evil-god-state) adds an evil command to switch to [god-mode](https://github.com/chrisdone/god-mode) for the next command. This enables an "automatically configured" leader key for evil-mode.

I am the author. This is my first time writing a package.el package, but `make recipes/evil-god-state` seems to work, so hopefully everything is in order :)
