### PR TITLE
Update move-dup repo name

### DIFF
--- a/recipes/move-dup
+++ b/recipes/move-dup
@@ -1,2 +1,2 @@
-(move-dup :fetcher github :repo "wyuenho/move-dup.el")
+(move-dup :fetcher github :repo "wyuenho/move-dup")
 


### PR DESCRIPTION
This reflects the name repo location of move-dup. The change was to avoid Windows file system naming limitations so Windows users can git clone the repo.
