### PR TITLE
Add new yapfify recipe.

### DIFF
--- a/recipes/yapfify
+++ b/recipes/yapfify
@@ -1,0 +1,1 @@
+(yapfify :repo "JorisE/yapfify" :fetcher github)


### PR DESCRIPTION
Yapfify can be used to (automatically) call the python formatter [YAPF](https://github.com/google/yapf) on a buffer.