### PR TITLE
Add a recipe for helm-ghc

### DIFF
--- a/recipes/helm-ghc
+++ b/recipes/helm-ghc
@@ -1,0 +1,3 @@
+(helm-ghc
+ :fetcher github
+ :repo "david-christiansen/helm-ghc")


### PR DESCRIPTION
This is a Helm datasource for ghc-mod error messages. I hope to include more ghc-mod capabilities in the future.

ghc-mod is a Haskell development environment that uses the compiler API for GHC (the main Haskell compiler) to provide a rich experience in Emacs.

Repository: https://github.com/david-christiansen/helm-ghc
