### PR TITLE
Add scribble-mode

### DIFF
--- a/recipes/scribble-mode
+++ b/recipes/scribble-mode
@@ -1,0 +1,2 @@
+(scribble-mode :repo "emacs-pe/scribble-mode" :fetcher github
+             :files ("*.el"))


### PR DESCRIPTION
`scribble-mode` is a major mode for editing documents written in Racket's scribble format. I'm merely an interested user; @emacs-pe hosts the upstream code here on Github.

Ref:

- Package repository: https://github.com/emacs-pe/scribble-mode
