### PR TITLE
Added org-wc for counting words in org files

### DIFF
--- a/recipes/org-wc
+++ b/recipes/org-wc
@@ -1,0 +1,1 @@
+(org-wc :fetcher github :repo "dato/org-wc")


### PR DESCRIPTION
The [org-wc package](https://github.com/dato/org-wc) counts words in org files, ignoring org structure and only counting the "content".  I asked the maintainer if it could be put and MELPA and he agreed (see https://github.com/dato/org-wc/issues/3).  Package creation and installation works on my machine.

Thanks!
