### PR TITLE
Remove recipe for deprecated clojure-test-mode

### DIFF
--- a/recipes/clojure-test-mode
+++ b/recipes/clojure-test-mode
@@ -1,2 +1,0 @@
-(clojure-test-mode :repo "clojure-emacs/clojure-mode" :fetcher github :files
-                   ("clojure-test-mode.el"))


### PR DESCRIPTION
The package has been deprecated & broken for a while. Let's make its demise official.
