### PR TITLE
Change `org-password-manager' location

### DIFF
--- a/recipes/org-password-manager
+++ b/recipes/org-password-manager
@@ -1,3 +1,3 @@
 (org-password-manager
- :fetcher github
- :repo "leafac/org-password-manager")
+ :fetcher git
+ :url "https://git.leafac.com/leafac/org-password-manager")


### PR DESCRIPTION
The maintainer is moving the repository from GitHub to a self-hosted solution. The GitHub repository is going to be removed soon.