### PR TITLE
rust-mode's :files is the same as :defaults

### DIFF
--- a/recipes/rust-mode
+++ b/recipes/rust-mode
@@ -1,3 +1,2 @@
 (rust-mode :repo "rust-lang/rust-mode"
-           :fetcher github
-           :files ("rust-mode.el"))
+           :fetcher github)


### PR DESCRIPTION
(I got this warning when compiling.)

Only if @MicahChalmer @steveklabnik are okay with it though (i.e perhaps they still have some reason for it).