### PR TITLE
Add lit-mode recipe.

### DIFF
--- a/recipes/lit-mode
+++ b/recipes/lit-mode
@@ -1,0 +1,1 @@
+(lit-mode :fetcher github :repo "HectorAE/lit-mode" :files ("*.el"))


### PR DESCRIPTION
This is a [new major mode](https://github.com/HectorAE/lit-mode) used for editing [`lit`](https://github.com/cdosborn/lit) template/macro files. `lit` is a literate programming tool, similar to noweb, written in Haskell. Its syntax is different, however, so I made a basic syntax highlighting mode that should work with polymode.

I am the original author and maintainer. I tested the recipe and installation and it works fine. Thank you for reviewing this. By the way, thank you for your continued work on MELPA; it's fantastic and I use it all the time.
