### PR TITLE
added recipe xah-css-mode

### DIFF
--- a/recipes/xah-css-mode
+++ b/recipes/xah-css-mode
@@ -1,0 +1,1 @@
+(xah-css-mode :repo "xahlee/xah-css-mode" :fetcher github)


### PR DESCRIPTION
major mode for CSS. Alternative to emacs builtin one. Major diff is that only exact CSS words are colored. (For example, class names are not colored.) And keyword completion for all CSS words.

A direct link to the package repository:
https://github.com/xahlee/xah-css-mode

I'm the author.

Thanks Steve Purcell.