### PR TITLE
Add pug-mode recipe

### DIFF
--- a/recipes/pug-mode
+++ b/recipes/pug-mode
@@ -1,0 +1,1 @@
+(pug-mode :repo "hlissner/emacs-pug-mode" :fetcher github)


### PR DESCRIPTION
`pug-mode` is a major-mode for [pug](http://jade-lang.com/) templates (formerly Jade), based off of [slim-mode](https://github.com/slim-template/emacs-slim).

* Repository: https://github.com/hlissner/emacs-pug-mode
* I am the author (though pug-mode was adapted from `emacs-slim` — credit is given in the package doc comments)