### PR TITLE
Add smart-shift-mode recipe

### DIFF
--- a/recipes/smart-shift
+++ b/recipes/smart-shift
@@ -1,0 +1,1 @@
+(smart-shift :fetcher github :repo "hbin/smart-shift")


### PR DESCRIPTION
Hi, 

This recipe provide a minor mode `smart-shift-mode` for shifting line/region to the left/right by infer the current major mode indentation level.

I build this package for the [PR](https://github.com/bbatsov/prelude/pull/552) to the `prelude`.

Repo is here: https://github.com/hbin/smart-shift

Thanks
