### PR TITLE
Remove google-weather as obsolete

### DIFF
--- a/recipes/google-weather
+++ b/recipes/google-weather
@@ -1,1 +1,0 @@
-(google-weather :fetcher git :url "git://git.naquadah.org/google-weather-el.git")


### PR DESCRIPTION
The Google Weather API has been shutdown in 2012 and therefore
package doesn't work anymore.

https://julien.danjou.info/projects/emacs-packages#google-weather

yandex-weather package can be used instead of google-weather.
