### PR TITLE
Add scala-outline-popup recipe

### DIFF
--- a/recipes/scala-outline-popup
+++ b/recipes/scala-outline-popup
@@ -1,0 +1,3 @@
+(scala-outline-popup
+ :repo "ancane/scala-outline-popup"
+ :fetcher github)


### PR DESCRIPTION
Hi, I'm a maintainer of [scala-outline-popup](https://github.com/ancane/scala-outline-popup).
`scala-outline-popup` is an addition to `scala-mode2`, which pops up a `.scala` file summary view.
