### PR TITLE
added ess-view recipes

### DIFF
--- a/recipes/ess-view
+++ b/recipes/ess-view
@@ -1,0 +1,1 @@
+(ess-view :fetcher github :repo "GioBo/ess-view")


### PR DESCRIPTION
Dear MELPA Maintainers,

  ess-view is a simple package which lets users of ess (Emacs Speaks Statistics) inspect R dataframes through an external spreadsheet software (this is useful for medium/big-size objects which do not display well inside the terminal): with a simple keybinding users can digit the name of the dataframe and ess-view will take care of converting it to a temporary csv file and open it via a spreadsheet; there's also the chance of saving any change done to the spreadsheet file and load back the results into the original R dataframe.

The original repository of ess-view is found at https://github.com/GioBo/ess-view.

I am the author of the package.