### PR TITLE
move package-build.el to lisp/ subdirectory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(NEED_CL-LIB), t)
 	EMACS_COMMAND := $(EMACS_COMMAND) --eval "(package-initialize)"
 endif
 
-EVAL := $(EMACS_COMMAND) --no-site-file --batch -l package-build.el --eval
+EVAL := $(EMACS_COMMAND) --no-site-file --batch -l lisp/package-build.el --eval
 
 TIMEOUT := $(shell which timeout && echo "-k 60 600")
 
@@ -65,16 +65,16 @@ packages/archive-contents: $(PKGDIR)/*.entry
 	$(EVAL) '(package-build-dump-archive-contents)'
 
 cleanup:
-	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--this-dir))) (package-build-cleanup))'
+	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--parent-dir))) (package-build-cleanup))'
 
 ## Json rules
 html/archive.json: $(PKGDIR)/archive-contents
 	@echo " • Building $@ ..."
-	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--this-dir))) (package-build-archive-alist-as-json "html/archive.json"))'
+	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--parent-dir))) (package-build-archive-alist-as-json "html/archive.json"))'
 
 html/recipes.json: $(RCPDIR)/.dirstamp
 	@echo " • Building $@ ..."
-	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--this-dir))) (package-build-recipe-alist-as-json "html/recipes.json"))'
+	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--parent-dir))) (package-build-recipe-alist-as-json "html/recipes.json"))'
 
 json: html/archive.json html/recipes.json
 
@@ -87,7 +87,7 @@ $(RCPDIR)/.dirstamp: .FORCE
 $(RCPDIR)/%: .FORCE
 	@echo " • Building recipe $(@F) ..."
 
-	- $(TIMEOUT) $(EVAL) "(let ((package-build-stable $(STABLE)) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"$(PKGDIR)\" package-build--this-dir))) (package-build-archive '$(@F)))"
+	- $(TIMEOUT) $(EVAL) "(let ((package-build-stable $(STABLE)) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"$(PKGDIR)\" package-build--parent-dir))) (package-build-archive '$(@F)))"
 
 	@echo " ✓ Wrote $$(ls -lsh $(PKGDIR)/$(@F)-*) "
 	@echo " Sleeping for $(SLEEP) ..."

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ format.
 
 ## API
 
-All repository code is contained in the `package-build.el`.
+All repository code is contained in the `lisp/package-build.el`.
 
 ### Functions
 

--- a/lisp/package-build.el
+++ b/lisp/package-build.el
@@ -45,23 +45,30 @@
 (require 'lisp-mnt)
 (require 'json)
 
-(defconst package-build--this-dir (file-name-directory (or load-file-name (buffer-file-name))))
+(defconst package-build--parent-dir
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory
+     (or load-file-name (buffer-file-name))))))
 
 (defgroup package-build nil
   "Facilities for building package.el-compliant packages from upstream source code."
   :group 'development)
 
-(defcustom package-build-working-dir (expand-file-name "working/" package-build--this-dir)
+(defcustom package-build-working-dir
+  (expand-file-name "working/" package-build--parent-dir)
   "Directory in which to keep checkouts."
   :group 'package-build
   :type 'string)
 
-(defcustom package-build-archive-dir (expand-file-name "packages/" package-build--this-dir)
+(defcustom package-build-archive-dir
+  (expand-file-name "packages/" package-build--parent-dir)
   "Directory in which to keep compiled archives."
   :group 'package-build
   :type 'string)
 
-(defcustom package-build-recipes-dir (expand-file-name "recipes/" package-build--this-dir)
+(defcustom package-build-recipes-dir
+  (expand-file-name "recipes/" package-build--parent-dir)
   "Directory containing recipe files."
   :group 'package-build
   :type 'string)

--- a/recipes/.dir-locals.el
+++ b/recipes/.dir-locals.el
@@ -7,7 +7,7 @@
                    (when (fboundp 'flycheck-mode)
                      (flycheck-mode -1))
                    (unless (featurep 'package-build)
-                     (let ((load-path (cons ".." load-path)))
+                     (let ((load-path (cons "../lisp" load-path)))
                        (require 'package-build)))
                    (package-build-minor-mode)
                    (set (make-local-variable 'package-build-working-dir) (expand-file-name "../working/"))

--- a/recipes/package-build
+++ b/recipes/package-build
@@ -1,3 +1,3 @@
 (package-build :repo "milkypostman/melpa"
                :fetcher github
-               :files ("package-build.el"))
+               :files ("lisp/package-build.el"))

--- a/run-travis-ci.sh
+++ b/run-travis-ci.sh
@@ -21,7 +21,7 @@ if [ -n "$TRAVIS_COMMIT_RANGE" ]; then
         if [ -f "./recipes/$recipe_name" ]; then
             echo "----------------------------------------------------"
             echo "Building new/modified recipe: $recipe_name"
-            "$ECUKES_EMACS" --batch --eval "(progn (load-file \"package-build.el\")(package-build-archive '$recipe_name))"
+            "$ECUKES_EMACS" --batch --eval "(progn (load-file \"lisp/package-build.el\")(package-build-archive '$recipe_name))"
         fi
     done
 fi

--- a/scripts/expired
+++ b/scripts/expired
@@ -22,7 +22,7 @@
   (match-string 1 fn))
 
 
-(add-to-list 'load-path (expand-file-name ".." (file-name-directory load-file-name)))
+(add-to-list 'load-path (expand-file-name "../lisp" (file-name-directory load-file-name)))
 (require 'package-build)
 
 (dolist (entry-file (directory-files package-build-archive-dir t ".*\.entry$"))


### PR DESCRIPTION
This allows me to mirror the `package-build` package on the Emacsmirror
using a fetcher build around `git subtree`.  I would like to do that
because I already mirror several packages which depend on it.  I do not
mirror complete repositories when they contain much much more than just
the elisp, except when I can mirror just a subtree using `git subtree`.

Of course the history extracted using `git subtree` will lack the old
history, but that's better than not mirroring the package at all.

I have tested building packages locally, but if it is possible to test this before putting it into production, then that would probably be a good idea. At the very least you have to review this carefully, as my understanding of any of the scripts and makefiles that make use of this library is very limited.

Thanks for considering!

Ps: The "re-announcement" of the Emacsmirror can happen any time now! :-) 