### PR TITLE
Add context-coloring recipe.

### DIFF
--- a/recipes/context-coloring
+++ b/recipes/context-coloring
@@ -1,5 +1,5 @@
 (context-coloring
  :fetcher github
  :repo "jacksonrayhamilton/context-coloring"
- :branch "master"
+ :branch "develop"
  :files ("*.el" "*.js" "bin" "lib"))


### PR DESCRIPTION
Provides a minor mode offering special "syntax highlighting" for JavaScript. Code is colored based on function scope, with variables retaining the same color as the scope in which they were defined. Inspired by Douglas Crockford's call for such a feature in a text editor, by [`rainbow-blocks-mode`](https://github.com/istib/rainbow-blocks), and by the [`vim plugin`](https://github.com/bigfish/vim-js-context-coloring).

https://github.com/jacksonrayhamilton/context-coloring

I am the maintainer of this package.

Note that this package requires Node.js to be installed in order to work properly. I didn't think that belonged in the `Package-Requires` section. I mention the requirement in the package description and display a message to the user if `node` is not installed. Hopefully that is sufficient.
