### PR TITLE
add recipe for scrooge

### DIFF
--- a/recipes/scrooge
+++ b/recipes/scrooge
@@ -1,0 +1,1 @@
+(scrooge :fetcher github :repo "cosmicexplorer/emacs-scrooge")


### PR DESCRIPTION
This is just a copy/paste of the mode provided by [thrift](melpa.org/#/thrift) already; I would normally declare it as a derived mode, but I don't think you can just delete entries from the syntax table as a derived mode, and that's required for this to work; also thrift-mode is < 200 lines anyway. Currently it just highlights lines starting with `#@namespace` nicely (instead of just making them comments like thrift mode currently does).