### PR TITLE
Remove stan-snippets and update stan-mode

### DIFF
--- a/recipes/stan-mode
+++ b/recipes/stan-mode
@@ -1,4 +1,5 @@
 (stan-mode
  :fetcher github
  :repo "stan-dev/stan-mode"
- :files ("stan-mode.el" "stan-keywords-lists.el" "ac-dict"))
+ :branch "master"
+ :files ("stan-mode.el" "stan-keywords-lists.el" "ac-dict" "snippets"))

--- a/recipes/stan-snippets
+++ b/recipes/stan-snippets
@@ -1,4 +1,0 @@
-(stan-snippets
- :fetcher github
- :repo "stan-dev/stan-mode"
- :files ("stan-snippets.el" "snippets"))


### PR DESCRIPTION
I'm the maintainer of both `stan-mode` and `stan-snippets`.  I recently incorporated the functionality of `stan-snippets` into `stan-mode`, so `stan-snippets` is no longer needed. This PR removes the `stan-snippets` recipe, and makes a minor change to `stan-mode` recipe to account for new files from the merge.
