### PR TITLE
adding recipe for `gradle-mode`

### DIFF
--- a/recipes/gradle-mode
+++ b/recipes/gradle-mode
@@ -1,0 +1,3 @@
+(gradle-mode
+ :fetcher github
+ :repo "jacobono/emacs-gradle-mode")


### PR DESCRIPTION
Gradle mode for emacs -- https://github.com/jacobono/emacs-gradle-mode

This is a mode that hooks the Gradle compilation process into compilation-mode, eliminating the need to go to the terminal to run Gradle builds.

I wrote this package and I plan on maintaining it as I continue to expand on it.
## Testing
- This recipe builds with `make recipes`
- Installs with `package-install-file`
## Sandbox

Running a sandbox and installing fresh works, and installs all the correct dependencies.  

For some odd reason the compilation doesn't work upon installation from `package-list-packages`.
The package `f.el`, while included as a dependency, does not appear to be on the load path for compilation.

However,  initializing the mode and running on local Gradle builds on my file system works just fine.

I'm not sure how to get it to compile after the dependencies are downloaded. If that is a problem, would you mind providing a little guidance as to how to get that to work?

Thanks!
