### PR TITLE
Fix make sandbox document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ packages will be available for installation along with those already
 in MELPA:
 
 ```
-EMACS=/path/to/emacs make sandbox
+EMACS_COMMAND=/path/to/emacs make sandbox
 ```
 
 then `M-x package-list-packages`, install and test as


### PR DESCRIPTION
Replace the EMACS variable with EMACS_COMMAND, because that's the
variable used in the Makefile.

Refer: #3760