### PR TITLE
add orgtbl-ascii-plot package

### DIFF
--- a/recipes/orgtbl-ascii-plot
+++ b/recipes/orgtbl-ascii-plot
@@ -1,0 +1,1 @@
+(orgtbl-ascii-plot :fetcher github :repo "tbanel/orgtblasciiplot")


### PR DESCRIPTION
I would like to submit orgtbl-ascii-plot package to Melpa.
- orgtbl-ascii-plot adds plotting capabilities to Org-mode tables, all in Emacs without external dependencies.
- full documentation here: http://orgmode.org/worg/org-contrib/orgtbl-ascii-plot.html
- GitHub home here: https://github.com/tbanel/orgtblasciiplot
- I am the author and maintainer.

This is my first contribution to Melpa (and any Elpa by the way).
I may miss something, so please tell me, I will fix it.

Regards,
Thierry Banel
tbanelwebmin@free.fr

| ! | x | x^2 |  |
| --- | --- | --- | --- |
| # | 0 | 0 |  |
| # | 1 | 1 | . |
| # | 2 | 4 | : |
| # | 3 | 9 | u |
| # | 4 | 16 | W |
| # | 5 | 25 | Wu |
| # | 6 | 36 | WW: |
| # | 7 | 49 | WWH |
| # | 8 | 64 | WWWV |
| # | 9 | 81 | WWWWH |
| # | 10 | 100 | WWWWWW |
| # | 11 | 121 | WWWWWWW- |
| # | 12 | 144 | WWWWWWWWl |
| # | 13 | 169 | WWWWWWWWWW. |
| # | 14 | 196 | WWWWWWWWWWWV |
# +TBLFM: $3=$x*$x::$4='(orgtbl-ascii-draw $3 0 200)
