### PR TITLE
Add Plim-mode

### DIFF
--- a/recipes/plim-mode
+++ b/recipes/plim-mode
@@ -1,0 +1,3 @@
+(plim-mode
+ :repo "dongweiming/plim-mode"
+ :fetcher github)


### PR DESCRIPTION
[Plim](https://github.com/avanov/Plim) is a Python port of Ruby's Slim template language built on top of Mako Templates. [Plim-mode](https://github.com/dongweiming/plim-mode) is is similar to [slim-mode](https://github.com/slim-template/emacs-slim). I would like you to add its recipe to MELPA. The recipe has passed my tests by running make recipes/plim-mode and invoking M-x package-install-file.

Thanks
