### PR TITLE
Add recipe for rich-minority

### DIFF
--- a/recipes/rich-minority
+++ b/recipes/rich-minority
@@ -1,0 +1,1 @@
+(rich-minority :repo "Bruce-Connor/rich-minority" :fetcher github)


### PR DESCRIPTION
Emacs package for hiding and/or highlighting the list of minor-modes in the mode-line.
https://github.com/Bruce-Connor/rich-minority
