### PR TITLE
Rename emms-status to emms-state

### DIFF
--- a/recipes/emms-state
+++ b/recipes/emms-state
@@ -1,0 +1,1 @@
+(emms-state :repo "alezost/emms-state.el" :fetcher github)

--- a/recipes/emms-status
+++ b/recipes/emms-status
@@ -1,1 +1,0 @@
-(emms-status :repo "alezost/emms-status.el" :fetcher github)


### PR DESCRIPTION
As pointed at https://github.com/alezost/emms-state.el/issues/1
there is another package that provides `emms-status` feature, so
I renamed this one `emms-state`.

Thanks and sorry for worries :-)
