### PR TITLE
added recipe function-follow

### DIFF
--- a/recipes/function-follow
+++ b/recipes/function-follow
@@ -1,0 +1,3 @@
+(function-follow
+ :fetcher github
+ :repo "aasoliz/Function_Follow")


### PR DESCRIPTION
Function-follow finds a method call's definition within the current buffer, open buffers, or files. 

The github [repo](https://github.com/aasoliz/Function_Follow).

I am both the creater and maintainer of the package.