### PR TITLE
new org-mode pandoc exporter.

### DIFF
--- a/recipes/ox-pandoc
+++ b/recipes/ox-pandoc
@@ -1,0 +1,2 @@
+(ox-pandoc :repo "kawabata/ox-pandoc"
+           :fetcher github)


### PR DESCRIPTION
This is a new org-mode exporter for Pandoc (version 1.12.4 or later) which supports org-mode
natively.  This enables org-mode text file to export to various formats supported by org-mode.
