### PR TITLE
Adding a pip requirements recipe.

### DIFF
--- a/recipes/pip-requirements
+++ b/recipes/pip-requirements
@@ -1,0 +1,1 @@
+(pip-requirements :repo "Wilfred/pip-requirements.el" :fetcher github)


### PR DESCRIPTION
This is a simple major mode that adds highlighting to pip requirements file (pip is a package manager for Python code).

I'm the maintainer, it's a quick evening hack so do let me know if I've missed anything obvious.
