### PR TITLE
Add turkish-mode package

### DIFF
--- a/recipes/turkish
+++ b/recipes/turkish
@@ -1,0 +1,1 @@
+(turkish :fetcher github :repo "emres/turkish-mode")


### PR DESCRIPTION
This package provides on-the-fly conversion to Turkish characters (such as `ç`, `ö`, `ü`, `ğ`, etc.) for Emacs users who don't have a keyboard with Turkish letters, or who don't prefer to type Turkish letters when typing Turkish words. Users can also select a region, buffer, etc. to convert to Turkish characters. 

https://github.com/emres/turkish-mode

I am the maintainer.