### PR TITLE
evil-space: A port of vim-space for evil

### DIFF
--- a/recipes/evil-space
+++ b/recipes/evil-space
@@ -1,0 +1,1 @@
+(evil-space :repo "linktohack/evil-space" :fetcher github)


### PR DESCRIPTION
This program emulates vim-space initially developed by Henrik Öhman
(spiiph) It help you using `<SPC>` key to repeat the last motion like
what the dot `<.>` key does to repeat the last command. The motion are
normally setup in pair, that means the `<S-SPC>` (or customized to what
one needs) to reverse that motion.

I (linktohack) latter improve it to repeat `vim-unimpared` motions like
`]q<SPC><SPC>` to go to next error (`:cn`) and ability to skip `;` and
`,` motion (`fFtT` still works, that means we press
`fa<SPC><SPC><S-SPC>` instead of `fa;;,`.) to allow us to free map ; as
: and , as <leader>

Original repo: https://github.com/linktohack/evil-space
My fork of vim-space: https://github.com/linktohack/vim-space
And evil-space: https://github.com/linktohack/evil-space
