### PR TITLE
get jabber from github

### DIFF
--- a/recipes/jabber
+++ b/recipes/jabber
@@ -1,4 +1,4 @@
 (jabber
- :url "git://git.code.sf.net/p/emacs-jabber/git"
- :fetcher git
+ :fetcher github
+ :repo "legoscia/emacs-jabber"
  :files ("*.el" "*.texi" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))


### PR DESCRIPTION
Jabber is available from both Sourceforge and Github, and he HEAD is
identical in both repositories.  http://emacs-jabber.sourceforge.net
doesn't say which is the official repository so lets use Github.

@legoscia is this a good course of action?