### PR TITLE
get helm-hoogle from new upstream repo

### DIFF
--- a/recipes/helm-hoogle
+++ b/recipes/helm-hoogle
@@ -1,1 +1,1 @@
-(helm-hoogle :fetcher github :repo "jwiegley/haskell-config" :files ("helm-hoogle.el"))
+(helm-hoogle :fetcher github :repo "jwiegley/helm-hoogle")


### PR DESCRIPTION
Pending https://github.com/jwiegley/haskell-config/pull/5.