### PR TITLE
Add nrepl-sync

### DIFF
--- a/recipes/nrepl-sync
+++ b/recipes/nrepl-sync
@@ -1,0 +1,4 @@
+(nrepl-sync
+   :fetcher github
+   :repo "phillord/lein-sync"
+   :files ("emacs/nrepl-sync.el"))


### PR DESCRIPTION
nrepl-sync connects to a externally launched nrepl process for Clojure development and at the same time syncs this process with the current Clojure project, for things like classpath. It supports the lein-sync https://github.com/phillord/lein-sync plugin.

I wrote it, and maintain it.
