### PR TITLE
Include css for documentation

### DIFF
--- a/recipes/m-buffer
+++ b/recipes/m-buffer
@@ -1,3 +1,5 @@
 (m-buffer :fetcher github :repo "phillord/m-buffer-el"
           :files (:defaults
-                  "m-buffer-doc.org"))
+                  "m-buffer-doc.org"
+                  "m-buffer-doc.css"))
+


### PR DESCRIPTION
m-buffer is documented directly within Emacs with HTML generated from
the source code. The CSS file defines the style for this HTML.