### PR TITLE
Adding a recipe for el2markdown.

### DIFF
--- a/recipes/el2markdown
+++ b/recipes/el2markdown
@@ -1,0 +1,1 @@
+(el2markdown :repo "Lindydancer/el2markdown" :fetcher github)


### PR DESCRIPTION
There are other packages to convert elisp headers to markdown, I'm aware of:
- https://github.com/mgalgs/make-readme-markdown
- https://github.com/thomas11/md-readme

I prefer this one, as it handles `;;; Foo:` (treating it as a header) and Emacs style ``foo'` quoting correctly.

I see that md-readme is already present on MELPA, does this conflict with MELPA's principle of being a curated collection of packages?
