### PR TITLE
Add magit-p4 package.

### DIFF
--- a/recipes/magit-p4
+++ b/recipes/magit-p4
@@ -1,0 +1,1 @@
+(magit-p4 :repo "qoocku/magit-p4" :fetcher github)


### PR DESCRIPTION
This plug-in is a glue between git-p4 and Magit.

url: https://github.com/qoocku/magit-p4

I'm a contributor.