### PR TITLE
Add spark recipe

### DIFF
--- a/recipes/spark
+++ b/recipes/spark
@@ -1,0 +1,1 @@
+(spark :fetcher github :repo "alvinfrancis/spark")


### PR DESCRIPTION
This provides functionality for creating text sparklines in emacs-lisp.  It is a port of the common lisp package [cl-spark](https://github.com/tkych/cl-spark).
Link: [spark](https://github.com/alvinfrancis/spark)
Association: Maintainer