### PR TITLE
Add recipe for org2elcomment

### DIFF
--- a/recipes/org2elcomment
+++ b/recipes/org2elcomment
@@ -1,0 +1,2 @@
+(org2elcomment :repo "cute-jumper/org2elcomment"
+               :fetcher github)


### PR DESCRIPTION
This package is mainly used to convert an org-mode file to the comments of an Elisp source code. It is a very simple package so I'm not sure whether it is worth being on melpa.

https://github.com/cute-jumper/org2elcomment

I'm the maintainer of this package.