### PR TITLE
Add org-bookmark-heading package

### DIFF
--- a/recipes/org-bookmark-heading
+++ b/recipes/org-bookmark-heading
@@ -1,0 +1,1 @@
+(org-bookmark-heading :fetcher github :repo "alphapapa/org-bookmark-heading")


### PR DESCRIPTION
This package provides Emacs bookmark support for org-mode.  You can bookmark headings in org-mode files and jump to them using standard Emacs bookmark commands.  Also supports Helm.

http://github.com/alphapapa/org-bookmark-heading

I am the author.

MELPA and Stable build tests pass, and the package installs and works correctly in the sandbox.

Thanks for your work on MELPA!