### PR TITLE
Don't include recipes in el-get package

### DIFF
--- a/recipes/el-get
+++ b/recipes/el-get
@@ -1,1 +1,1 @@
-(el-get :fetcher github :repo "dimitri/el-get" :files ("*.el" "*.info" "recipes" "methods"))
+(el-get :fetcher github :repo "dimitri/el-get" :files ("*.el" ("recipes" "recipes/el-get.rcp") "methods"))


### PR DESCRIPTION
The el-get installer works by bootstrapping from melpa installed code so
only the el-get recipe is needed. Because Emacs insists on listing every
single file when extracting from a tar file, including the recipes makes
the initial install quite a bit slower.

see dimitri/el-get#1975
