### PR TITLE
New recipe: bnfc-mode

### DIFF
--- a/recipes/bnfc
+++ b/recipes/bnfc
@@ -1,0 +1,3 @@
+(bnfc
+  :repo "jmitchell/bnfc-mode"
+  :fetcher github)


### PR DESCRIPTION
BNFC is useful for defining context-free grammars as labelled-BNFs.
These files may be compiled into parser implementations in several
programming languages, pygments syntax highlighting, and
documentation.

Currently the mode provides basic font-locking support. I am the
author and current maintainer.

Repo: https://github.com/jmitchell/bnfc-mode