### PR TITLE
Add color-theme-darkmine recipe

### DIFF
--- a/recipes/color-theme-darkmine
+++ b/recipes/color-theme-darkmine
@@ -1,0 +1,4 @@
+(color-theme-darkmine
+ :repo "pierre-lecocq/color-theme-darkmine"
+ :fetcher github)
+


### PR DESCRIPTION
Hello,

Here is a recipe for the color-theme-darkmine github repo.
This is a simple dark theme for emacs.
Url: https://github.com/pierre-lecocq/color-theme-darkmine

Thank you.
