### PR TITLE
Add recipe for crm-custom

### DIFF
--- a/recipes/crm-custom
+++ b/recipes/crm-custom
@@ -1,0 +1,1 @@
+(crm-custom :repo "DarwinAwardWinner/crm-custom" :fetcher github)


### PR DESCRIPTION
crm-custom is my package for bringing "completing-read-multiple" (which
is used by e.g. "describe-face") under the domain of "ido-ubiquitous",
or any other custom completion mechanism that modifies the behavior of
"completing-read".
