### PR TITLE
Add docker-api recipe

### DIFF
--- a/recipes/docker-api
+++ b/recipes/docker-api
@@ -1,0 +1,1 @@
+(docker-api :fetcher github :repo "Silex/docker-api.el")


### PR DESCRIPTION
Hello,

This package https://github.com/Silex/docker-api.el is a generic interface to https://docs.docker.com/engine/reference/api/docker_remote_api, it's meant to be later used by https://github.com/Silex/docker.el as the "implementation" for it.

@purcell: before you merge, can you enlighten me a little bit about the options I have for dependencies/versioning when I have multiple files?

For example, in `docker.el` I use a pkg file like https://github.com/Silex/docker.el/blob/master/docker-pkg.el. I use this because I copy-pasted from another package... but could I also remove this file and put all the dependencies/version in `docker.el` but not the other files? What is the "best" way to deal with this? With the pkg file I had to specify `:url` otherwise it didn't link back to the repo, is that also a problem if I put the dependencies inside `docker.el` ?

Thanks in advance!