### PR TITLE
Add ansible-doc

### DIFF
--- a/recipes/ansible-doc
+++ b/recipes/ansible-doc
@@ -1,0 +1,1 @@
+(ansible-doc :repo "lunaryorn/ansible-doc.el" :fetcher github)


### PR DESCRIPTION
Provides documentation lookup for Ansible modules in YAML Mode, see
https://github.com/lunaryorn/ansible-doc.el
