### PR TITLE
Add irony-eldoc.

### DIFF
--- a/recipes/irony-eldoc
+++ b/recipes/irony-eldoc
@@ -1,0 +1,1 @@
+(irony-eldoc :fetcher github :repo "ikirill/irony-eldoc")


### PR DESCRIPTION
It is a minor mode that enables eldoc-mode support (showing docstrings
in minibuffer) for C/C++/ObjC, based on irony-mode, which is based on
libclang. Based on irony-mode and libclang, it is quite precise (except
for ambiguous function calls), and avoids recompilation of files.

https://github.com/ikirill/irony-eldoc

It's closely tied to irony-mode, it was thought (https://github.com/Sarcasm/irony-mode/pull/147) it would be better to publish this separately than merge into irony-mode.
