### PR TITLE
Add recipe for click-mode

### DIFF
--- a/recipes/click-mode
+++ b/recipes/click-mode
@@ -1,0 +1,1 @@
+(click-mode :fetcher github :repo "bmalehorn/click-mode")


### PR DESCRIPTION
`click-mode` is a major mode for editting configuration files for the Click Modular Router Project ([homepage](http://read.cs.ucla.edu/click/click)). I'm the author of the package, which you can get at https://github.com/bmalehorn/click-mode.

I've tried installing it in a sandboxed Emacs and it works fine. If you need to test it, open up [bmalehorn/click-mode/example.click](https://raw.githubusercontent.com/bmalehorn/click-mode/master/example.click) and verify it highlights properly. It should look something like this:

![Screenshot](https://github.com/bmalehorn/click-mode/raw/master/example.png)

Let me know if there's anything I need to change to get it merged in. It's not worth writing a package unless it gets into melpa!