### PR TITLE
Add recipe for sml-modeline

### DIFF
--- a/recipes/sml-modeline
+++ b/recipes/sml-modeline
@@ -1,0 +1,3 @@
+(sml-modeline :fetcher bzr
+              :url "lp:~nxhtml/nxhtml/main"
+              :files ("util/sml-modeline.el"))


### PR DESCRIPTION
sml-modeline is a nice minor mode that shows a diagram of the currently displayed buffer area relative to the total buffer size, like a small non-interactive scroll bar located in the modeline.

It's been written by Lennart Borgman as an independent utility within his [nXhtml](http://ourcomments.org/Emacs/nXhtml/doc/nxhtml.html) project.
