### PR TITLE
Add recipe for restclient-test

### DIFF
--- a/recipes/restclient-test
+++ b/recipes/restclient-test
@@ -1,0 +1,4 @@
+(restclient-test
+ :fetcher github
+ :repo "simenheg/restclient-test.el"
+ :files ("restclient-test.el"))


### PR DESCRIPTION
[restclient-test.el](https://github.com/simenheg/restclient-test.el) is a tool for turning [restclient.el](https://github.com/pashky/restclient.el) documents into interactive test suites.

I'm the package creator, and the repository is here: https://github.com/simenheg/restclient-test.el.

I had to provide `:files` because `*-test.el` is excluded by default.