### PR TITLE
Add autodisass-java-bytecode

### DIFF
--- a/recipes/autodisass-java-bytecode
+++ b/recipes/autodisass-java-bytecode
@@ -1,0 +1,1 @@
+(autodisass-java-bytecode :fetcher github :repo "gbalats/autodisass-java-bytecode")


### PR DESCRIPTION
Adding recipe for a utility that automatically dissassembles Java bytecode (plain classfiles + classfiles inside jars) by using javap.
