### PR TITLE
Add flycheck support for the Pony programming language

### DIFF
--- a/recipes/flycheck-pony
+++ b/recipes/flycheck-pony
@@ -1,0 +1,1 @@
+(flycheck-pony :fetcher github :repo "SeanTAllen/flycheck-pony")


### PR DESCRIPTION
This package provides flycheck support for the Pony programming language. The official repository
is located at https://github.com/SeanTAllen/flycheck-pony. 

I am the current maintainer of flycheck-pony and intend to support it for the forseeable future.