### PR TITLE
Add ivy recipe

### DIFF
--- a/recipes/ivy
+++ b/recipes/ivy
@@ -1,0 +1,6 @@
+(ivy :repo "abo-abo/swiper"
+     :fetcher github
+     :files ("*.el"
+             (:exclude "swiper.el" "counsel.el")
+             "doc/ivy.texi"
+             "doc/ivy-help.org"))

--- a/recipes/swiper
+++ b/recipes/swiper
@@ -1,8 +1,3 @@
 (swiper :repo "abo-abo/swiper"
         :fetcher github
-        :files ("swiper.el"
-                "ivy.el"
-                "colir.el"
-                "ivy-hydra.el"
-                "doc/ivy.texi"
-                "doc/ivy-help.org"))
+        :files ("swiper.el"))


### PR DESCRIPTION
See abo-abo/swiper#463. 

I've already pushed a `swiper-0.7.0` -> `ivy-0.8.0` rename to GELPA, the build finished successfully locally.  Hopefully the update will be on http://elpa.gnu.org/packages/ soon.

The new recipe for `ivy` includes almost everything in the repo, except `swiper.el` and `counsel.el` which are separate packages on MELPA. I think it should work fine, the only bad situation I can think of is the user having `swiper` and `counsel` installed from MELPA and `ivy` from GELPA, but that situation would be eliminated by auto-upgrading the packages, since the MELPA versions are always newer. Is that correct?
