### PR TITLE
ensime recipe and remove self-packaged files

### DIFF
--- a/recipes/ensime
+++ b/recipes/ensime
@@ -1,2 +1,2 @@
-(ensime :fetcher github :repo "ensime/ensime"
-        :files("*.el" "bin" "lib"))
+(ensime :fetcher github
+	:repo "ensime/ensime-emacs")


### PR DESCRIPTION
we've completely redesigned how we distribute the codebase (which includes a large server component written in Scala).

Sources are in a new github repository and binary builds are now hosted on `bintray.com` and handled entirely in our codebase... nothing to do with MELPA anymore. This closes #1792.

Also removed dependency on `popup.el` that you were keen for us to remove.
