### PR TITLE
Add recipe for evil-find-char-pinyin

### DIFF
--- a/recipes/evil-find-char-pinyin
+++ b/recipes/evil-find-char-pinyin
@@ -1,0 +1,2 @@
+(evil-find-char-pinyin :repo "cute-jumper/evil-find-char-pinyin"
+                       :fetcher github)


### PR DESCRIPTION
`evil-find-char-pinyin`  adds pinyin support to `evil`'s f/F/t/T commands.

https://github.com/cute-jumper/evil-find-char-pinyin

I'm the maintainer of this package.
