### PR TITLE
Update org-trello recipe

### DIFF
--- a/recipes/org-trello
+++ b/recipes/org-trello
@@ -1,3 +1,3 @@
 (org-trello :fetcher github
             :repo "org-trello/org-trello"
-            :files ("org-trello.el" "org-trello-pkg.el"))
+            :files ("org-trello*.el"))


### PR DESCRIPTION
Hi,
-  A brief summary of what the package does.
  org-trello is a minor mode to sync back and forth an org-mode buffer with a trello board.
- A direct link to the package repository.
  https://github.com/org-trello/org-trello
- Your association with the package
  Main author and maintainer.
  I also love package.
- Test that the package builds properly via make recipes/<recipe>
  Done and ok. Both in dev phase and deployed version.
- Test that the package installs properly via package-install-file
  Done and ok. Both in dev phase and deployed version.

This has been introduced from the latest stable version 0.4.4 - https://github.com/org-trello/org-trello/pull/165.

Thanks for your time

Cheers,
