### PR TITLE
move flymake-cursor source from wiki to github

### DIFF
--- a/recipes/flymake-cursor
+++ b/recipes/flymake-cursor
@@ -1,2 +1,2 @@
-(flymake-cursor :fetcher wiki)
+(flymake-cursor :repo "illusori/emacs-flymake-cursor" :fetcher github)
 


### PR DESCRIPTION
MELPA currently sources ```flymake-cursor``` from the emacswiki, which as I understand it makes it impossible to tag and get into MELPA Stable.  I'm trying to transition over to using just MELPA Stable for my packages, and I happen to use this package quite a bit (it's great!).  My hope is that this pull request gets merged, and then since the ```emacs-flymake-cursor``` [repo](https://github.com/illusori/emacs-flymake-cursor) already has a tag (1.0.2) it'll automatically get included in the next melpa stable build.

I hope that makes sense - I'm not the author/maintainer of the ```emacs-flymake-cursor``` github repo, so I'm not sure if this is the correct way forward.  I searched around previous issues and found https://github.com/melpa/melpa/issues/3905

Also maybe worth noting, this github repo is the one that marmalade uses to provide the package.