### PR TITLE
Adding a recipe for llvm-mode.

### DIFF
--- a/recipes/llvm-mode
+++ b/recipes/llvm-mode
@@ -1,0 +1,4 @@
+(llvm-mode
+ :url "http://llvm.org/git/llvm"
+ :files ("utils/emails/llvm-mode.el")
+ :fetcher git)


### PR DESCRIPTION
llvm-mode provides syntax highlighting to .ll files, with are LLVM IR files. I'm not a maintainer, this is just me adding the official upstream git repo.

I'm pretty sure that this recipe is correct, but MELPA does a full clone rather than a shallow clone and it's very slow for LLVM's large git repo. I don't see any reason why MELPA couldn't do a shallow clone, the patch is straightforward as far as I can see:

```
(pb/run-process nil "git" "clone" repo dir "--depth" "1")
```

Let me know if I've missed anything.
