### PR TITLE
Add recipe for propfont-mixed.

### DIFF
--- a/recipes/propfont-mixed
+++ b/recipes/propfont-mixed
@@ -1,0 +1,3 @@
+(propfont-mixed
+ :fetcher github
+ :repo "ikirill/propfont-mixed")


### PR DESCRIPTION
It is a minor mode for using proportional-width fonts alongside fixed-width space-based indentation.
