### PR TITLE
Add cl-format recipe

### DIFF
--- a/recipes/cl-format
+++ b/recipes/cl-format
@@ -1,0 +1,1 @@
+(cl-format :fetcher github :repo "alvinfrancis/cl-format")


### PR DESCRIPTION
This adds the Common Lisp format routine. This is an existing package in marmalade with no existing official repo. Consequently, the source has been taken unchanged from the latest version of the marmalade package. Relevant communications found [here](https://github.com/alvinfrancis/spark/issues/1) with the original author of the package on creating this repository.

Link: [cl-format](https://github.com/alvinfrancis/cl-format)