### PR TITLE
Add a sql-impala Recipe

### DIFF
--- a/recipes/sql-impala
+++ b/recipes/sql-impala
@@ -1,0 +1,1 @@
+(sql-impala :fetcher github :repo "jterk/sql-impala")


### PR DESCRIPTION
'sql-impala' adds basic support for [Cloudera Impala][1] to Emacs' SQL
Mode.

https://github.com/jterk/sql-impala

I am the creator/maintainer of 'sql-impala'.

[1]: http://www.cloudera.com/documentation/enterprise/latest/topics/impala_impala_shell.html