### PR TITLE
Add a new recipe for helm-ad

### DIFF
--- a/recipes/helm-ad
+++ b/recipes/helm-ad
@@ -1,0 +1,3 @@
+(helm-ad
+ :fetcher github
+ :repo "tnoda/helm-ad")


### PR DESCRIPTION
I created [helm-ad](helm-ad), [helm](helm) source for Active Directory. I would
like you to add its recipe to MELPA. The recipe has passed my tests
by running [`make recipes/helm-ad`](make) and invoking `M-x package-install-file`.

Thanks,
