### PR TITLE
Add recipe `serverspec`

### DIFF
--- a/recipes/serverspec
+++ b/recipes/serverspec
@@ -1,0 +1,1 @@
+(serverspec :fetcher github :repo "k1LoW/emacs-serverspec" :files ("*.el" "snippets"))


### PR DESCRIPTION
`serverspec.el` is [Serverspec](http://serverspec.org/) minor mode.
- provide snippets.
- provide spec dir helm source.
