### PR TITLE
JIRA Backend for Org Export Engine

### DIFF
--- a/recipes/ox-jira
+++ b/recipes/ox-jira
@@ -1,0 +1,3 @@
+(ox-jira :repo "stig/ox-jira.el"
+         :fetcher github
+         :files ("ox-jira.el"))


### PR DESCRIPTION
This module plugs into the regular Org Export Engine and transforms Org files to JIRA markup for pasting into JIRA tickets & comments.

Its homepage is here: https://github.com/stig/ox-jira.el

I am its author. It certainly doesn't support all JIRA / Org elements, but it supports enough that I find it useful, and others might too.