### PR TITLE
remove save-sexp

### DIFF
--- a/recipes/save-sexp
+++ b/recipes/save-sexp
@@ -1,1 +1,0 @@
-(save-sexp :repo "tarsius/save-sexp" :fetcher github)


### PR DESCRIPTION
I stopped maintaining this package a long
time ago but forgot to remove it from Melpa.