### PR TITLE
Buffer Layers is now Buffer Sets

### DIFF
--- a/recipes/buffer-layers
+++ b/recipes/buffer-layers
@@ -1,1 +1,0 @@
-(buffer-layers :repo "swflint/buffer-layers" :fetcher github)

--- a/recipes/buffer-sets
+++ b/recipes/buffer-sets
@@ -1,0 +1,1 @@
+(buffer-sets :repo "swflint/buffer-sets" :fetcher github)


### PR DESCRIPTION
I'm renaming my packages to Buffer Sets, and would like to have that fixed in Melpa.