### PR TITLE
Add slovak-holidays

### DIFF
--- a/recipes/slovak-holidays
+++ b/recipes/slovak-holidays
@@ -1,0 +1,1 @@
+(slovak-holidays :fetcher github :repo "Fuco1/slovak-holidays")


### PR DESCRIPTION
A simple package listing Slovak national holidays.  Loading this will add them to Emacs calendar and org-diary if that is enabled.
