### PR TITLE
Don't read files literally. Should fix #741

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -105,7 +105,7 @@ function for access to this function")
   "Return the contents of FILE-NAME as a string, or nil if no such file exists."
   (when (file-exists-p file-name)
     (with-temp-buffer
-      (insert-file-contents-literally file-name)
+      (insert-file-contents file-name)
       (buffer-substring-no-properties (point-min) (point-max)))))
 
 (defun pb/string-rtrim (str)


### PR DESCRIPTION
This causes problems when we read in utf-8 and then try to dump the
contents back out. Utf-8 characters get read in as if they are ascii.

I'm not sure of the consequences of this though. Because it turns out that the `archive.json` file does not come out at utf-8. Is this a json issue?
