### PR TITLE
get transpose-frame from wiki

### DIFF
--- a/recipes/transpose-frame
+++ b/recipes/transpose-frame
@@ -1,4 +1,1 @@
-(transpose-frame
- :fetcher github
- :repo "pyluyten/emacs-nu"
- :files ("nu-mode/transpose-frame.el"))
+(transpose-frame :fetcher wiki)


### PR DESCRIPTION
Getting this package from the nu-mode repository (see #3757) was a
mistake because that isn't the upstream repository, it just bundled
this third-party library.  And now the nu-mode repository no longer
bundles transpose-frame.el.