### PR TITLE
Add readability.el

### DIFF
--- a/recipes/readability
+++ b/recipes/readability
@@ -1,0 +1,1 @@
+(readability :repo "ShingoFukuyama/emacs-readability" :fetcher github)


### PR DESCRIPTION
I created readability.el which use Readability's api via oauth.el authentication, and show articles by shr.el (built-in Emacs24.3).
Could you add this?

Thanks always.
