### PR TITLE
A helm source for emacs filesets.

### DIFF
--- a/recipes/helm-filesets
+++ b/recipes/helm-filesets
@@ -1,0 +1,2 @@
+(helm-filesets :repo "gcla/helm-filesets"
+	       :fetcher github)


### PR DESCRIPTION
Hi - this package provides a function to construct a helm source from an emacs fileset. A fileset is an emacs feature for making a grouping of files, based on a list or directory tree, and upon which common operations can be executed, such as shell commands, dired, etc. Filesets are described here in the emacs manual: http://www.gnu.org/software/emacs/manual/html_node/emacs/Filesets.html

The package repository can be found here: https://github.com/gcla/helm-filesets

I have no association with helm except that I use it frequently and spend a lot of time in emacs. While working on small projects, I found I wanted a way to provide candidates from a specific list of directories e.g. javascript files in /usr/share/gnome-shell/js/. Helm provides a source for the emacs filecache, but that cache has to be manually updated if the contents of the directory of interest change. So this package provides a helm source for emacs filesets, which logically capture all files in a directory (if desired), rather than just a snapshot of the contents at one point in time.

I first tried to submit this to helm itself, but the maintainer doesn't want the feature built in directly because my package itself depends on an ELPA package (I think that's his reason)

Graham
