### PR TITLE
Add recipe for yankpad

### DIFF
--- a/recipes/selected
+++ b/recipes/selected
@@ -1,0 +1,1 @@
+(selected :repo "Kungsgeten/selected.el" :fetcher github)

--- a/recipes/steam
+++ b/recipes/steam
@@ -1,0 +1,1 @@
+(steam :repo "Kungsgeten/steam.el" :fetcher github)

--- a/recipes/yankpad
+++ b/recipes/yankpad
@@ -1,0 +1,1 @@
+(yankpad :repo "Kungsgeten/yankpad" :fetcher github)


### PR DESCRIPTION
[Yankpad](https://github.com/Kungsgeten/yankpad) is a way to insert text snippets from an org-mode file. The snippets may use [Yasnippet](https://github.com/capitaomorte/yasnippet) syntax, if the user has Yasnippet installed, but it is not a requirement. I'm the creator and maintainer.

I get a warning from flycheck: `yas-expand-snippet is not known to be defined`. Perhaps I've missed something about how to require packages without actually having them as a dependency.