### PR TITLE
point flymake-cursor repo to my github fork

### DIFF
--- a/recipes/flymake-cursor
+++ b/recipes/flymake-cursor
@@ -1,2 +1,2 @@
-(flymake-cursor :repo "illusori/emacs-flymake-cursor" :fetcher github)
+(flymake-cursor :repo "ryoung786/emacs-flymake-cursor" :fetcher github)
 

--- a/recipes/flymake-cursor
+++ b/recipes/flymake-cursor
@@ -1,2 +1,2 @@
-(flymake-cursor :repo "ryoung786/emacs-flymake-cursor" :fetcher github)
+(flymake-cursor :repo "flymake/emacs-flymake-cursor" :fetcher github)
 


### PR DESCRIPTION
As discussed in https://github.com/melpa/melpa/pull/4086

If this is not necessary (as I've only added a warning to the repo readme to advise switching to flycheck), feel free to reject the pull request.