### PR TITLE
Add toggle-quotes

### DIFF
--- a/recipes/toggle-quotes
+++ b/recipes/toggle-quotes
@@ -1,0 +1,1 @@
+(toggle-quotes :repo "toctan/toggle-quotes.el" :fetcher github)


### PR DESCRIPTION
[toggle-quotes.el](https://github.com/toctan/toggle-quotes.el) lets you toggle between single and double quotes easily. It takes advantage of the `syntax-table` instead of regexp to do the escape. In addition, it only toggle the quotes when it makes sense. For example, in lisp-modes, toggle quotes won't convert the double quotes string to single quoted one.
