### PR TITLE
Add recipe for cdb.el

### DIFF
--- a/recipes/cdb
+++ b/recipes/cdb
@@ -1,0 +1,5 @@
+(cdb
+ :url ":pserver:guest:guest@openlab.jp:/circus/cvsroot"
+ :module "skk/main"
+ :fetcher cvs
+ :files ("cdb.el"))


### PR DESCRIPTION
This package provides constant database (cdb) reader for Emacs Lisp. The code is part of package `skk`, which was recently registered to MELPA. Following the advice of belows comment, this is a pull request to register cdb as separate package.
https://github.com/milkypostman/melpa/pull/2116#issuecomment-60573294

Package repository.
http://openlab.ring.gr.jp/skk/cvs.html

I'm not a maintainer, just an user.
I already notified the maintainers that I'm making a pull requeset to regsiter cdb as a package.

I sent them a patch that formats cdb.el comment, so it can be reconigzed by package.el.
http://mail.ring.gr.jp/skk/201412/msg00003.html

I tested the pacakge, had no problem building and installing locally.

Best regards.
