### PR TITLE
Add hl-indent.

### DIFF
--- a/recipes/hl-indent
+++ b/recipes/hl-indent
@@ -1,0 +1,1 @@
+(hl-indent :fetcher github :repo "ikirill/hl-indent")


### PR DESCRIPTION
It is a minor mode for highlighting irregular indentation, which is
indentation not necessarily at multiples of some number.

There is already a highlight-indentation mode that works for languages like Python or C++, for which indentation is guaranteed to be at specific multiples of spaces. In other languages like Haskell or Lisp, indentation offsets are not so restricted, and this minor mode highlights them. (See the screenshot in readme.)

https://github.com/ikirill/hl-indent
