### PR TITLE
Add multicolumn

### DIFF
--- a/recipes/multicolumn
+++ b/recipes/multicolumn
@@ -1,0 +1,1 @@
+(multicolumn :repo "Lindydancer/multicolumn" :fetcher github)


### PR DESCRIPTION
This package help you to set up and manage multiple side-by-side windows.

The setup system and can resize, position, and split a frame so that it can host a suitable number of side-by-side windows. The other functions lets you jump to the first/last/next/prev etc.

The package also provides a global minor mode that binds suitable keys.

Some 20 years ago, I wrote Follow mode, a package that treats side-by-side windows (showing the same buffer) as one tall virtual window. Follow mode provides a function to enable itself, delete the other windows and the split the current window into two. Multicolumn takes this one step further as it can split the frame into any number of windows. Concretely, I use two monitors and six side-by-side windows -- using this setup I can see 888 consecutive lines.

Sincerely,
    Anders Lindgren
