### PR TITLE
Add switch-buffer-functions recipe

### DIFF
--- a/recipes/switch-buffer-functions
+++ b/recipes/switch-buffer-functions
@@ -1,0 +1,2 @@
+(switch-buffer-functions :fetcher github
+                         :repo "10sr/switch-buffer-functions-el")


### PR DESCRIPTION
This package provides a hook variable <del>`post-command-current-buffer-changed-functions`</del> `switch-buffer-functions`, which will be run when the current buffer has been changed after each interactive command.

I'm the author of this pckage.

<del>https://github.com/10sr/post-command-current-buffer-changed-functions-el</del>
https://github.com/10sr/switch-buffer-functions-el
