### PR TITLE
Add recipe for evil-embrace

### DIFF
--- a/recipes/evil-embrace
+++ b/recipes/evil-embrace
@@ -1,0 +1,2 @@
+(evil-embrace :repo "cute-jumper/evil-embrace.el"
+              :fetcher github)


### PR DESCRIPTION
`evil-embrace` provides evil integration of [embrace.el](https://github.com/cute-jumper/embrace.el).

Repo: https://github.com/cute-jumper/evil-embrace.el

This code used to be part of `embrace.el`. Here is [the related discussion](https://github.com/melpa/melpa/pull/3798).

The `evil` dependency should live in the `evil-surround`. I've submitted a [PR](https://github.com/timcharper/evil-surround/pull/77). When that gets merged, the redundant `evil` dependency can be removed.