### PR TITLE
Add intero recipe (new package)

### DIFF
--- a/recipes/intero
+++ b/recipes/intero
@@ -1,0 +1,3 @@
+(intero :repo "commercialhaskell/intero" 
+        :fetcher github
+        :files ("elisp/intero.el"))


### PR DESCRIPTION
Intero is a new Haskell package. It depends on flycheck and company, and the two built-in packages cl-lib and comint. haskell-mode is also necessary for the flycheck mode. Test on Emacs 24.5.1. More information here http://commercialhaskell.github.io/intero But I'm waiting until the package is in MELPA before adding "how to get" to the page.