### PR TITLE
new recipe - obvious parentheses

### DIFF
--- a/recipes/obvious-parentheses
+++ b/recipes/obvious-parentheses
@@ -1,0 +1,1 @@
+(obvious-parentheses :repo "bigos/obvious-parentheses" :fetcher github)


### PR DESCRIPTION
I thought i might be useful to be able to tweak colours of rainbow-delimiters irrespective of colours decided upon you by theme. My suggestion adds easily discernible colours which might make Lisp editing easier.