### PR TITLE
get elisp-format directly from the Emacswiki

### DIFF
--- a/recipes/elisp-format
+++ b/recipes/elisp-format
@@ -1,1 +1,1 @@
-(elisp-format :fetcher github :repo "emacsmirror/elisp-format")
+(elisp-format :fetcher wiki)


### PR DESCRIPTION
The repository on the Emacsmirror is created from the file from
the Emacswiki.  Packages from the Emacswiki are only infrequently
updated on the Emacsmirror, so it is better if Melpa gets those
packages directly from the Emacswiki.