### PR TITLE
Add highlight-numbers.

### DIFF
--- a/recipes/highlight-numbers
+++ b/recipes/highlight-numbers
@@ -1,0 +1,2 @@
+(highlight-numbers :fetcher github :repo "Fanael/highlight-numbers"
+                   :old-names (number-font-lock-mode))

--- a/recipes/number-font-lock-mode
+++ b/recipes/number-font-lock-mode
@@ -1,1 +1,0 @@
-(number-font-lock-mode :fetcher "github" :repo "Fanael/number-font-lock-mode")


### PR DESCRIPTION
What is the recommended way to inform users that a package has been renamed and they should move to the new one? Would adding something like `(error "number-font-lock-mode has been renamed to highlight-numbers, please install that instead")` to `number-font-lock-mode` be a good idea?
