### PR TITLE
Add recipe for sly-repl-ansi-color

### DIFF
--- a/recipes/sly-repl-ansi-color
+++ b/recipes/sly-repl-ansi-color
@@ -1,0 +1,3 @@
+(sly-repl-ansi-color
+ :fetcher github
+ :repo "PuercoPop/sly-repl-ansi-color")


### PR DESCRIPTION
[sly-repl-ansi-color](https://github.com/PuercoPop/sly-repl-ansi-color) adds ansi color support to the sly mrepl. I've now tested it successfully in the sandbox.