### PR TITLE
Added emacs backup files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /download_log.json.gz
 /.ecukes-failing-scenarios
 /sandbox
+*~


### PR DESCRIPTION
I've added `*~` to .gitignore so that we don't have to see emacs backup files in git listings.
