### PR TITLE
remove org-eww due to name conflict

### DIFF
--- a/recipes/org-eww
+++ b/recipes/org-eww
@@ -1,1 +1,0 @@
-(org-eww :fetcher github :repo "lujun9972/org-eww")


### PR DESCRIPTION
Org itself comes with a library named `org-eww`.  It can be found here: http://repo.or.cz/org-mode.git/blob/ddd58ff99a8684f6bcae24ffa5050857f533e26d:/contrib/lisp/org-eww.el.

I have made the author of the third-party org-eww aware of this (https://github.com/lujun9972/org-eww/issues/5).  Unfortunately they haven't replied yet.

This org-eww that isn't part of Org is newer and should be remove from Melpa until upstream has renamed it.