### PR TITLE
add node-resolver-mode recipe

### DIFF
--- a/recipes/node-resolver-mode
+++ b/recipes/node-resolver-mode
@@ -1,0 +1,1 @@
+(node-resolver-mode :fetcher github :repo "meandavejustice/node-resolver-mode.el")


### PR DESCRIPTION
This package allows you to start a process using [node-resolver](https://github.com/meandavejustice/node-resolver) in the root directory of the file you are working on. This process checks for `require('...')` statements in your nodejs programs and will install node_modules in the background for you.

The source for the package can be found at [https://github.com/meandavejustice/node-resolver-mode.el](https://github.com/meandavejustice/node-resolver-mode.el).

I am the author/maintainer of this package.
