### PR TITLE
merlin: use stable branch rather than master

### DIFF
--- a/recipes/merlin
+++ b/recipes/merlin
@@ -1,1 +1,1 @@
-(merlin :fetcher github :repo "the-lambda-church/merlin" :files ("emacs/*.el"))
+(merlin :fetcher github :repo "the-lambda-church/merlin" :branch "beta" :files ("emacs/*.el"))


### PR DESCRIPTION
The current merlin recipe tracks the master branch.

Sometimes backward incompatible changes are pushed there and this will break merlin-mode for people using melpa.
We created the opam-stable branch to track the current stable version.