### PR TITLE
Add helm-org-rifle

### DIFF
--- a/recipes/helm-org-rifle
+++ b/recipes/helm-org-rifle
@@ -1,0 +1,1 @@
+(helm-org-rifle :fetcher github :repo "alphapapa/helm-org-rifle")


### PR DESCRIPTION
This package lets you "rifle" through Org buffers, quickly displaying results in a Helm buffer.

http://github.com/alphapapa/helm-org-rifle

I am the author.

The build test passes without warnings, and the package installs and works correctly in the sandbox.

Thanks!