### PR TITLE
Adding a recipe for flycheck-pkg-config

### DIFF
--- a/recipes/flycheck-pkg-config
+++ b/recipes/flycheck-pkg-config
@@ -1,0 +1,3 @@
+(flycheck-pkg-config
+ :repo "Wilfred/flycheck-pkg-config"
+ :fetcher github)


### PR DESCRIPTION
Flycheck defines a `flycheck-clang-include-path' variable that it
searches for headers when checking C/C++ code.

This package provides a convenient way of adding libraries to that list,
using pkg-config and completion.