### PR TITLE
Change ox-reveal to use the stable branch

### DIFF
--- a/recipes/ox-reveal
+++ b/recipes/ox-reveal
@@ -1,2 +1,2 @@
 (ox-reveal :repo "yjwen/org-reveal" :fetcher github
-           :old-names (org-reveal))
+           :old-names (org-reveal) :branch "stable")


### PR DESCRIPTION
Change ox-reveal to fetch the stable branch, to be consistent with org-mode in ELPA.
