### PR TITLE
Add editorconfig-custom-majormode recipe

### DIFF
--- a/recipes/editorconfig-custom-majormode
+++ b/recipes/editorconfig-custom-majormode
@@ -1,0 +1,2 @@
+(editorconfig-custom-majormode :fetcher github
+                               :repo "10sr/editorconfig-custom-majormode-el")


### PR DESCRIPTION
editorconfig-custom-majormode is an [EditorConfig](http://editorconfig.org) extension that defines a property to specify which Emacs major-mode to use for files.

I'm the author of this package.

https://github.com/10sr/editorconfig-custom-majormode-el