### PR TITLE
Change the location of the groovy-mode repository on GitHub.

### DIFF
--- a/recipes/groovy-mode
+++ b/recipes/groovy-mode
@@ -1,1 +1,1 @@
-(groovy-mode :fetcher github :repo "russel/Emacs-Groovy-Mode")
+(groovy-mode :fetcher github :repo "Groovy-Emacs-Modes/groovy-emacs-modes")


### PR DESCRIPTION
I have created an organization for the Groovy modes and so a change in repository is appropriate. I am the original maintainer and am a member of the new organization. I have run this change through the tests and it appears to be fine.
