### PR TITLE
remove recipe for obsolete header-button

### DIFF
--- a/recipes/header-button
+++ b/recipes/header-button
@@ -1,1 +1,0 @@
-(header-button :repo "emacsattic/header-button" :fetcher github)


### PR DESCRIPTION
Equivalent functionality was added to Emacs in [1] and was released with
version 24.4.  The author of `header-button` (me) has deprecated [2] it
ten months ago.  It was only downloaded 87 times and no other package
depends on it [3].

[1] http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=24fc9480399b2d018e8d85f34e9c5d8c327ce3bf
[2] https://github.com/emacsattic/header-button/commit/2dcffd59f79fbdf9940a93075e37d919eff50d19
[3] http://melpa.org/#/header-button

---

But if you want to keep it around a little longer, that's fine with me too.
