### PR TITLE
grails-minor-mode recipe

### DIFF
--- a/recipes/grails
+++ b/recipes/grails
@@ -1,0 +1,1 @@
+(grails :fetcher github :repo "lifeisfoo/emacs-grails" :branch "master")


### PR DESCRIPTION
I'm the author of this minor mode that allows an easy navigation of grails projects. 
This recipe isn't related to the existing grails-mode (this is a brand new minor-mode).

I've built it locally and everything seems to be ok:

```
 melpa git:(master) ✗ make recipes/grails-minor-mode
 • Building recipe grails-minor-mode ...
emacs --no-site-file --batch -l package-build.el --eval "(let ((package-build-stable nil) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"./packages\" package-build--this-dir))) (package-build-archive 'grails-minor-mode))"

;;; grails-minor-mode

Fetcher: github
Source: lifeisfoo/grails-minor-mode

Cloning https://github.com/lifeisfoo/grails-minor-mode.git to /Users/alessandro/Dev/emacs/melpa/working/grails-minor-mode/
Note: grails-minor-mode :files spec is equivalent to the default.
Saving file /Users/alessandro/Dev/emacs/melpa/packages/grails-minor-mode-20160303.1724.el...
Wrote /Users/alessandro/Dev/emacs/melpa/packages/grails-minor-mode-20160303.1724.el
Wrote /Users/alessandro/Dev/emacs/melpa/packages/grails-minor-mode-readme.txt
File: /Users/alessandro/Dev/emacs/melpa/packages/grails-minor-mode-20160303.1724.entry
Built in 0.889s, finished at Thu Mar  3 17:41:54 2016
 ✓ Wrote 16 -rw-r--r--  1 alessandro  staff   7,6K  3 Mar 17:41 ./packages/grails-minor-mode-20160303.1724.el
 8 -rw-r--r--  1 alessandro  staff   161B  3 Mar 17:41 ./packages/grails-minor-mode-20160303.1724.entry
 8 -rw-r--r--  1 alessandro  staff   750B  3 Mar 17:41 ./packages/grails-minor-mode-badge.svg
 8 -rw-r--r--  1 alessandro  staff   1,1K  3 Mar 17:41 ./packages/grails-minor-mode-readme.txt 
 Sleeping for 0 ...
sleep 0
```