### PR TITLE
Floobits requires its own patched highlight.el

### DIFF
--- a/recipes/floobits
+++ b/recipes/floobits
@@ -1,4 +1,4 @@
 (floobits
  :fetcher github
  :repo "Floobits/floobits-emacs"
- :files ("floo" "floobits.el" "floobits.py"))
+ :files ("floo" "floobits.el" "highlight.el" "floobits.py"))


### PR DESCRIPTION
On Fri, 1 Jul 2016, at 03:20 AM, Geoff Greer wrote:
> Floobits bundles its own patched highlight.el. It should work fine as long as MELPA hasn’t stripped that file from the Floobits package.