### PR TITLE
rainbow-delimiters moved to a new location, point to the new one.

### DIFF
--- a/recipes/rainbow-delimiters
+++ b/recipes/rainbow-delimiters
@@ -1,2 +1,2 @@
-(rainbow-delimiters :fetcher github :repo "jlr/rainbow-delimiters")
+(rainbow-delimiters :fetcher github :repo "Fanael/rainbow-delimiters")
 


### PR DESCRIPTION
As discussed in https://github.com/jlr/rainbow-delimiters/pull/47#issuecomment-60515310.
