### PR TITLE
Adding ein2 project

### DIFF
--- a/recipes/ein
+++ b/recipes/ein
@@ -1,2 +1,3 @@
-(ein :repo "tkf/emacs-ipython-notebook" :fetcher github
+(ein :repo "millejoh/emacs-ipython-notebook" :fetcher github
      :files ("lisp/*"))
+


### PR DESCRIPTION
A fork of tkf's ein project (https://github.com/tkf/emacs-ipython-notebook), which appears to have become abandonware. EIN2 aims to provide support for IPython notebook versions 2.0 and
beyond. Somewhat relevant discussion in tkf/emacs-ipython-notebook#155 and tkf/emacs-ipython-notebook#156.

Project page is https://github.com/millejoh/emacs-ipython-notebook and I
am the current maintainer of the project.
