### PR TITLE
Create org-ref-ivy

### DIFF
--- a/recipes/org-ref
+++ b/recipes/org-ref
@@ -1,1 +1,4 @@
-(org-ref :fetcher github :repo "jkitchin/org-ref" :files (:defaults "org-ref.org" "org-ref.bib" "citeproc"))
+(org-ref-helm :fetcher github
+              :repo "jkitchin/org-ref"
+              :files ("org-ref-helm*.el"))
+

--- a/recipes/org-ref
+++ b/recipes/org-ref
@@ -1,4 +1,4 @@
-(org-ref-helm :fetcher github
-              :repo "jkitchin/org-ref"
-              :files ("org-ref-helm*.el"))
+(org-ref :fetcher github
+	 :repo "jkitchin/org-ref"
+	 :files ("org-ref-helm*.el"))
 

--- a/recipes/org-ref-core
+++ b/recipes/org-ref-core
@@ -1,0 +1,6 @@
+(org-ref-core :fetcher github
+	      :repo "jkitchin/org-ref"
+	      :files (:defaults
+		      "org-ref.org" "org-ref.bib" "citeproc"
+		      (:exclude "org-ref-ivy*.el" "org-ref-helm*.el")))
+

--- a/recipes/org-ref-ivy
+++ b/recipes/org-ref-ivy
@@ -1,0 +1,4 @@
+(org-ref-ivy :fetcher github :repo "jkitchin/org-ref"
+	     :files (:defaults
+		     "org-ref.org" "org-ref.bib" "citeproc"
+		     :exclude "*helm*"))

--- a/recipes/org-ref-ivy
+++ b/recipes/org-ref-ivy
@@ -1,4 +1,4 @@
 (org-ref-ivy :fetcher github :repo "jkitchin/org-ref"
 	     :files (:defaults
 		     "org-ref.org" "org-ref.bib" "citeproc"
-		     :exclude "*helm*"))
+		     (:exclude "*helm*")))

--- a/recipes/org-ref-ivy
+++ b/recipes/org-ref-ivy
@@ -1,4 +1,3 @@
-(org-ref-ivy :fetcher github :repo "jkitchin/org-ref"
-	     :files (:defaults
-		     "org-ref.org" "org-ref.bib" "citeproc"
-		     (:exclude "*helm*")))
+(org-ref-ivy :fetcher github
+             :repo "jkitchin/org-ref"
+             :files ("org-ref-ivy*.el"))


### PR DESCRIPTION
This is an org-ref variant that does not depend on helm, and uses ivy instead.