### PR TITLE
New package: font-lock-studio

### DIFF
--- a/recipes/font-lock-studio
+++ b/recipes/font-lock-studio
@@ -1,0 +1,1 @@
+(font-lock-studio :repo "Lindydancer/font-lock-studio" :fetcher github)

--- a/recipes/old-emacs-support
+++ b/recipes/old-emacs-support
@@ -1,0 +1,1 @@
+(old-emacs-support :repo "Lindydancer/old-emacs-support" :fetcher github)


### PR DESCRIPTION
Hi!

I just added "font-lock-studio", an interactive debugger for font-lock keywords. I am the author of the package. The package repository is located at https://github.com/Lindydancer/font-lock-studio.

In addition, I have included the backward compatibility package "old-emacs-support". It is used by font-lock-studio, and by a number of other package I will send pull request for in the next couple of days. I am the author of this package (although some functions are taken directly from a modern Emacs version). Package repository https://github.com/Lindydancer/old-emacs-support

Sincerely,
    Anders Lindgren
