### PR TITLE
Adding gnus-desktop-notify

### DIFF
--- a/recipes/gnus-desktop-notify
+++ b/recipes/gnus-desktop-notify
@@ -1,0 +1,2 @@
+(gnus-desktop-notify :repo "wavexx/gnus-desktop-notify"
+                     :fetcher github)


### PR DESCRIPTION
This pull requests adds the 'gnus-desktop-notify' package. It's a global-minor-mode for Gnus that generates desktop notifications in response to new messages.

The source can be found at:

https://github.com/wavexx/gnus-desktop-notify

Official homepage with longer description:

http://www.thregr.org/~wavexx/hacks/gnus-desktop-notify/

It's a single file package. I'm the author/maintainer. I've been using this mode since early 2011.
The package builds fine via make recipes/gnus-desktop-notify and also installs fine on emacs 24.3.1 on debian/linux.
