### PR TITLE
Add a :defaults "macro" to the :files spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ to the root of the package.* More complex options are available,
 submit an [Issue](https://github.com/milkypostman/melpa/issues) if the
 specified package requires more complex file specification.
 
+    If the the package merely requires some additional files, for example for
+bundling external dependencies, but is otherwise fine with the defaults, it's
+recommended to use `:defaults` as the very first element of this list, which
+causes the default value shown above to be prepended to the specified file list.
+
 [git]: http://git-scm.com/
 [github]: https://github.com/
 [bzr]: http://bazaar.canonical.com/en/

--- a/package-build.el
+++ b/package-build.el
@@ -848,7 +848,14 @@ for ALLOW-EMPTY to prevent this error."
 
 (defun pb/config-file-list (config)
   "Get the :files spec from CONFIG, or return `package-build-default-files-spec'."
-  (or (plist-get config :files) package-build-default-files-spec))
+  (let ((file-list (plist-get config :files)))
+    (cond
+     ((null file-list)
+      package-build-default-files-spec)
+     ((eq :default (car file-list))
+      (append package-build-default-files-spec (cdr file-list)))
+     (t
+      file-list))))
 
 (defun pb/expand-source-file-list (dir config)
   "Shorthand way to expand paths in DIR for source files listed in CONFIG."


### PR DESCRIPTION
This allows users to add files to the default file list without overwriting it. For instance:

```
(example :fetcher example :url "http://example.com/"
         :files (:defaults "an.example"))
```

This would fetch Emacs Lisp (except tests) and Texinfo files, just like the defaults, but unlike the defaults, the file `an.example` would be included too.

`:defaults` is only recognized when it's the first element of `:files`.

Fixes #2275.
