### PR TITLE
Add biblio-core

### DIFF
--- a/recipes/biblio-core
+++ b/recipes/biblio-core
@@ -1,0 +1,4 @@
+(biblio-core
+ :repo "cpitclaudel/biblio.el"
+ :fetcher github
+ :files ("biblio-core.el"))


### PR DESCRIPTION
This is the base package for a collection of bibliographic reference
browsing packages; it contains the browsing UI and the search
infrastructure.

I broke this package into small subpackages so that people can install just the sources that they are interested in (in the style of ac or company)

Source: https://github.com/cpitclaudel/biblio.el
I'm the maintainer :)