### PR TITLE
Add recipe for tramp-term

### DIFF
--- a/recipes/tramp-term
+++ b/recipes/tramp-term
@@ -1,0 +1,1 @@
+(tramp-term :fetcher github :repo "randymorris/tramp-term.el")


### PR DESCRIPTION
This is a new package I've created to support my own workflow when working with remote files.  It automates the setup of directory tracking on remote servers so it is easier to open them via TRAMP.  The package can be found here: https://github.com/randymorris/tramp-term.el.  More info on the general idea can be found here: http://www.emacswiki.org/emacs-se/AnsiTermHints#toc5, this package is more or less just wrapping this in a package for convenience.

I have tested this file with `make recipies/tramp-term` and installed with `package-install-file` and as far as I can tell everything is in order.  This is my first published package but it's quite simple so I believe everything is set up correctly.
