### PR TITLE
added org-dropbox

### DIFF
--- a/recipes/org-dropbox
+++ b/recipes/org-dropbox
@@ -1,0 +1,1 @@
+(org-dropbox :fetcher github :repo "heikkil/org-dropbox")


### PR DESCRIPTION
This minor mode syncs DropBox notes from mobile devices into org datetree file that can be part of org agenda. The minor mode starts a daemon that periodically scans the note directory.
