### PR TITLE
Add auto-virtualenv

### DIFF
--- a/recipes/auto-virtualenv
+++ b/recipes/auto-virtualenv
@@ -1,0 +1,1 @@
+(auto-virtualenv :fetcher github :repo "marcwebbie/auto-virtualenv")


### PR DESCRIPTION
Automatically activate python virtualenvs on emacs based on project name or `.python-version` file.

repo: https://github.com/marcwebbie/auto-virtualenv