### PR TITLE
add xo

### DIFF
--- a/recipes/xo
+++ b/recipes/xo
@@ -1,0 +1,1 @@
+(xo :fetcher github :repo "j-em/xo-emacs")


### PR DESCRIPTION
This package add support for [XO](https://github.com/sindresorhus/xo) (a JS linter) in compile mode.
I am the maintainer. Building and installation seem to work fine on my machine.

Link to repo: https://github.com/j-em/xo-emacs

Let me know if something should be changed :-)