### PR TITLE
prettify-symbols for Greek and move darcula-theme to gitlab

### DIFF
--- a/recipes/darcula-theme
+++ b/recipes/darcula-theme
@@ -1,2 +1,2 @@
-(darcula-theme :fetcher github
-               :repo "fommil/darcula-theme-emacs")
+(darcula-theme :fetcher gitlab
+               :repo "fommil/emacs-darcula-theme")

--- a/recipes/prettify-greek
+++ b/recipes/prettify-greek
@@ -1,0 +1,3 @@
+(prettify-greek
+ :fetcher gitlab
+ :repo "fommil/emacs-prettify-greek")


### PR DESCRIPTION
since the FSF gave gitlab an A rating, I'm thinking of moving all my personal emacs projects to gitlab.

- https://gitlab.com/fommil/emacs-darcula-theme
- https://gitlab.com/fommil/emacs-prettify-greek