### PR TITLE
systemd: add *.txt files to recipe

### DIFF
--- a/recipes/systemd
+++ b/recipes/systemd
@@ -1,1 +1,3 @@
-(systemd :fetcher github :repo "holomorph/systemd-mode")
+(systemd :fetcher github
+         :repo "holomorph/systemd-mode"
+         :files (:defaults "*.txt"))


### PR DESCRIPTION
i'm storing byte-compile-time data in text files now, as it is much less painful to manage that way