### PR TITLE
Add grab-mac-link and remove markdown-mac-link

### DIFF
--- a/recipes/grab-mac-link
+++ b/recipes/grab-mac-link
@@ -1,0 +1,1 @@
+(grab-mac-link :fetcher github :repo "xuchunyang/grab-mac-link.el")

--- a/recipes/markdown-mac-link
+++ b/recipes/markdown-mac-link
@@ -1,1 +1,0 @@
-(markdown-mac-link :fetcher github :repo "xuchunyang/markdown-mac-link")


### PR DESCRIPTION
Repo: https://github.com/xuchunyang/grab-mac-link.el
Description: Grab link from Mac Apps and insert it into Emacs

markdown-mac-link is removed by the way, becuase grab-mac-link makes it
unneeded.