### PR TITLE
Rename ac-cider-compliment to ac-cider

### DIFF
--- a/recipes/ac-cider
+++ b/recipes/ac-cider
@@ -1,0 +1,3 @@
+(ac-cider :fetcher github
+          :repo "clojure-emacs/ac-cider"
+          :old-names (ac-cider-compliment))

--- a/recipes/ac-cider-compliment
+++ b/recipes/ac-cider-compliment
@@ -1,1 +1,0 @@
-(ac-cider-compliment :fetcher github :repo "alexander-yakushev/ac-cider-compliment")


### PR DESCRIPTION
It's me again. `ac-cider-compliment` was renamed to `ac-cider` and moved inside clojure-emacs group: https://github.com/clojure-emacs/ac-cider
