### PR TITLE
Modify window-purpose recipe: include subdirectory

### DIFF
--- a/recipes/window-purpose
+++ b/recipes/window-purpose
@@ -1,3 +1,4 @@
 (window-purpose :repo "bmag/emacs-purpose"
                 :fetcher github
+                :files (:defaults "layouts")
                 :old-names (purpose))


### PR DESCRIPTION
Hey, I'd like to bundle a few preconfigured window layouts with my package. The layouts are contained inside a "layouts" subdirectory in my project, and the new recipe should catch all the elisp files in the project toplevel and the layouts directory, and no more. I tested the new recipe locally with quelpa and it seems to work.

I used Yasnippet's [recipe](https://github.com/melpa/melpa/blob/master/recipes/yasnippet) as reference. For your convenience, here is a [link](https://github.com/bmag/emacs-purpose) to my project.