### PR TITLE
Create kodi-remote

### DIFF
--- a/recipes/kodi-remote
+++ b/recipes/kodi-remote
@@ -1,0 +1,1 @@
+(kodi-remote :fetcher github :repo "spiderbit/kodi-remote.el")


### PR DESCRIPTION
Want to make my kodi/json functions to remote control kodi availible on melpa.

its no complete remote at the moment, but you can use it to start music party mode, or send a youtube url to your kodi machine.

It has some minor issues maybe at the moment:
1. the youtube-feature depends on having youtube-dl installed
2. I have at the moment a absolute path to youtube-dl inside the kodi which works fine for most linux distros, but some distros like nixos have different paths.
3. at least this youtube-feature works only under linux or maybe other unixes, but not windows.

But it works good enough to be usefull to others I think.

And yes I am the author.