### PR TITLE
Add recipe for emms-status

### DIFF
--- a/recipes/emms-status
+++ b/recipes/emms-status
@@ -1,0 +1,1 @@
+(emms-status :repo "alezost/emms-status.el" :fetcher github)


### PR DESCRIPTION
Hello, I was not satisfied with the existing `emms-mode-line`
look, so I wrote an alternative.  Would it be acceptable to add
it to MELPA?

https://github.com/alezost/emms-status.el
