### PR TITLE
Add palette-emacs-theme recipe

### DIFF
--- a/recipes/palette-theme
+++ b/recipes/palette-theme
@@ -1,3 +1,4 @@
-(palette :repo "aslpavel/palette-emacs-theme"
-         :fetcher github
-         :files ("palette-theme.el"))
+(palette-theme 
+ :repo "aslpavel/palette-emacs-theme"
+ :fetcher github
+ :files ("palette-theme.el"))

--- a/recipes/palette-theme
+++ b/recipes/palette-theme
@@ -1,4 +1,3 @@
 (palette-theme 
  :repo "aslpavel/palette-emacs-theme"
- :fetcher github
- :files ("palette-theme.el"))
+ :fetcher github)

--- a/recipes/palette-theme
+++ b/recipes/palette-theme
@@ -1,0 +1,3 @@
+(palette :repo "aslpavel/palette-emacs-theme"
+         :fetcher github
+         :files ("palette-theme.el"))


### PR DESCRIPTION
Color palette based Emacs theme. Can be easily extended to support more color palettes.
Comes with gruvbox-{dark,light} included. Please read README.md for details.