### PR TITLE
Add org-projectile recipe

### DIFF
--- a/recipes/org-projectile
+++ b/recipes/org-projectile
@@ -1,0 +1,2 @@
+(org-projectile :repo "IvanMalison/org-projectile"
+		:fetcher github)


### PR DESCRIPTION
org-projectile provides a simple interface to manage org TODOs on a per projectile project basis. It offers a function to build a capture entry that can be added to org-capture templates that will insert TODOs for the current active project, as well as a function which will perform a completing read to select the project for which a TODO should be entered.
