### PR TITLE
starting to phase out scala-mode2

### DIFF
--- a/recipes/scala-mode2
+++ b/recipes/scala-mode2
@@ -1,3 +1,4 @@
 (scala-mode2
  :repo "ensime/emacs-scala-mode"
+ :branch "scala-mode2"
  :fetcher github)


### PR DESCRIPTION
`scala-mode2` has been the de facto standard `scala-mode` for over 3 years now and it is confusing some people.

This is starting the process of phasing out `scala-mode2` and moving to `scala-mode`. Each step needs to wait for a melpa dist.

1. make melpa's `scala-mode2` build off a branch (this PR)
2. swap melpa's definition of `scala-mode` to (what is currently) `scala-mode2`
3. change `scala-mode2` to be a zero content package that depends on `scala-mode`
4. change `ensime` to depend on `scala-mode`, tell everybody to drop their direct dependency on `scala-mode2`
5. should we delete the `scala-mode2` recipe? I would hope it will be preserved in melpa `stable` but be deleted in the dev / unstable repo. We could do the same for `scala-outline-popup` (which is now split into functionality in ensime and the awesome `popup-imenu`).

@reactormonk would you consider moving your `ob-scala` into `scala-mode` as a file with optional dependencies? We do this in `ensime`, the functionality simply wouldn't be available if `ob` is not installed, but `scala-mode` wouldn't depend on `ob`.

FYI (no actions needed, I'm on it :smile:): @hvesalai @milkypostman @bradwright
