### PR TITLE
Add recipe for hc-zenburn-theme

### DIFF
--- a/recipes/hc-zenburn-theme
+++ b/recipes/hc-zenburn-theme
@@ -1,0 +1,4 @@
+(hc-zenburn-theme
+ :repo "edran/hc-zenburn-emacs"
+ :fetcher github
+ :files ("hc-zenburn-theme.el"))


### PR DESCRIPTION
This package adds an higher contrast version of the famous Zenburn theme, with a darker tone and more brilliant colours. I'm really liking it so far, so I might as well share it with everybody else :) (I'm the author)
URL: https://github.com/edran/hc-zenburn-emacs
