### PR TITLE
Add a recipe for ghc-imported-from

### DIFF
--- a/recipes/ghc-imported-from
+++ b/recipes/ghc-imported-from
@@ -1,0 +1,3 @@
+(ghc-imported-from
+ :fetcher github
+ :repo "david-christiansen/ghc-imported-from-el")


### PR DESCRIPTION
This package provides an Emacs command for running and processing the
output of ghc-imported-from, which is a command-line app for determining
the Haddock documentation page for a symbol in a Haskell program.

The package repository is at
https://github.com/david-christiansen/ghc-imported-from-el

I am the author and maintainer of the package.
