### PR TITLE
Add recipe for ubuntu-theme

### DIFF
--- a/recipes/ubuntu-theme
+++ b/recipes/ubuntu-theme
@@ -1,0 +1,1 @@
+(ubuntu-theme :fetcher github :repo "rocher/ubuntu-theme" :files ("ubuntu-theme.el"))


### PR DESCRIPTION
This is a new theme for Emacs 24 inspired by default color theme terminal in Ubuntu.
Repository can be found here: https://github.com/rocher/ubuntu-theme

(this is my first contribution to MELPA, hope all is correct!)
