### PR TITLE
search all words separately

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -49,7 +49,9 @@
     this.readmeURL = "/packages/" + data.name + "-readme.txt";
     this.badgeURL = "/packages/" + data.name + "-badge.svg";
     this.matchesTerm = function(term) {
-      return this._searchText.indexOf(term) != -1;
+      return _.every(term.split(' ').map(function(part) {
+        return this._searchText.indexOf(part) !== -1;
+      }.bind(this)));
     };
   };
 


### PR DESCRIPTION
Currently search only finds exact matches. This PR attempts to improve search results by separately searching each word in the search term. So while every word in a search term is still required, the order no longer matters. 

For example, before and after:

![image](https://cloud.githubusercontent.com/assets/31308/14272693/1796ad12-faba-11e5-9646-7fb9a6cfa33d.png)
