### PR TITLE
Add keyswap recipe

### DIFF
--- a/recipes/keyswap
+++ b/recipes/keyswap
@@ -1,0 +1,1 @@
+(keyswap :repo "hardenedapple/keyswap.el" :fetcher github)


### PR DESCRIPTION
After implementing the changes from the previously named 'keyswap-mode.el' package.

Add keyswap recipe.

I wrote this package.

https://github.com/hardenedapple/keyswap.el

This mode allows swapping a set of keys on a per-major-mode basis.

e.g. In programming languages it's often useful to switch the numeric keys and their shifted counterparts so the more frequent keys are easier to press.
