### PR TITLE
ycmd - Don't install third-party folder

### DIFF
--- a/recipes/ycmd
+++ b/recipes/ycmd
@@ -1,3 +1,3 @@
 (ycmd :fetcher github
       :repo "abingham/emacs-ycmd"
-      :files ("ycmd.el" "third-party/*.el" "contrib/*.el"))
+      :files ("ycmd.el" "contrib/*.el"))


### PR DESCRIPTION
Since the original repo of `emacs-request` is updatead again (#3797) `ycmd` is using the upstream version of request and we don't need to install the bundled version. 