### PR TITLE
Update ledger-mode recipe to reflect its new home.

### DIFF
--- a/recipes/ledger-mode
+++ b/recipes/ledger-mode
@@ -1,1 +1,1 @@
-(ledger-mode :fetcher github :repo "ledger/ledger" :files ("lisp/*.el") :branch "next" :old-names (ldg-mode))
+(ledger-mode :fetcher github :repo "ledger/ledger-mode" :files ("*.el") :old-names (ldg-mode))


### PR DESCRIPTION
See ledger/ledger@15d18d664f0e9c5e454bf4927f7d0e0bca02b0c2 and the
recent mailing list discussion on ledger-cli.

Since old elisp files were removed from the next branch of
ledger/ledger, the old recipe does not work at all any more.