### PR TITLE
added github fetcher for goto-chg

### DIFF
--- a/recipes/goto-chg
+++ b/recipes/goto-chg
@@ -1,1 +1,1 @@
-(goto-chg :fetcher wiki)
+(goto-chg :fetcher github :repo "joe9/goto-chg.el")


### PR DESCRIPTION
Added a github repo for goto-chg so it can be included to stable melpa
packages

A brief summary of what the package does: goes to the last edit or change
A direct link to the package repository: github repo: https://github.com/joe9/goto-chg.el
Your association with the package: I just like the package a lot. The evil package that I use heavily is dependent on goto-chg. Unavailability of goto-chg in a git repo is blocking evil from being hosted in the stable melpa.
Relevant communications with the upstream package maintainer: Just emailed the Package Author, Mr. David Andersson  <l.david.andersson at sverige.nu> about this.
Test that the package builds properly via make recipes/<recipe>, or pressing C-c C-c in the recipe buffer: Yes, it builds and works fine.
Test that the package installs properly via package-install-file, or entering "yes" when prompted after pressing C-c C-c in the recipe buffer: Yes, it installed properly.

If you are not the original author or maintainer of the package you are submitting, please consider notifying the author prior to submitting and make reasonable effort to include them in the pull request process.

Below is my email to the package author:

From: Joe M joe9mail@gmail.com
To: l.david.andersson@sverige.nu
Cc: 
Bcc: 
Subject: Re: goto-chg on github
Reply-To: 

Joe M wrote:

> Hello Mr. David Andersson,
> 
> Sorry for bothering you about this.
> 
> I use evil-mode of emacs quite a bit. It is dependent on goto-chg. As
> goto-chg is hosted only on emacswiki and not on some git repository,
> it is not being made available in the stable melpa.
> 
> Hence, I took the initiative in adding goto-chg to github.com 
> (https://github.com/joe9/goto-chg.el) and submitting an updated recipe
> to melpa (https://github.com/milkypostman/melpa/pull/2262).
> 
> Just wanted to bring this to your attention. If you plan to host
> goto-chg yourself, I can update the above melpa fetcher to your repo.
> 
> Any thoughts, please?
> 
> Thanks
> Joe

Thanks
