### PR TITLE
Update recipe from marmalade-upload to marmalade-client

### DIFF
--- a/recipes/marmalade-client
+++ b/recipes/marmalade-client
@@ -1,0 +1,1 @@
+(marmalade-client :fetcher github :repo "nicferrier/emacs-marmalade-upload")

--- a/recipes/marmalade-upload
+++ b/recipes/marmalade-upload
@@ -1,1 +1,0 @@
-(marmalade-upload :fetcher github :repo "nicferrier/emacs-marmalade-upload")


### PR DESCRIPTION
"upload packages to marmalade and do other things with it, from inside
Emacs." - https://github.com/nicferrier/emacs-marmalade-upload

context: marmalade-upload has been renamed to marmalade-client

I am not the maintainer.

make recipes/marmalade-client ok.

M-x package-install-file ok.

Note:
I do not know if it's a good idea to remove marmalade-upload (it's what
I did in this PR) or to have both marmalade-upload (old one) and
marmalade-client (new one) side by side.
Please, let me know what you think.
