### PR TITLE
Add recipe for sprunge package

### DIFF
--- a/recipes/sprunge
+++ b/recipes/sprunge
@@ -1,0 +1,1 @@
+(sprunge :fetcher github :repo "tomjakubowski/sprunge.el")


### PR DESCRIPTION
sprunge (not to be confused with el-sprunge) is an Emacs package to
upload text to sprunge.us, the command-line pastebin.