### PR TITLE
* recipes/ddskk: Remove queue-m.el

### DIFF
--- a/recipes/ddskk
+++ b/recipes/ddskk
@@ -2,5 +2,5 @@
  :repo "skk-dev/ddskk"
  :fetcher github
  :old-names (skk)
- :files ("ccc.el" "context-skk.el" "queue-m.el" "skk*.el" "doc/skk.texi"
+ :files ("ccc.el" "context-skk.el" "skk*.el" "doc/skk.texi"
          (:exclude "skk-xemacs.el")))


### PR DESCRIPTION
DDSKK is no need to `queue-m.el`

See https://github.com/skk-dev/ddskk/commit/ddf6d167807af0a228b5ba5aca9cec2da063fbcb
