### PR TITLE
Add `org-commentary` recipe

### DIFF
--- a/recipes/org-commentary
+++ b/recipes/org-commentary
@@ -1,0 +1,3 @@
+(org-commentary :repo "smaximov/org-commentary"
+                :fetcher github
+                :files (:defaults "bin"))

--- a/recipes/org-doc
+++ b/recipes/org-doc
@@ -1,3 +1,0 @@
-(org-doc :repo "smaximov/org-doc"
-         :fetcher github
-         :files (:defaults "bin"))

--- a/recipes/org-doc
+++ b/recipes/org-doc
@@ -1,0 +1,3 @@
+(org-doc :repo "smaximov/org-doc"
+         :fetcher github
+         :files (:defaults "bin"))


### PR DESCRIPTION
(**EDIT**: the package name was changed from `org-doc`  to `org-commentary`).

General info:

* Summary: generate or update conventional [library headers][headers] using Org mode files.
* URL: https://github.com/smaximov/org-commentary.
* My association with the package: author/maintainer.

[headers]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html