### PR TITLE
Add recipe for mozc-temp

### DIFF
--- a/recipes/mozc-temp
+++ b/recipes/mozc-temp
@@ -1,0 +1,1 @@
+(mozc-temp :repo "HKey/mozc-temp" :fetcher github)


### PR DESCRIPTION
Hi, mozc-temp is a wrapper of [mozc](https://github.com/google/mozc) for modeless input of Japanese.
I'm the author and the repository is https://github.com/HKey/mozc-temp.