### PR TITLE
get zeitgeist from new upstream

### DIFF
--- a/recipes/zeitgeist
+++ b/recipes/zeitgeist
@@ -1,1 +1,3 @@
-(zeitgeist :url "lp:zeitgeist-datasources" :fetcher bzr :files ("emacs/*.el"))
+(zeitgeist :fetcher git
+	   :url "git://anongit.freedesktop.org/zeitgeist/zeitgeist-datasources"
+	   :files ("emacs/*.el"))


### PR DESCRIPTION
The old page on launchpad says: "Zeitgeist Data-Sources hosts its code
at git://anongit.freedesktop.org/zeitgeist/zeitgeist-datasources."