### PR TITLE
Added 'contrib' directory to ycmd recipe.

### DIFF
--- a/recipes/ycmd
+++ b/recipes/ycmd
@@ -1,3 +1,3 @@
 (ycmd :fetcher github
       :repo "abingham/emacs-ycmd"
-      :files ("ycmd.el" "third-party/*.el"))
+      :files ("ycmd.el" "third-party/*.el" "contrib/*.el"))


### PR DESCRIPTION
We're using a `contrib` directory for optional features provided by other people.
