### PR TITLE
Add recipe for nu-mode

### DIFF
--- a/recipes/nu-mode
+++ b/recipes/nu-mode
@@ -1,4 +1,4 @@
 (nu-mode
  :fetcher github
  :repo "pyluyten/emacs-nu"
- :files ("nu-mode/*.el" "doc/nu-mode.texi" "doc/nu-mode.info"))
+ :files ("nu-mode/*.el" "doc/nu-mode.info"))


### PR DESCRIPTION
Modern keybinding for Emacs, altogether with a prompt mechanism.

URL is https://github.com/pyluyten/emacs-nu/nu-mode
I am the maintainer.
Package does build & install into sandboxed Emacs. I will fix compilation warnings.
