### PR TITLE
Add markdown-mac-link recipe

### DIFF
--- a/recipes/markdown-mac-link
+++ b/recipes/markdown-mac-link
@@ -1,0 +1,1 @@
+(markdown-mac-link :fetcher github :repo "xuchunyang/markdown-mac-link")


### PR DESCRIPTION
Summary: Insert Markdown links to items selected in various Mac apps
Homepage: https://github.com/xuchunyang/markdown-mac-link