### PR TITLE
Add recipe for hgrc-mode

### DIFF
--- a/recipes/hgrc-mode
+++ b/recipes/hgrc-mode
@@ -1,0 +1,1 @@
+(hgrc-mode :fetcher github :repo "omajid/hgrc-mode")


### PR DESCRIPTION
This recipe adds the [hgrc-mode](https://github.com/omajid/hgrc-mode) package to melpa. This package adds basic syntax highlighting for [`hgrc`](https://www.selenic.com/mercurial/hgrc.5.html) files, which are similar to `gitconfig` files, except for mercurial rather than git.