### PR TITLE
Add orgtbl-aggregate recipe

### DIFF
--- a/recipes/orgtbl-aggregate
+++ b/recipes/orgtbl-aggregate
@@ -1,0 +1,3 @@
+(orgtbl-aggregate
+  :fetcher github
+  :repo "tbanel/orgaggregate")


### PR DESCRIPTION
I would like to submit the orgtbl-aggregate package to Melpa
- orgtbl-aggregate builds aggregated tables out of Org Mode tables.
  It is somewhat similar to the "group by" feature of the SQL language.
- home page and full documentation here: https://github.com/tbanel/orgaggregate
- I am the author and maintainer.

This is my second contribution to MELPA (after orgtbl-ascii-plot).

Maybe you could give me some advice about dependencies.
On one hand, a line like this in the *.el could be useful.
   ;; Package-Requires: ((org "7"))
On the other hand, people often already have Org Mode installed
from a source other than Melpa. With such a dependency, they end-up
with two different installations of Org Mode.
What is the best practice for packages based on Org Mode?

Regards
Thierry Banel
tbanelwebmin@free.fr
