### PR TITLE
add recipe for mode-on-region

### DIFF
--- a/recipes/mode-on-region
+++ b/recipes/mode-on-region
@@ -1,0 +1,1 @@
+(mode-on-region :repo "miketz/mor" :fetcher github)


### PR DESCRIPTION
I'd like to add my package "mode-on-region" to melpa.  
It's for working with code in multi-language files. You select a region of text. The region is opened in a new buffer with a dedicated language mode. Edits are copied back to the original buffer.

The github repo is at https://github.com/miketz/mor

I'm the only author.

