### PR TITLE
Add recipe for coverage-mode

### DIFF
--- a/recipes/coverage
+++ b/recipes/coverage
@@ -1,0 +1,1 @@
+(coverage :fetcher github :repo "trezona-lecomte/coverage")


### PR DESCRIPTION
Hey Steve,

`coverage` provides a minor mode (`coverage-mode`) that enables line-by-line highlighting of source code to reflect test coverage status.

The package repo can be found [here](https://github.com/trezona-lecomte/coverage).

Thanks very much!