### PR TITLE
Delete company-path

### DIFF
--- a/recipes/company-path
+++ b/recipes/company-path
@@ -1,1 +1,0 @@
-(company-path :fetcher github :repo "bolasblack/company-path")


### PR DESCRIPTION
This reverts commit ee0b8da950a874b3cc86177d1c9157753d750ba6.

Sorry for my mistake, I didn't find company has an `company-files`
backend, it is greater than my plugin, so I want to delete
`company-path` to avoid users use it.
