### PR TITLE
parenface is merging with paren-face

### DIFF
--- a/recipes/paren-face
+++ b/recipes/paren-face
@@ -1,1 +1,1 @@
-(paren-face :repo "tarsius/paren-face" :fetcher github)
+(paren-face :repo "tarsius/paren-face" :fetcher github :old-names (parenface))

--- a/recipes/parenface
+++ b/recipes/parenface
@@ -1,1 +1,0 @@
-(parenface :fetcher github :repo "grettke/parenface")


### PR DESCRIPTION
Old pull request was here https://github.com/milkypostman/melpa/pull/2221#issuecomment-64962777

Discussion about this merger is here https://github.com/grettke/parenface/pull/8#issuecomment-64838006

I didn't first check to see if paren-face already had a recipe, hence the first pull requests, my apologies.

Steve as you can see I deleted the parenface recipe because it is being replaced with paren-face. If this was in correct, then you will say so.
