### PR TITLE
Add recipe for cd-compile

### DIFF
--- a/recipes/cd-compile
+++ b/recipes/cd-compile
@@ -1,0 +1,1 @@
+(cd-compile :repo "jamienicol/emacs-cd-compile" :fetcher github)


### PR DESCRIPTION
Add a recipe for the package cd-compile - https://github.com/jamienicol/emacs-cd-compile

cd-compile is a simple wrapper around the compile command which runs compile from a specific directory. It either chooses the directory from the value of a variable, or prompts the user to select one.

I am the author/maintainer.
