### PR TITLE
Add keyswap-mode recipe

### DIFF
--- a/recipes/keyswap-mode
+++ b/recipes/keyswap-mode
@@ -1,0 +1,1 @@
+(keyswap-mode :repo "hardenedapple/keyswap-mode.el" :fetcher github)


### PR DESCRIPTION
Add keyswap-mode recipe.

I wrote this package.

https://github.com/hardenedapple/keyswap-mode.el

This mode allows swapping a set of keys on a per-major-mode basis.

e.g. In programming languages it's often useful to switch the numeric keys and their shifted counterparts so the more frequent keys are easier to press.