### PR TITLE
Add recipe for all-the-icons

### DIFF
--- a/recipes/all-the-icons
+++ b/recipes/all-the-icons
@@ -1,4 +1,4 @@
 (all-the-icons
- :repo "domtronn/all-the-icons"
+ :repo "domtronn/all-the-icons.el"
  :fetcher github
  :files ("all-the-icons.el" ("data" "data/*.el")))

--- a/recipes/all-the-icons
+++ b/recipes/all-the-icons
@@ -1,0 +1,4 @@
+(all-the-icons
+ :repo "domtronn/all-the-icons"
+ :fetcher github
+ :files ("all-the-icons.el" ("data" "data/*.el")))

--- a/recipes/all-the-icons
+++ b/recipes/all-the-icons
@@ -1,4 +1,4 @@
 (all-the-icons
  :repo "domtronn/all-the-icons.el"
  :fetcher github
- :files ("all-the-icons.el" ("data" "data/*.el")))
+ :files (:defaults "data"))


### PR DESCRIPTION
https://github.com/domtronn/all-the-icons.el

Hi there, this recipe adds a helper package for using Icon Fonts within Emacs which can be properly propertized and formatted like any other text, for things like mode lines, file trees, tabs etc.

I've added in the `ttf` font files as part of the repo, and linked through to their respective licenses, all of which allow for distribution and re-use.

I am the maintainer of the package.