### PR TITLE
Update julia-mode for repo move

### DIFF
--- a/recipes/julia-mode
+++ b/recipes/julia-mode
@@ -1,4 +1,4 @@
 (julia-mode
- :repo "JuliaLang/julia"
+ :repo "JuliaLang/julia-emacs"
  :fetcher github
- :files ("contrib/julia-mode.el"))
+ :files ("julia-mode.el"))


### PR DESCRIPTION
The julia-mode file now lives at https://github.com/JuliaLang/julia-emacs

cc @Wilfred @yuyichao