### PR TITLE
Add projectile-hanami

### DIFF
--- a/recipes/projectile-hanami
+++ b/recipes/projectile-hanami
@@ -1,0 +1,2 @@
+(projectile-hanami :repo "avdgaag/projectile-hanami"
+                   :fetcher github)


### PR DESCRIPTION
[Projectile Hanami](https://github.com/avdgaag/projectile-hanami) is an Emacs minor mode, based on Projectile, for navigating projects using the Hanami web framework. With Projectile Hanami, you can:

* navigate through entities, repositories, actions, views and templates are
  different apps in your project;
* run `hanami server`
* run `hanami console`
* run Rake tasks

Projectile Hanami is based on Projectile Rails, but is not a complete port of all its functionality. I am the author of the package.