### PR TITLE
Add evil-multiedit recipe

### DIFF
--- a/recipes/evil-multiedit
+++ b/recipes/evil-multiedit
@@ -1,0 +1,1 @@
+(evil-multiedit :repo "hlissner/evil-multiedit" :fetcher github)


### PR DESCRIPTION
Description: A multiple cursor implementation that integrates `iedit-mode` into `evil-mode`, bringing Sublime Text's (or Atom's) multiple cursor feature to Emacs.

A little hackish, and is 24.5+ only (because I use the new advising library), but I'll iron out some of those kinks over the next week or two. As I'm relatively new to elisp, any advice would be appreciated!

+ [Repository](https://github.com/hlissner/evil-multiedit)
+ I am the author