### PR TITLE
Fix missing file in cider recipe.

### DIFF
--- a/recipes/cider
+++ b/recipes/cider
@@ -1,1 +1,4 @@
-(cider :fetcher github :repo "clojure-emacs/cider" :old-names (nrepl))
+(cider :fetcher github
+       :repo "clojure-emacs/cider"
+       :files ("*.el" (:exclude ".dir-locals.el"))
+       :old-names (nrepl))


### PR DESCRIPTION
See clojure-emacs/cider#627 - the default file spec excludes `*-test.el` by default, and the file `cider-test.el` was recently added to CIDER.
