### PR TITLE
Add go-guru

### DIFF
--- a/recipes/go-guru
+++ b/recipes/go-guru
@@ -1,0 +1,4 @@
+(go-guru
+ :url "https://go.googlesource.com/tools"
+ :fetcher git
+ :files ("cmd/guru/go-guru.el"))


### PR DESCRIPTION
go-guru provides integration of the 'guru' tool into Emacs.

Link to the package file in the official repository:
https://go.googlesource.com/tools/+/master/cmd/guru/go-guru.el

I am not the author of the package but use it quite a lot. I've also submitted
the following package.el compatibility changes for go-guru:
https://go-review.googlesource.com/#/c/19789/