### PR TITLE
Add unicocde-escape recipe

### DIFF
--- a/recipes/unicode-escape
+++ b/recipes/unicode-escape
@@ -1,0 +1,1 @@
+(unicode-escape :fetcher github :repo "kosh04/unicode-escape.el")


### PR DESCRIPTION
https://github.com/kosh04/unicode-escape.el

I think it is easy to use, but export functions `unicode-unescape` and `unicode-unescape-region`
might have deviate from the rule of package namespace.

I'll be modify these codes if necessary.