### PR TITLE
release nix-sandbox.el on melpa

### DIFF
--- a/recipes/nix-sandbox
+++ b/recipes/nix-sandbox
@@ -1,0 +1,3 @@
+(nix-sandbox :fetcher github
+             :repo "travisbhartwell/nix-emacs"
+             :files ("nix-sandbox.el"))


### PR DESCRIPTION
Hello,

I wrote an emacs package that allows to work with sandboxes in NixOS. I want to release it on MELPA because people asked for it. I used this package every day on work for the last few months and it works. @purcell, let me know what you think.

Best,
Sven