### PR TITLE
Add recipe for pinyinlib

### DIFF
--- a/recipes/pinyinlib
+++ b/recipes/pinyinlib
@@ -1,0 +1,2 @@
+(pinyinlib :repo "cute-jumper/pinyinlib.el"
+           :fetcher github)


### PR DESCRIPTION
[ace-pinyin](https://github.com/cute-jumper/ace-pinyin) and [evil-find-char-pinyin](https://github.com/cute-jumper/evil-find-char-pinyin) (PR pending, see https://github.com/melpa/melpa/pull/3843) shares some code. So I extract the common code and put it in this library. If it's OK to merge this, I'll make both `ace-pinyin` and `evil-find-char-pinyin` depend on this package. Both repos have a `use-pinyinlib` branch that uses this package and is ready to be merged.

Some other packages that might also use this library: [find-by-pinyin-dired](https://github.com/redguardtoo/find-by-pinyin-dired) and [pinyin-search](https://github.com/xuchunyang/pinyin-search.el).

https://github.com/cute-jumper/pinyinlib.el