### PR TITLE
New recipe: purescript-mode

### DIFF
--- a/recipes/purescript-mode
+++ b/recipes/purescript-mode
@@ -1,0 +1,8 @@
+(purescript-mode
+ :repo "dysinger/purescript-mode"
+ :fetcher github
+ :files ("*.el"
+         "purescript-mode.texi"
+         "NEWS"
+         "snippets"
+         "logo.svg"))


### PR DESCRIPTION
PureScript mode package for Emacs
https://github.com/dysinger/purescript-mode

I am not the maintainer.
(@dysinger owns the repository used in this recipe)

The recipe is duplicated and adapted from haskell-mode.

The recipe builds ok and the installation is ok.
