### PR TITLE
Add a recipe for cider-browse-ns

### DIFF
--- a/recipes/cider-browse-ns
+++ b/recipes/cider-browse-ns
@@ -1,0 +1,2 @@
+(cider-browse-ns :fetcher github
+                 :repo "jxa/cider-browse-ns")


### PR DESCRIPTION
cider-browse-ns leverages existing cider doc to provide useful clojure namespace listing and navigation buffers
- List all loaded namespaces
- List all vars of a single namespace
- open cider-doc on function at point
