### PR TITLE
Add quack

### DIFF
--- a/recipes/quack
+++ b/recipes/quack
@@ -1,0 +1,1 @@
+(quack :repo "emacsmirror/quack" :fetcher github)


### PR DESCRIPTION
[Quack](http://www.neilvandyke.org/quack/) is an extension of Emacs’s scheme-mode that provides enhanced support for Racket, including highlighting and indentation of Racket-specific forms, and documentation integration.
