### PR TITLE
Add company-dict recipe

### DIFF
--- a/recipes/company-dict
+++ b/recipes/company-dict
@@ -1,0 +1,1 @@
+(company-dict :repo "hlissner/emacs-company-dict" :fetcher github)


### PR DESCRIPTION
Description: A simple backend for [company-mode](https://github.com/company-mode/company-mode)  that reads completion candidates from user-provided dictionaries. This emulates `ac-source-dictionary` and vim's dictionary omnicompletion (`C-x C-k`), and is much like `company-keywords` but with lazy-loaded dictionary files.

+ [Repository](https://github.com/hlissner/emacs-company-dict)
+ I am the author

