### PR TITLE
Add arview recipe

### DIFF
--- a/recipes/arview
+++ b/recipes/arview
@@ -1,0 +1,1 @@
+(arview :repo "afainer/arview" :fetcher github)


### PR DESCRIPTION
Arview is an Emacs package for viewing archives in temporary
directories.  It extracts an archive file in a temporary directory and
opens a dired buffer for the directory.

The package is useful when archives have big directory trees and it is
inconvenient to view their content with `archive-mode`.  Or if you
want to use external programs on archived files, or copy them to some
other place, or do some sophisticated processing.

Link: https://github.com/afainer/arview
