### PR TITLE
Add recipe for cubicaltt

### DIFF
--- a/recipes/cubicaltt
+++ b/recipes/cubicaltt
@@ -1,0 +1,4 @@
+(cubicaltt
+ :fetcher github
+ :repo "mortberg/cubicaltt"
+ :files ("cubicaltt.el"))


### PR DESCRIPTION
This recipe builds the Emacs major mode for cubical, an implementation of cubical type theory developed at Chalmers.

I am neither the primary developer of cubicaltt nor this mode, but I did get permission from the developer to add it to MELPA. I'm also willing to update the recipe should it prove necessary, but this has never happened with the other recipes that I have on MELPA. I have also contributed a couple of features to the mode.

This was discussed at https://github.com/mortberg/cubicaltt/pull/45 , and the package headers were added at https://github.com/mortberg/cubicaltt/pull/46 .

CC @mortberg