### PR TITLE
elpy: Remove release branch

### DIFF
--- a/recipes/elpy
+++ b/recipes/elpy
@@ -1,7 +1,6 @@
 (elpy
  :fetcher github
  :repo "jorgenschaefer/elpy"
- :branch "release"
  :files ("elpy.el"
          "elpy-refactor.el"
          "elpy-pkg.el.in"


### PR DESCRIPTION
Elpy development has stabilized sufficiently so that average users can (mostly) safely use the master branch without causing unnecessary workload to the maintainers. Also, MELPA Stable allows users to pick a stable version if they so choose.