### PR TITLE
Add tern-context-coloring recipe

### DIFF
--- a/recipes/tern-context-coloring
+++ b/recipes/tern-context-coloring
@@ -1,0 +1,3 @@
+(tern-context-coloring :fetcher github
+                       :repo "jacksonrayhamilton/tern-context-coloring"
+                       :files ("emacs/tern-context-coloring.el"))


### PR DESCRIPTION
This package allows for [tern](https://github.com/ternjs/tern) with the [tern-context-coloring](https://github.com/jacksonrayhamilton/tern-context-coloring) Node.js plugin to function as a back-end for [context coloring](https://github.com/jacksonrayhamilton/context-coloring) in Emacs.

Package repository: https://github.com/jacksonrayhamilton/tern-context-coloring

I am the maintainer.

To verify that this works, you can use `make sandbox` and `package-install` `tern-context-coloring`. Create a `.tern-config` file with the contents `{"plugins":{"context-coloring":{"charOffset":1}}}` in your home directory. Have Node.js installed (tested with version 6.2,1), `tern` and `tern-context-coloring` installed via npm (`npm i -g tern`, `git clone https://github.com/jacksonrayhamilton/tern-context-coloring.git && cd tern-context-coloring && npm link` [I will publish this package very soon]). Then visit a JavaScript buffer, do `tern-mode`, then do `context-coloring-mode`, and the functions and variables in the buffer should be colored according to their scope depth.

Or if that's too much of a hassle, just check if the functions got autoloaded. :) Tested this all myself and it worked.