### PR TITLE
add recipe for ob-coffee

### DIFF
--- a/recipes/ob-coffee
+++ b/recipes/ob-coffee
@@ -1,1 +1,3 @@
-(ob-coffee :fetcher github :repo "zweifisch/ob-coffee")
+(ob-coffee
+ :fetcher github :repo "zweifisch/ob-coffee"
+ :files (:defaults "repl.js"))

--- a/recipes/ob-coffee
+++ b/recipes/ob-coffee
@@ -1,0 +1,1 @@
+(ob-coffee :fetcher github :repo "zweifisch/ob-coffee")


### PR DESCRIPTION
The ob-coffee package adds coffeescript support for org-babel.

(I'm not the author, just a user.)