### PR TITLE
Add recipe for github-clone

### DIFF
--- a/recipes/github-clone
+++ b/recipes/github-clone
@@ -1,0 +1,1 @@
+(github-clone :fetcher github :repo "dgtized/github-clone.el")


### PR DESCRIPTION
Provides functionality similar to https://github.com/github/hub, but only for the initial repo fork and clone. The project is hosted at https://github.com/dgtized/github-clone.el, and I am author.
