### PR TITLE
add elisp-fmt, CLI wrapper around elisp-format

### DIFF
--- a/recipes/elisp-fmt
+++ b/recipes/elisp-fmt
@@ -1,0 +1,4 @@
+(elisp-fmt
+ :fetcher git
+ :url "https://gitlab.com/fommil/elisp-fmt.git"
+ :files ("*.el" "bin"))


### PR DESCRIPTION
as discussed in https://github.com/cask/cask/issues/353 I don't know what needs to be done to get the `bin` directory using `Cask` so just going straight to publish.

1. Do I need to add the `:files` section here? My `Cask` already declares it.
2. Should I really add `*-test.el` to the exclude if I'm planning on adding tests later?