### PR TITLE
add immortal-scratch recipe

### DIFF
--- a/recipes/immortal-scratch
+++ b/recipes/immortal-scratch
@@ -1,0 +1,3 @@
+(immortal-scratch
+ :fetcher bitbucket
+ :repo "jpkotta/immortal-scratch")


### PR DESCRIPTION
This is a simple global minor mode that respawns the scratch buffer when it's killed, similar to just clearing the buffer.