### PR TITLE
Add robots-txt-mode recipe

### DIFF
--- a/recipes/robots-txt-mode
+++ b/recipes/robots-txt-mode
@@ -1,0 +1,1 @@
+(robots-txt-mode :fetcher github :repo "zonuexe/robots-txt-mode")


### PR DESCRIPTION
[robots-txt-mode](https://github.com/zonuexe/robots-txt-mode) is major-mode for editing [Robots exclusion standard](https://en.wikipedia.org/wiki/Robots_exclusion_standard) file.

I am the author of this package.
