### PR TITLE
Added ssh-deploy recipe

### DIFF
--- a/recipes/ssh-deploy
+++ b/recipes/ssh-deploy
@@ -1,0 +1,1 @@
+(ssh-deploy :repo "cjohansson/emacs-ssh-deploy" :fetcher github)


### PR DESCRIPTION
ssh-deploy enables optional automatic uploads and manual uploads, downloads and diffs via key-paired authorized password-less ssh-connections globally or on a per directory basis via DirectoryVariables. It is useful when working with local files that are deployed to remote hosts.

It uses local scp for transfers (upload/download) and tramp and ediff for diffs. I am the maintainer and creator of the package. I have tested the package with the tests on the https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md page.

https://github.com/cjohansson/emacs-ssh-deploy