### PR TITLE
add recipe emacs-profiles

### DIFF
--- a/recipes/emacs-profiles
+++ b/recipes/emacs-profiles
@@ -1,0 +1,1 @@
+(emacs-profiles :repo "myTerminal/emacs-profiles" :fetcher github)


### PR DESCRIPTION
This package can be used to declare multiple configuration sets as profiles and name them to be able to load them as and when required. These declared configuration profiles can also be loaded at Emacs startup.

The package repository can be found at [https://github.com/myTerminal/emacs-profiles](https://github.com/myTerminal/emacs-profiles).

I am the creator and maintainer of this package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/melpa/melpa/3960)
<!-- Reviewable:end -->
