### PR TITLE
remove rnc-mode

### DIFF
--- a/recipes/rnc-mode
+++ b/recipes/rnc-mode
@@ -1,1 +1,0 @@
-(rnc-mode :fetcher github :repo "TreeRex/rnc-mode")


### PR DESCRIPTION
A new implementation is now part of GNU Elpa.  The repository that
used to provide the old implementation has been updated to instead
provide a copy of the implementation from Elpa.  This might have
been done in response to https://github.com/TreeRex/rnc-mode/issues/7.

The file "externals-list" in the Elpa repository does not contain
an entry for `rnc-mode`, so I doubt that the author of the old
implementation has offered to maintain the new implementation now.

/cc @TreeRex 