### PR TITLE
Add a recipe for auto-complete-sage.

### DIFF
--- a/recipes/auto-complete-sage
+++ b/recipes/auto-complete-sage
@@ -1,0 +1,1 @@
+(auto-complete-sage :fetcher github :repo "stakemori/auto-complete-sage")


### PR DESCRIPTION
[auto-complete-sage](https://github.com/stakemori/auto-complete-sage) provides an [auto-complete](https://github.com/auto-complete/auto-complete) source for [sage-shell-mode](https://github.com/stakemori/sage-shell-mode).
I am the author and the maintainer of [auto-complete-sage](https://github.com/stakemori/auto-complete-sage).

Please merge this pull request.
