### PR TITLE
add sqlup-mode 0.0.1

### DIFF
--- a/recipes/sqlup-mode
+++ b/recipes/sqlup-mode
@@ -1,0 +1,2 @@
+(sqlup-mode :fetcher github :repo "trevoke/sqlup-mode.el")
+


### PR DESCRIPTION
sqlup-mode is a minor mode which transforms SQL keywords to upper case.

The repo is at https://github.com/Trevoke/sqlup-mode.el

I am the author and maintainer.

I followed the steps in the testing area and got sqlup-mode to work properly.
