### PR TITLE
added package for persistent overlays

### DIFF
--- a/recipes/persistent-overlays
+++ b/recipes/persistent-overlays
@@ -1,0 +1,6 @@
+(persistent-overlays
+ :fetcher github
+ :repo "mneilly/Emacs-Persistent-Overlays"
+ :files ("persistent-overlays.el"
+	 "README.md"
+	 "LICENSE"))


### PR DESCRIPTION
persistent-overlays is a minor mode that stores overlays between Emacs sessions. By default it stores only overlays with the invisible property. This is useful when using other minor modes such as hideshow or outline so that your hidden text/code is remembered between sessions. It has various custom variables that control auto load, auto merge, storage directory etc.

https://github.com/mneilly/Emacs-Persistent-Overlays

The package is clean per flycheck-package, I have tested that the package builds and can be installed with package-install-file.
