### PR TITLE
Add recipe for helm-idris

### DIFF
--- a/recipes/helm-idris
+++ b/recipes/helm-idris
@@ -1,0 +1,3 @@
+(helm-idris
+ :fetcher github
+ :repo "david-christiansen/helm-idris")


### PR DESCRIPTION
helm-idris is a Helm data source for querying the online documentation in the Idris compiler.

The main repo is at https://github.com/david-christiansen/helm-idris

I am the author and maintainer of the package.

I've tested that it builds and installs, per the README.
