### PR TITLE
Add recipe `helm-qiita`

### DIFF
--- a/recipes/helm-qiita
+++ b/recipes/helm-qiita
@@ -1,0 +1,1 @@
+(helm-qiita :repo "masutaka/emacs-helm-qiita" :fetcher github)


### PR DESCRIPTION
I want to add [`helm-qiita.el`](https://github.com/masutaka/emacs-helm-qiita). This is a helm interface for [Qiita](https://qiita.com/).

Qiita is a Japanese web service like a little http://stackoverflow.com/ .

Thanks :sparkles: