### PR TITLE
Add osx-clipboard recipe

### DIFF
--- a/recipes/osx-clipboard
+++ b/recipes/osx-clipboard
@@ -1,0 +1,1 @@
+(osx-clipboard :fetcher github :repo "joddie/osx-clipboard-mode")


### PR DESCRIPTION
This adds a recipe for a tiny minor-mode I wrote to enable copying and pasting using the Mac OS X clipboard in a text-terminal Emacs.

The mode itself compiles and works on Emacs 23.4 and 24.3 on my machine, and I believe the MELPA recipe works as well.
