### PR TITLE
jape-mode recipe

### DIFF
--- a/recipes/jape-mode
+++ b/recipes/jape-mode
@@ -1,0 +1,1 @@
+(jape-mode :repo "tanzoniteblack/jape-mode" :fetcher github)


### PR DESCRIPTION
The original major mode for JAPE files doesn't appear to have been
updated since 2005 is very feature incomplete. The original version was
also GPL licensed, but I can't find a copy of it online anymore. This is
an update to that original jape-mode that is more modern and under
active development.
