### PR TITLE
Adding a wiki recipe for sqlplus.

### DIFF
--- a/recipes/sqlplus
+++ b/recipes/sqlplus
@@ -1,0 +1,1 @@
+(sqlplus :fetcher wiki)


### PR DESCRIPTION
sqlplus.el is a superb Emacs mode for querying an Oracle database. I think the screenshot on the wiki shows it best:

![screenshot](http://www.emacswiki.org/pics/static/EmSqlPlus.png)
