### PR TITLE
Add eshell-fringe-status

### DIFF
--- a/recipes/eshell-fringe-status
+++ b/recipes/eshell-fringe-status
@@ -1,0 +1,1 @@
+(eshell-fringe-status :fetcher github :repo "ryuslash/eshell-fringe-status")


### PR DESCRIPTION
This package shows an indicator in Emacs' fringe indicating the exit status (succeeded, failed) of the last command executed in eshell.

Link: https://github.com/ryuslash/eshell-fringe-status

I am the maintainer/author of this package.