### PR TITLE
Add ace-mc recipe

### DIFF
--- a/recipes/ace-mc
+++ b/recipes/ace-mc
@@ -1,0 +1,1 @@
+(ace-mc :repo "mm--/ace-mc" :fetcher github)


### PR DESCRIPTION
This adds the package [ace-mc](https://github.com/mm--/ace-mc), which makes it easy to add and remove multiple-cursor mode cursors using ace-jump.

I'm the author of this package.