### PR TITLE
recipes/goto-last-change: update to pull from GitHub

### DIFF
--- a/recipes/goto-last-change
+++ b/recipes/goto-last-change
@@ -1,1 +1,1 @@
-(goto-last-change :fetcher wiki)
+(goto-last-change :repo "camdez/goto-last-change.el" :fetcher github)


### PR DESCRIPTION
Got permission from the author to host this on GitHub, allowing us to
tag for MELPA Stable:

> Date: Wed, 17 Dec 2014 09:26:03 -0700
> Subject: Re: goto-last-change.el
> From: Kevin Rodgers kevin.d.rodgers@gmail.com
> To: Cameron Desautels camdez@gmail.com
> 
> Hi Cameron,
> 
> Thanks for the info, I had no idea about such dependencies.  I'm
> pleased to hear that it is being used, but at the moment I don't have
> a working development machine so I can't handle the Git upload and
> tagging.  I'd really appreciate it if you would take care of that and
> host goto-last-change.el on MELPA.
