### PR TITLE
Add shackle recipe

### DIFF
--- a/recipes/shackle
+++ b/recipes/shackle
@@ -1,0 +1,1 @@
+(shackle :fetcher github :repo "wasamasa/shackle")


### PR DESCRIPTION
[shackle](https://github.com/wasamasa/shackle) simplifies the customization of `display-buffer-alist` by introducing a global minor mode that allows you to specify how exactly to deal with buffers that match your criteria. For instance it allows you to refuse Emacs to split windows automatically, arrange the popup windows at a fixed location, etc. I'm its author and would like it to be included into MELPA and MELPA stable.
