### PR TITLE
Add auto-highlight-symbol recipe

### DIFF
--- a/recipes/auto-highlight-symbol
+++ b/recipes/auto-highlight-symbol
@@ -1,0 +1,2 @@
+(auto-highlight-symbol :repo "gennad/auto-highlight-symbol" :fetcher github)
+


### PR DESCRIPTION
Hi Steve,

This PR adds a recipe for [auto-highlight-symbol](https://github.com/gennad/auto-highlight-symbol/blob/master/auto-highlight-symbol.el).
I do it on behalf of the repository owner because I have no news from him since the opening of this issue gennad/auto-highlight-symbol#1 and it is a missing dependency for [EDTS](https://github.com/tjarvstrand/edts) (see tjarvstrand/edts#147 and [MELPA EDTS package page](http://melpa.milkbox.net/#/edts)).

Cheers,
syl20bnr
