### PR TITLE
Add netrunner recipe.

### DIFF
--- a/recipes/netrunner
+++ b/recipes/netrunner
@@ -1,0 +1,1 @@
+(netrunner :repo "Kungsgeten/netrunner" :fetcher github)


### PR DESCRIPTION
`netrunner` is a package adding `company-mode` and `helm` support for creating decklists for the _Android: Netrunner_ card game by Fantasy Flight Games, primarily using `org-mode`. I'm the creator and maintainer.

It requires Emacs 25 due to `if-let` and `when-let`, but perhaps I should refactor in order to make it possible to use Emacs 24? I guess the number of people who wants to use this package is fairly small :)