### PR TITLE
Add recipe for helm-systemd

### DIFF
--- a/recipes/helm-systemd
+++ b/recipes/helm-systemd
@@ -1,0 +1,3 @@
+(helm-systemd :repo "lompik/helm-systemd"
+                 :fetcher github
+                 :files ("helm-systemd.el"))


### PR DESCRIPTION
Helm's interface to control systemd units (on linux).

I created of the package.
https://github.com/lompik/helm-systemd

I tested using `emacs -Q` and `package-install-file`. Not sure where to put autoloads magics. Only one function for the user.