### PR TITLE
remove recipe for obsolete object-registry

### DIFF
--- a/recipes/object-registry
+++ b/recipes/object-registry
@@ -1,1 +1,0 @@
-(object-registry :repo "emacsattic/object-registry" :fetcher github)


### PR DESCRIPTION
The author of `object-registry` (me) has deprecated [1] it half a
year ago.  It likely is broken on Emacs 24.4, due to incompatible
changes to `eieio`.  It was only downloaded 58 times and no other
package depends on it [2].

[1] https://github.com/emacsattic/object-registry/commit/1f2185f5e6b629f59542f2e093eaf97edde8a1e3
[2] http://melpa.org/#/object-registry
