### PR TITLE
add orgit recipe

### DIFF
--- a/recipes/orgit
+++ b/recipes/orgit
@@ -1,0 +1,1 @@
+(orgit :fetcher github :repo "magit/orgit")


### PR DESCRIPTION
`orgit` defines three Org-mode link types which link to various Magit buffer types. It is intended to replace `org-magit` which also allows linking to the same buffers, but uses a single link type to do so. Using just one link type is wrong, in my opinion, which is why I created `orgit`. But `org-magit` cannot be deprecated just yet because no converter exists.
