### PR TITLE
New recipe: wn-mode

### DIFF
--- a/recipes/wn-mode
+++ b/recipes/wn-mode
@@ -1,0 +1,1 @@
+(wn-mode :repo "luismbo/wn-mode" :fetcher github)


### PR DESCRIPTION
wn-mode is a global minor mode for quickly switching among visible windows, adapted from the one available at the EmacsWiki.
