### PR TITLE
Update repo for rust-mode recipe

### DIFF
--- a/recipes/rust-mode
+++ b/recipes/rust-mode
@@ -1,3 +1,3 @@
-(rust-mode :repo "mozilla/rust"
+(rust-mode :repo "rust-lang/rust"
            :fetcher github
            :files ("src/etc/emacs/rust-mode.el"))


### PR DESCRIPTION
The [Rust repository](https://github.com/rust-lang/) moved to the [rust-mode](https://github.com/rust-lang/) org.

(I believe GitHub redirects the `git://` and `https://`urls for moved repositories indefinitely, so this change isn't strictly necessary.)
