### PR TITLE
Add recipes for epkg and closql

### DIFF
--- a/recipes/closql
+++ b/recipes/closql
@@ -1,0 +1,1 @@
+(closql :fetcher gitlab :repo "tarsius/closql")

--- a/recipes/epkg
+++ b/recipes/epkg
@@ -1,0 +1,1 @@
+(epkg :fetcher gitlab :repo "tarsius/epkg")


### PR DESCRIPTION
I am getting ready to re-introduce the Emacsmirror very soon now. `epkg` is a client which allows browsing the Emacsmirror database. I would like it to be available from Melpa when I make the announcement. Right now it is not very useful because without the database it doesn't do much and I haven't made that public yet. I will do so shortly before making the announcement, which will happen no earlier than when the package has landed on Melpa and no later than tomorrow.

Duke Nukem Forever!