### PR TITLE
Add helm-clojuredocs recipe

### DIFF
--- a/recipes/helm-clojuredocs
+++ b/recipes/helm-clojuredocs
@@ -1,0 +1,1 @@
+(helm-clojuredocs :repo "mbuczko/helm-clojuredocs" :fetcher github)


### PR DESCRIPTION
```helm-clojuredocs``` is yet another helm source which makes searching for help with clojure functions/macros a bit easier. It looks for given phrase on marvelous http://clojuredocs.org and gives an instant feedback back to emacs.

I'm the author and maintainer of this packages (localized here: http://github.com/mbuczko/helm-clojuredocs)

Thanks.