### PR TITLE
Pillar repository moved

### DIFF
--- a/recipes/pillar
+++ b/recipes/pillar
@@ -1,2 +1,2 @@
 (pillar :fetcher github
-        :repo "DamienCassou/pillar-mode")
+        :repo "pillar-markup/pillar-mode")


### PR DESCRIPTION
I'm the author and package maintainer of pillar and I've just moved its
repository to a dedicated team on github.

Old location:
https://github.com/DamienCassou/pillar-mode

New location:
https://github.com/pillar-markup/pillar-mode
