### PR TITLE
add xref-js2 recipe

### DIFF
--- a/recipes/xref-js2
+++ b/recipes/xref-js2
@@ -1,0 +1,1 @@
+(xref-js2 :fetcher github :repo "NicolasPetton/xref-js2")


### PR DESCRIPTION
### Description

xref-js2 is a package for navigating to definitions or references in JavaScript projects in Emacs.
It adds an xref backend for JavaScript files.

### Repository
https://github.com/NicolasPetton/xref-js2

### Association with the package
Author