### PR TITLE
add org-clock-convenience

### DIFF
--- a/recipes/org-clock-convenience
+++ b/recipes/org-clock-convenience
@@ -1,0 +1,3 @@
+(org-clock-convenience
+ :fetcher github
+ :repo "dfeich/org-clock-convenience")


### PR DESCRIPTION
This package introduces a number of convenience functions for time
tracking in Org-mode. Allows modifying clocked times directly from the
log lines in the agenda buffer.

Thanks,
Derek