### PR TITLE
Remove flycheck-typescript-tslint package

### DIFF
--- a/recipes/flycheck-typescript-tslint
+++ b/recipes/flycheck-typescript-tslint
@@ -1,1 +1,0 @@
-(flycheck-typescript-tslint :fetcher github :repo "Simplify/flycheck-typescript-tslint")


### PR DESCRIPTION
flycheck-typescript-tslint is now part of Flycheck package.