### PR TITLE
VHDL-capf package added.

### DIFF
--- a/recipes/vhdl-capf
+++ b/recipes/vhdl-capf
@@ -1,0 +1,1 @@
+(vhdl-capf :fetcher github :repo "sh-ow/vhdl-capf")


### PR DESCRIPTION
This package provides a completion-at-point-function for vhdl-mode. This shall improve auto-completion in vhdl-mode because with the help of this function any completion framework can be used, like company-mode (with all its benefits like fuzzy matching auto-completion).
The package's repo is the following: https://github.com/sh-ow/vhdl-capf

I (sh-ow) am the creator and maintainer of this package.