### PR TITLE
Add go-stacktracer

### DIFF
--- a/recipes/go-stacktracer
+++ b/recipes/go-stacktracer
@@ -1,0 +1,1 @@
+(go-stacktracer :fetcher github :repo "samertm/go-stacktracer.el")


### PR DESCRIPTION
go-stacktracer takes a Go stacktrace and formats it in a grep-mode buffer to facilitate jumping between the functions in the stacktrace.

Link: https://github.com/samertm/go-stacktracer.el

I am the maintainer.
