### PR TITLE
Add swank folder to SLIME's recipe

### DIFF
--- a/recipes/slime
+++ b/recipes/slime
@@ -2,6 +2,7 @@
        :fetcher github
        :files ("*.el"
                ("lib" "lib/hyperspec.el")
+               ("swank" "swank/*")
                "*.lisp"
                "*.asd"
                ("contrib" "contrib/*" (:exclude "contrib/test"))


### PR DESCRIPTION
All the backend files were moved to swank folder see [75735eb](https://github.com/slime/slime/commit/75735)
