### PR TITLE
Add tabulated-list-ext package

### DIFF
--- a/recipes/tle
+++ b/recipes/tle
@@ -1,0 +1,1 @@
+(tle :fetcher github :repo "Silex/tabulated-list-extensions")


### PR DESCRIPTION
Hello!

Please wait a bit before merging.

Things to discuss:

* Wether I should prefix everything with `tabulated-list-ext` or is it fine to extend some obvious features with `tabulated-list` only?
* ????
* Profit!

This idea happend thanks to @dougm because of https://github.com/Silex/docker.el/issues/13