### PR TITLE
Remove git submodules from anaconda-mode recipe.

### DIFF
--- a/recipes/anaconda-mode
+++ b/recipes/anaconda-mode
@@ -1,7 +1,4 @@
 (anaconda-mode
  :fetcher github
  :repo "proofit404/anaconda-mode"
- :files ("*.el"
-         "*.py"
-         "vendor/jedi/jedi"
-         ("jsonrpc" "vendor/jsonrpc/jsonrpc/*.py")))
+ :files ("*.el" "*.py"))


### PR DESCRIPTION
New anaconda-mode will install its dependencies in python subprocess.
