### PR TITLE
add recipe for highlight-operators

### DIFF
--- a/recipes/highlight-operators
+++ b/recipes/highlight-operators
@@ -1,0 +1,3 @@
+(highlight-operators
+ :repo "jpkotta/highlight-operators"
+ :fetcher bitbucket)


### PR DESCRIPTION
A minor mode for syntax highlighting common operators like '+' and '&'.