### PR TITLE
Deleted ac-dcd-dub from recipes. Package no longer needed, functionality in ac-dcd

### DIFF
--- a/recipes/ac-dcd-dub
+++ b/recipes/ac-dcd-dub
@@ -1,1 +1,0 @@
-(ac-dcd-dub :repo "atilaneves/ac-dcd-dub" :fetcher github)


### PR DESCRIPTION
Deleted ac-dcd-dub from recipes. Package no longer needed, functionality in ac-dcd
