### PR TITLE
Add tempbuf recipe.

### DIFF
--- a/recipes/tempbuf
+++ b/recipes/tempbuf
@@ -1,0 +1,1 @@
+(tempbuf :fetcher git :url "git://gitorious.org/tempbuf-mode/tempbuf-mode.git")


### PR DESCRIPTION
;; Tempbuf-mode is a minor mode that enables buffers to get
;; automatically deleted in the background when it can be deduced that
;; they are no longer of any use.

Its master repo is at git://gitorious.org/tempbuf-mode/tempbuf-mode.git

I am just a happy user of this package, using it daily for a couple of years now.

I have had no communications with the package author.
