### PR TITLE
Add recipe for parsec.el

### DIFF
--- a/recipes/parsec
+++ b/recipes/parsec
@@ -1,0 +1,2 @@
+(parsec :repo "cute-jumper/parsec.el"
+        :fetcher github)


### PR DESCRIPTION
This is a parser combinator library for Emacs Lisp, which is similar to Haskell's Parsec.

https://github.com/cute-jumper/parsec.el

I'm the maintainer of this package.