### PR TITLE
Add recipe for pinboard-list.el

### DIFF
--- a/recipes/pinboard-list
+++ b/recipes/pinboard-list
@@ -1,4 +1,3 @@
 (pinboard-list
  :fetcher github
- :repo "joddie/pinboard-list.el"
- :files ("pinboard-list.el"))
+ :repo "joddie/pinboard-list.el")


### PR DESCRIPTION
Hi,
This PR adds a MELPA recipe for an Emacs Pinboard.in client I have been working on. It depends on the existing `pinboard-api` package already in MELPA.
Tested and seems to install fine on OS X, Emacs 24.4 pre-release.
