### PR TITLE
Add recipe for github/Bogdanp/py-test.el

### DIFF
--- a/recipes/py-test
+++ b/recipes/py-test
@@ -1,0 +1,1 @@
+(py-test :repo "Bogdanp/py-test.el" :fetcher github :files ("py-test.el"))


### PR DESCRIPTION
I am the maintainer of this package. You can find it at https://github.com/Bogdanp/py-test.el .

From its description:

```
py-test gives you the ability to define testing projects and, based
on those projects, run a single test that's defined in the current
buffer, all of the tests that you have defined in the current
buffer, or all of the tests that you have defined in the current
buffers's parent directory.
```

I've had to explicitly state which files are part of the package since files matching `*-test.el` are excluded by default.
