### PR TITLE
Add pretty-sha-path

### DIFF
--- a/recipes/pretty-sha-path
+++ b/recipes/pretty-sha-path
@@ -1,0 +1,1 @@
+(pretty-sha-path :fetcher github :repo "alezost/pretty-sha-path.el")


### PR DESCRIPTION
pretty-sha-path provides minor-mode for prettifying Guix / Nix store paths by replacing SHA-sequences with ellipsis, i.e.:

```
/gnu/store/onecansee32lettersandnumbershere-foo-0.1  →  /gnu/store/…-foo-0.1
/nix/store/someother32lettersandnumbershere-bar-0.2  →  /nix/store/…-bar-0.2
```
