### PR TITLE
Add recipe for pinky-mode, a minor mode to reduce strain on pinkies

### DIFF
--- a/recipes/pinky-mode
+++ b/recipes/pinky-mode
@@ -1,0 +1,3 @@
+(pinky-mode :repo "jayconrod/pinky-mode"
+            :fetcher github
+            :files ("pinky-mode.el"))


### PR DESCRIPTION
Hello! This request is to add a recipe for pinky-mode, a minor mode which is intended to reduce strain on pinkies by altering key bindings. While pinky-mode is active, letter keys invoke common navigation commands instead of inserting text. For example, you can go to the next line (`next-line`) by pressing `n` instead of `C-n`. Pressing `i` exits pinky-mode.

pinky-mode is maintained at https://github.com/jayconrod/pinky-mode

I'm the creator of this package. I've verified this builds with `make recipes/pinky-mode` and installs with `M-x package-install-file`.

This is my first contribution to Melpa, so please let me know if I should fix anything.

Thanks!
