### PR TITLE
Add recipe for evalator-context-cider package

### DIFF
--- a/recipes/evalator-clojure
+++ b/recipes/evalator-clojure
@@ -1,0 +1,3 @@
+(evalator-clojure :fetcher github
+                  :repo "seanirby/evalator-clojure"
+                  :files (:defaults "*.clj"))


### PR DESCRIPTION
Hello again,

I'd like to add [evalator-context-cider](https://github.com/seanirby/evalator-context-cider) to MELPA.

This package adds Clojure support to [evalator](https://github.com/seanirby/evalator)

If you want to manually test this then the newest version of evalator is required, which may or may not be built in MELPA yet.