### PR TITLE
added search-highlight-persist-mode

### DIFF
--- a/recipes/search-highlight-persist-mode
+++ b/recipes/search-highlight-persist-mode
@@ -1,0 +1,3 @@
+(search-highlight-persist-mode
+  :fetcher github
+  :repo "juanjux/search-highlight-persist-mode")


### PR DESCRIPTION
This extension will make isearch and evil-ex-search-incremental (the "slash search") to highlight the search term (taken as a regexp) in all the buffer and persistently until you make another search or clear the highlights with the search-highlight-persist-remove-all command (default binding to C-x SPC). This is how Vim search works by default when you enable hlsearch.
