### PR TITLE
Update buffer-move location, now on github

### DIFF
--- a/recipes/buffer-move
+++ b/recipes/buffer-move
@@ -1,3 +1,3 @@
 (buffer-move
-:fetcher github
-:repo "lukhas/buffer-move")
+ :fetcher github
+ :repo "lukhas/buffer-move")


### PR DESCRIPTION
Hello,

buffer-move is now available on github.
