### PR TITLE
add chumpy-windows

### DIFF
--- a/recipes/chumpy-windows
+++ b/recipes/chumpy-windows
@@ -1,0 +1,2 @@
+(chumpy-windows :fetcher github :repo "chumpage/chumpy-windows"
+                  :files ("*.el"))


### PR DESCRIPTION
Add chumpy-windows, an alternative to the deprecated window-jump package.
