### PR TITLE
Add cat-mode recipe

### DIFF
--- a/recipes/cat-mode
+++ b/recipes/cat-mode
@@ -1,0 +1,1 @@
+(cat-mode :fetcher github :repo "ad1217/emacs-cat-mode")


### PR DESCRIPTION
An emacs minor mode that helps manage buffers by assigning them cats (short for categories`).
https://github.com/ad1217/emacs-cat-mode