### PR TITLE
Adding a recipe for pyimport

### DIFF
--- a/recipes/pyimport
+++ b/recipes/pyimport
@@ -1,0 +1,1 @@
+(pyimport :repo "Wilfred/pyimport" :fetcher github)


### PR DESCRIPTION
Pyimport is a package I've written that automates the process of adding or removing imports in Python scripts.

See the [GIFs in the readme](https://github.com/Wilfred/pyimport) for more details.