### PR TITLE
distribute packed-git as a separate package

### DIFF
--- a/recipes/packed
+++ b/recipes/packed
@@ -1,1 +1,1 @@
-(packed :repo "tarsius/packed" :fetcher github)
+(packed :repo "tarsius/packed" :fetcher github :files ("packed.el"))

--- a/recipes/packed-git
+++ b/recipes/packed-git
@@ -1,0 +1,1 @@
+(packed-git :repo "tarsius/packed" :fetcher github :files ("packed-git.el"))


### PR DESCRIPTION
This is preferable because someone who just wants `packed.el` (most
likely as a dependency of `auto-compile`) should not have to install
`magit` which is required by `packed-git.el`.
