### PR TITLE
parenface is being merged with paren-face

### DIFF
--- a/recipes/parenface
+++ b/recipes/parenface
@@ -1,1 +1,1 @@
-(parenface :fetcher github :repo "grettke/parenface" :files ("parenface*.el"))
+(parenface :fetcher github :repo "tarsius/paren-face" :files ("paren-face.el"))


### PR DESCRIPTION
Per this discussion

https://github.com/grettke/parenface/pull/8#issuecomment-64838006

parenface is being merged with paren-face. 

This is recipe change to refer to the new project instead of the old one.
