### PR TITLE
Add recipe for `auto-package-update`

### DIFF
--- a/recipes/auto-package-update
+++ b/recipes/auto-package-update
@@ -1,0 +1,1 @@
+(auto-package-update :fetcher github :repo "rranelli/auto-package-update.el")


### PR DESCRIPTION
This package provides functionality for automatically updating
packages periodically. 

The main idea is that you can set a desired periodicity for the updates, and when
you start Emacs, the packages will be automatically updated if enough days 
(more than one period)  have passed since the last update.

The package is still pretty crude, and I will probably refine it a little bit more in the future.
