### PR TITLE
Added recipe for ivy-bibtex.

### DIFF
--- a/recipes/ivy-bibtex
+++ b/recipes/ivy-bibtex
@@ -1,0 +1,1 @@
+(ivy-bibtex :fetcher github :repo "tmalsburg/helm-bibtex" :files ("ivy-bibtex.el" "bibtex-completion.el"))


### PR DESCRIPTION
ivy-bibtex is like helm-bibtex but for the ivy completion framework.  It can be used to perform bibliographic searches in BibTeX libraries.