### PR TITLE
Add editorconfig-domain-specific recipe

### DIFF
--- a/recipes/editorconfig-domain-specific
+++ b/recipes/editorconfig-domain-specific
@@ -1,0 +1,3 @@
+(editorconfig-domain-specific
+ :fetcher github
+ :repo "lassik/editorconfig-emacs-domain-specific")


### PR DESCRIPTION
This is a hook for the Emacs EditorConfig package that adds support for the unofficial/semi-official "indent_brace_style" property. Other properties will hopefully follow in future versions.

Repo: https://github.com/lassik/editorconfig-emacs-domain-specific

I am the maintainer (just wrote this :))