### PR TITLE
Add recipes/sly

### DIFF
--- a/recipes/sly
+++ b/recipes/sly
@@ -1,0 +1,12 @@
+(sly :repo "capitaomorte/sly"
+     :fetcher github
+     :files ("*.el"
+             ("lib" "lib/*.el")
+             ("lib/lisp" "lib/lisp/*.lisp")
+             ("lib/lisp/backend" "lib/lisp/backend/*.lisp")
+             "*.lisp"
+             "slynk.asd"
+             ("contrib" "contrib/*" (:exclude "contrib/test"))
+             "doc/*.texi"
+             "doc/*.info"
+             "doc/dir"))


### PR DESCRIPTION
SLY is a fork of SLIME. SLY lives at https://github.com/capitaomorte/sly, SLIME lives at https://github.com/slime/slime.

A user asked me to support MELPA, see issue https://github.com/capitaomorte/sly/issues/12

Here's what I did testing-wise in emacs 24.3.1 

```
$ make recipes/sly
$ emacs -Q -f package-initialize --eval "(package-install-file \"$PWD/packages/sly-20140911.132.tar\")"
M-x sly   ;; you need to have a `lisp` executable, otherwise try C-u M-x sly
```
