### PR TITLE
Generalize regexp for tags to identify stable versions

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -524,7 +524,9 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
           (let* ((bound (goto-char (point-max)))
                  (tag-version (and (package-build--run-process dir "git" "tag")
                                    (or (package-build--find-tag-version-newest
-                                        "^\\(?:v[.-]?\\)?\\([0-9]+[^ \t\n]*\\)$" bound)
+                                        (concat "^\\(?:\\(?:" (regexp-quote (symbol-name name)) "[-]\\)"
+                                                "\\(?:v[.-]?\\)?\\)?\\([0-9]+[^ \t\n]*\\)$")
+                                        bound)
                                        (error
                                         "No valid stable versions found for %s"
                                         name)))))
@@ -607,7 +609,8 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
           (let* ((bound (goto-char (point-max)))
                  (tag-version (and (package-build--run-process dir "hg" "tags")
                                    (or (package-build--find-tag-version-newest
-                                        "^\\(?:v[.-]?\\)?\\([0-9]+[^ \t\n]*\\)[ \t]*[0-9]+:\\([[:xdigit:]]+\\)$"
+                                        (concat "^\\(?:\\(?:" (regexp-quote (symbol-name name)) "[-]\\)"
+                                                "^\\(?:v[.-]?\\)?\\)?\\([0-9]+[^ \t\n]*\\)[ \t]*[0-9]+:\\([[:xdigit:]]+\\)$")
                                         bound
                                         2)
                                        (error


### PR DESCRIPTION
This allows for tags that are prefixed with name of the package followed by
a version number to be identified as tags corresponding to stable
versions. E.g. "foo-mode-v.1.0.0"  or "foo-mode-1.0.0" will now be identified as a commit containing a stable version of the package.

The use case is when multiple packages are kept in a single
repo (which is admitted sub-optimal) or if the package is kept in a repo
with other code.