### PR TITLE
Fix upstreams of various packages

### DIFF
--- a/recipes/desktop-registry
+++ b/recipes/desktop-registry
@@ -1,1 +1,1 @@
-(desktop-registry :fetcher git :url "git://ryuslash.org/desktop-registry.git")
+(desktop-registry :fetcher github :repo "ryuslash/desktop-registry")

--- a/recipes/dummy-h-mode
+++ b/recipes/dummy-h-mode
@@ -1,1 +1,1 @@
-(dummy-h-mode :fetcher wiki)
+(dummy-h-mode :fetcher github :repo "yascentur/dummy-h-mode-el")

--- a/recipes/eimp
+++ b/recipes/eimp
@@ -1,1 +1,1 @@
-(eimp :fetcher wiki)
+(eimp :fetcher github :repo "nicferrier/eimp")

--- a/recipes/elisp-depend
+++ b/recipes/elisp-depend
@@ -1,1 +1,1 @@
-(elisp-depend :fetcher wiki)
+(elisp-depend :fetcher github :repo "tehom/elisp-depend")

--- a/recipes/fic-mode
+++ b/recipes/fic-mode
@@ -1,2 +1,1 @@
-(fic-mode :fetcher wiki)
-
+(fic-mode :fetcher github :repo "lewang/fic-mode")

--- a/recipes/furl
+++ b/recipes/furl
@@ -1,1 +1,1 @@
-(furl :fetcher hg :url "https://code.google.com/p/furl-el/")
+(furl :fetcher github :repo "nex3/furl-el")

--- a/recipes/inform7-mode
+++ b/recipes/inform7-mode
@@ -1,3 +1,1 @@
-(inform7-mode
- :url "https://github.com/fred-o/inform7-mode.git"
- :fetcher git)
+(inform7-mode :fetcher github :repo "fred-o/inform7-mode")

--- a/recipes/iy-go-to-char
+++ b/recipes/iy-go-to-char
@@ -1,1 +1,1 @@
-(iy-go-to-char :fetcher wiki)
+(iy-go-to-char :fetcher github :repo "doitian/iy-go-to-char")

--- a/recipes/jg-quicknav
+++ b/recipes/jg-quicknav
@@ -1,3 +1,1 @@
-(jg-quicknav
- :url "https://github.com/jeffgran/jg-quicknav"
- :fetcher git)
+(jg-quicknav :fetcher github :repo "jeffgran/jg-quicknav")

--- a/recipes/legalese
+++ b/recipes/legalese
@@ -1,1 +1,1 @@
-(legalese :fetcher wiki)
+(legalese :fetcher github :repo "jorgenschaefer/legalese")

--- a/recipes/list-register
+++ b/recipes/list-register
@@ -1,1 +1,1 @@
-(list-register :fetcher wiki)
+(list-register :fetcher github :repo "emacsmirror/list-register")

--- a/recipes/lively
+++ b/recipes/lively
@@ -1,1 +1,1 @@
-(lively :fetcher wiki)
+(lively :fetcher github :repo "emacsorphanage/lively")

--- a/recipes/mic-paren
+++ b/recipes/mic-paren
@@ -1,1 +1,1 @@
-(mic-paren :fetcher wiki)
+(mic-paren :fetcher github :repo "emacsmirror/mic-paren")

--- a/recipes/mode-icons
+++ b/recipes/mode-icons
@@ -1,1 +1,1 @@
-(mode-icons :fetcher git :url "git://ryuslash.org/mode-icons.git" :files ("*.el" "icons"))
+(mode-icons :fetcher github :repo "ryuslash/mode-icons" :files ("*.el" "icons"))

--- a/recipes/nav
+++ b/recipes/nav
@@ -1,1 +1,1 @@
-(nav :url "https://code.google.com/p/emacs-nav/" :fetcher hg :files ("ack*" "nav.el"))
+(nav :fetcher github :repo "ijt/emacs-nav" :files ("ack*" "nav.el"))

--- a/recipes/pastebin
+++ b/recipes/pastebin
@@ -1,1 +1,1 @@
-(pastebin :fetcher wiki)
+(pastebin :fetcher github :repo "nicferrier/elpastebin")

--- a/recipes/scheme-complete
+++ b/recipes/scheme-complete
@@ -1,3 +1,1 @@
-(scheme-complete
- :fetcher hg
- :url "http://code.google.com/p/scheme-complete/")
+(scheme-complete :fetcher github :repo "ashinn/scheme-complete")

--- a/recipes/wc-mode
+++ b/recipes/wc-mode
@@ -1,1 +1,1 @@
-(wc-mode :fetcher wiki)
+(wc-mode :fetcher github :repo "bnbeckwith/wc-mode")


### PR DESCRIPTION
I checked that the new upstreams are more up-to-date than the old.

While doing so I also ran into some packages were it is not obvious whether we should stick with the old upstream or not.

* `desktop-registry` and `mode-icons` by @ryuslash are available from github as well from repositories on his own server. All repositories appear to be up-to-date. **Edit:** changed recipes as per reply below.

* `jabber` by @legoscia are available from github as well as from sourceforge. The homepage on sourceforge only mentions the repository on sourceforge. Both repositories appear to be up-to-date. **Edit**: use sourceforge as per #3563.

I would prefer getting the packages from the github repositories, as that would allow users to click on a link on Melpa's webpage to go to the web view of the repository. (And also because that's already what I do on the Emacsmirror.) @ryuslash @legoscia what do you think?

* `goto-chg` was modified [on github]( https://github.com/martinp26/goto-chg/commit/2440191e1ebe14a6fac5278bd9dcb2fd0be9ff59) by @martinp26 and on the wiki by David Andersson, the original author. I have gone back to mirroring the version from the wiki. @martinp26 I suggest you contact David and suggest that he merges your changes and makes the result available as a git or hg repository.