### PR TITLE
add scad-mode recipe

### DIFF
--- a/recipes/scad-mode
+++ b/recipes/scad-mode
@@ -1,0 +1,4 @@
+(scad-mode
+	:repo "openscad/openscad"
+	:fetcher github
+	:files ("contrib/scad-mode.el"))


### PR DESCRIPTION
i'm getting into emacs and OpenSCAD, and i'd love for the scad-mode package to be available through MELPA. 

seeing as i'm new to emacs and i've had no involvement in this package's development, i hope i've done this right, but i'd appreciate any feedback.

this package adds support for the OpenSCAD language, and the repo is at [openscad/openscad](http://github.com/openscad/openscad)
