### PR TITLE
Add take-off

### DIFF
--- a/recipes/take-off
+++ b/recipes/take-off
@@ -1,0 +1,4 @@
+(take-off
+ :fetcher github
+ :repo "tburette/take-off"
+ :files ("*.el" "front"))


### PR DESCRIPTION
take-off  takes your emacs off the terminal and into the wonderful web cloud 2.0 (2.0, I miss that buzzword).
It shows emacs in a webpage and you can interact with it (type, shortcuts, arbitrary code).

Repository at: https://github.com/tburette/take-off
I am the maintainer of the package.

I tested the package (building and installing/running) successfully :

```
base:melpa 593$ make recipes/take-off 
End of file during parsing
 • Building recipe take-off ...
emacs --no-site-file --batch -l package-build.el --eval "(let ((package-build-stable nil) (package-build-archive-dir (expand-file-name \"./packages\" pb/this-dir))) (package-build-archive 'take-off))"
End of file during parsing
make: [recipes/take-off] Error 255 (ignored)
 ✓ Wrote    8 -rw-r--r--  1 burettethomas  staff   104B 20 May 14:43 ./packages/take-off-20140520.1441.entry
1152 -rw-r--r--  1 burettethomas  staff   574K 20 May 14:43 ./packages/take-off-20140520.1441.tar
   8 -rw-r--r--  1 burettethomas  staff   642B 20 May 14:43 ./packages/take-off-readme.txt

./packages/take-off-20140520.1358:
total 24
 0 drwxr-xr-x  11 burettethomas  staff   374B 20 May 14:06 front
 8 -rw-r--r--   1 burettethomas  staff   115B 20 May 14:06 take-off-pkg.el
16 -rw-r--r--   1 burettethomas  staff   6.7K 20 May 14:06 take-off.el 
 Sleeping for 0 ...
sleep 0
```

I don't know what the Error 255 is but everything works fine.

If I get things correctly I don't need to have the file `take-off-pkg.el`, it will be generated. Right?
