### PR TITLE
Add recipe for iss-mode

### DIFF
--- a/recipes/iss-mode
+++ b/recipes/iss-mode
@@ -1,0 +1,3 @@
+(iss-mode
+ :repo "rasmus-toftdahl-olesen/iss-mode"
+ :fetcher github)


### PR DESCRIPTION
iss-mode is a major mode for editing InnoSetup installation script files (http://www.jrsoftware.org/isinfo.php) - InnoSetup is a tool for generating windows installer packages (setup.exe).

I am not the original author, the original author is Stefan (http://www.xsteve.at/prg/emacs/iss-mode.el), all i did was import his iss-mode.el in a github repo on my account.

I have not contacted Stefan.
