### PR TITLE
Add the bin and resources folder to slime-docker.

### DIFF
--- a/recipes/slime-docker
+++ b/recipes/slime-docker
@@ -1,1 +1,3 @@
-(slime-docker :repo "daewok/slime-docker" :fetcher github)
+(slime-docker :repo "daewok/slime-docker"
+              :fetcher github
+              :files (:defaults "bin" "resources"))


### PR DESCRIPTION
bin/ currently contains a script to make it easier to forward SSH Agent
into containers on computers using docker-machine.

resources/ currently contains .json files describing seccomp profiles
for Docker, including one needed to get rid of some SBCL warnings.