### PR TITLE
New recipe: cryptsy-public-api

### DIFF
--- a/recipes/cryptsy-public-api
+++ b/recipes/cryptsy-public-api
@@ -1,3 +1,2 @@
 (cryptsy-public-api :repo "sodaware/cryptsy-public-api.el"
-                    :fetcher github
-                    :files ("*.el" (:exclude "features" "fixtures" "test")))
+                    :fetcher github)


### PR DESCRIPTION
Adds library functionality for interacting with the cryptsy.com public API.
