### PR TITLE
Move repository of pabbrev.

### DIFF
--- a/recipes/pabbrev
+++ b/recipes/pabbrev
@@ -1,4 +1,2 @@
 (pabbrev
- :fetcher hg
- :url "https://code.google.com/p/phillord-emacs-packages/"
- :files ("pabbrev.el"))
+ :fetcher github :repo "phillord/pabbrev")


### PR DESCRIPTION
The repository of pabbrev has been moved (actually, it was moved a while back!). It is single file now and tagged, so it would be good to be in stable.

I am the package author and maintainer.
