### PR TITLE
Add gg-find-def recipe

### DIFF
--- a/recipes/gg-find-def
+++ b/recipes/gg-find-def
@@ -1,0 +1,2 @@
+(gg-find-def :fetcher github
+             :repo "mallt/gg-find-def")


### PR DESCRIPTION
- gg-find-def is a function to find the definition of a symbol in a git repository using git grep
- repository url: https://github.com/mallt/gg-find-def
- I am the author of the package

