### PR TITLE
dix-evil

### DIFF
--- a/recipes/dix-evil
+++ b/recipes/dix-evil
@@ -1,0 +1,1 @@
+(dix-evil :fetcher github :repo "unhammer/dix" :files ("dix-evil.el"))


### PR DESCRIPTION
Summary: evil integration for dix (dix is a minor mode under nxml for
editing Apertium (machine translation) XML dictionaries and rules files)

Link: https://github.com/unhammer/dix

Association: Author.

(This file is rather trivial, but putting it in the main dix package
would make that depend on Evil, which most users probably wouldn't
want.)