### PR TITLE
Ensure SCM tools are available under travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
-
+# XXX: Requires sudo because travis-ci apt-package-whitelist doesn't contain the
+# following packages: cvs darcs fossil texinfo
+sudo: required
 before_install:
+  - sudo apt-get -yq update
+  - sudo apt-get -yq install bzr git mercurial subversion cvs darcs fossil texinfo
+
   - git clone https://github.com/rejeep/evm.git $HOME/.evm
   - export PATH=$HOME/.evm/bin:$PATH
 


### PR DESCRIPTION
Fixes #3592 
Also I took the liberty from evm to flycheck's [emacs-travis](https://github.com/flycheck/emacs-travis/) which is more easy to use

I know which packages are necessary because long ago [I used travis-ci to build melpa](https://github.com/emacs-pe/melpa/blob/master/.travis.yml)