### PR TITLE
Updated files spec for term-cmd.

### DIFF
--- a/recipes/term-cmd
+++ b/recipes/term-cmd
@@ -1,1 +1,1 @@
-(term-cmd :fetcher github :repo "CallumCameron/term-cmd")
+(term-cmd :fetcher github :repo "CallumCameron/term-cmd" :files (:defaults "bin"))


### PR DESCRIPTION
Term-cmd now has a 'bin' folder which needs to be included.