### PR TITLE
New recipe: sourcegraph

### DIFF
--- a/recipes/sourcegraph
+++ b/recipes/sourcegraph
@@ -1,0 +1,1 @@
+(sourcegraph :fetcher github :repo "sourcegraph/emacs-sourcegraph-mode")


### PR DESCRIPTION
Hi, I'm a maintainer of the "sourcegraph" package, and I would love for it to be included in melpa.

"sourcegraph" provides the commands:
- "sourcegraph-search-site" for searching for code on sourcegraph.com
- "sourcegraph-describe" to look up documentation and type information for an identifier
- "sourcegraph-describe-show-examples" to get usage examples for an identifier from sourcegraph.com

Url: github.com/sourcegraph/emacs-sourcegraph-mode

Let me know if I missed anything!
