### PR TITLE
Add magma-mode

### DIFF
--- a/recipes/magma-mode
+++ b/recipes/magma-mode
@@ -1,0 +1,8 @@
+(magma-mode
+ :fetcher github
+ :repo "ThibautVerron/magma-mode"
+ :files ("magma-mode.el" "magma-completion.el" "magma-font-lock.el"
+         "magma-smie.el" "magma-interactive.el" "magma-scan.el"
+         "magma-snippets.el"
+         "snippets"
+         ("bin" "bin/build_completion_table.sh")))


### PR DESCRIPTION
Hey,

This adds a recipe for `magma-mode`, a mode to edit [Magma](http://magma.maths.usyd.edu.au/magma/) source code.

The repository can be found here: https://github.com/ThibautVerron/magma-mode
I am the current maintainer for the package.

Thanks!
