### PR TITLE
Add recipe for magit-gitflow

### DIFF
--- a/recipes/magit-gitflow
+++ b/recipes/magit-gitflow
@@ -1,0 +1,2 @@
+(magit-gitflow :fetcher github :repo "jtatarik/magit-gitflow")
+


### PR DESCRIPTION
magit-gitflow is magit extension implementing 'git flow' support. Its repository is at https://github.com/jtatarik/magit-gitflow

I am the package maintainer.
