### PR TITLE
elixir-mix it's not maintained anymore, use alchemist instead

### DIFF
--- a/recipes/elixir-mix
+++ b/recipes/elixir-mix
@@ -1,1 +1,0 @@
-(elixir-mix :fetcher github :repo "tonini/elixir-mix.el")


### PR DESCRIPTION
Hi,

The `elixir-mix` package is now integrated in the [`alchemist`](https://github.com/tonini/alchemist.el) package and will not be maintained in the future.

Cheers
