### PR TITLE
New recipe: artbollocks-mode

### DIFF
--- a/recipes/artbollocks-mode
+++ b/recipes/artbollocks-mode
@@ -1,0 +1,2 @@
+(artbollocks-mode :repo "sachac/artbollocks-mode"
+                  :fetcher github)


### PR DESCRIPTION
# Art Bollocks Mode

This minor mode monitors your writing and highlights words or patterns
you may want to reconsider. It can detect repeated words which sometimes
slip past proof-reading. It has a list of common passive verbs, making
it easier for you to rewrite the sentences to use the active voice. It
detects weasel words like “many” and “surprisingly”. It even comes with
jargon catchers for art critics (“postmodern”, “ironic”, and so forth) –
hence artbollocks-mode.el.
## For More Details

http://sachachua.com/blog/2011/12/emacs-artbollocks-mode-el-and-writing-more-clearly/
# Link to the repository

https://github.com/sachac/artbollocks-mode
# My association with the package

I just like it a lot. I opened an issue to the maintainer, she said she would accept a pull request, here I
come.
- sachac/artbollocks-mode#10
