### PR TITLE
update lorem-ipsum recipe

### DIFF
--- a/recipes/lorem-ipsum
+++ b/recipes/lorem-ipsum
@@ -1,1 +1,2 @@
-(lorem-ipsum :fetcher wiki)
+(lorem-ipsum :fetcher github
+             :repo "jschaf/emacs-lorem-ipsum")


### PR DESCRIPTION
Inserts latin dummy text into a buffer.  The original was hosted at Emacswiki hasn't been updated since 2003.  I attempted to contact the author, but the email address didn't work.

Rehosted at https://github.com/jschaf/emacs-lorem-ipsum

Testing says that the package lacks a version header, but it's clearly in the file.  
