### PR TITLE
Missing Cache-control header for badges

### DIFF
--- a/cfg/etc/nginx/sites-available/melpa
+++ b/cfg/etc/nginx/sites-available/melpa
@@ -68,6 +68,10 @@ server {
 	    proxy_busy_buffers_size    64k;
 	    proxy_temp_file_write_size 64k;
 	}
+
+	location /packages/*.svg {
+	    add_header Cache-Control no-cache;
+	}
 }
 
 

--- a/cfg/etc/nginx/sites-available/melpa-stable
+++ b/cfg/etc/nginx/sites-available/melpa-stable
@@ -66,6 +66,10 @@ server {
 	    proxy_busy_buffers_size    64k;
 	    proxy_temp_file_write_size 64k;
 	}
+
+	location /packages/*.svg {
+	    add_header Cache-Control no-cache;
+	}
 }
 
 


### PR DESCRIPTION
Hello,

Currently grabbing a badge over HTTP comes with headers like this:

```
HTTP/1.1 200 OK
Server: nginx/1.4.6 (Ubuntu)
Date: Mon, 01 Dec 2014 11:35:43 GMT
Content-Type: image/svg+xml
Content-Length: 835
Connection: keep-alive
Last-Modified: Mon, 01 Dec 2014 10:25:25 GMT
ETag: "547c4215-343"
Accept-Ranges: bytes
```

Due to GitHub's aggressive image caching, this means that the badges will never be updated. Well, maybe _infrequently_ rather than _never_. (E.g., as of this writing, the badges at https://github.com/slime/slime/blob/master/README.md still display 20141122.806 and 2.10.1, when the latest versions are 20141201.205 and 2.11, respectively.)

If I understand https://github.com/github/markup/issues/224 correctly, the MELPA server should be sending out `Cache-Control: no-cache`, in addition to the `ETag` header, which it's already sending.
