### PR TITLE
Add recipe for evil-snipe

### DIFF
--- a/recipes/evil-snipe
+++ b/recipes/evil-snipe
@@ -1,0 +1,1 @@
+(evil-snipe :repo "hlissner/evil-snipe" :fetcher github)


### PR DESCRIPTION
Evil-snipe brings the functionality of vim-sneak and vim-seek to evil-mode. It is a more streamlined alternative to ace-jump or isearch. Put simply, it's vim's f/F/t/T on steroids, and with N character search, but by default is set for 2-character searching. E.g. `shi` will jump to the next occurrence of 'hi'.

More about it's features here: https://github.com/hlissner/evil-snipe

This is my first emacs plugin, so any advice would be appreciated!
