### PR TITLE
evil-lispy: don't specify

### DIFF
--- a/recipes/evil-lispy
+++ b/recipes/evil-lispy
@@ -1,3 +1,2 @@
 (evil-lispy :repo "sp3ctum/evil-lispy"
-            :fetcher github
-            :branch "master")
+            :fetcher github)


### PR DESCRIPTION
The specified "master" branch is the "HEAD branch".  It also is
the only branch.  So it is not necessary to explicitly specify it.