### PR TITLE
Add recipe for cricbuzz

### DIFF
--- a/recipes/cricbuzz
+++ b/recipes/cricbuzz
@@ -1,0 +1,1 @@
+(cricbuzz :fetcher github :repo "lepisma/cricbuzz.el")


### PR DESCRIPTION
A package to get live Cricket scores and scorecards from [cricbuzz](http://cricbuzz.com)

Full details in the github repository [https://github.com/lepisma/cricbuzz.el](https://github.com/lepisma/cricbuzz.el)