### PR TITLE
Delete python3-info

### DIFF
--- a/recipes/python3-info
+++ b/recipes/python3-info
@@ -1,3 +1,0 @@
-(python3-info
- :repo "dvhansen/python3-info"
- :fetcher github)


### PR DESCRIPTION
python3-info will not build on the server because the build times out. the package is just too big.

@dvhansen any chance there is a better way to do this? it's compiling the info files that is just too much. if they were prebuilt in the repo it might work, otherwise i think we should just remove the recipe.