### PR TITLE
widgetjs, minor mode for the widgetjs js library

### DIFF
--- a/recipes/widgetjs
+++ b/recipes/widgetjs
@@ -1,0 +1,1 @@
+(widgetjs :fetcher github :repo "foretagsplatsen/emacs-js" :files ("widgetjs/widgetjs.el"))


### PR DESCRIPTION
repository: https://github.com/foretagsplatsen/emacs-js

association: I need the package and the maintainer (Nicolas Petton)
asked me to package it on melpa:
https://github.com/foretagsplatsen/emacs-js/issues/1. widgetjs is a
sub-project of emacs-js which will get a separate PR to melpa.

communication: I got write access to the repository and did a few
changes to permit packaging on melpa:
a1e91bdcecdea50c80f5ff87f7a4f7a2c249713e (and the following)