### PR TITLE
Add the ‘hasky-extensions’ package

### DIFF
--- a/recipes/hasky-extensions
+++ b/recipes/hasky-extensions
@@ -1,0 +1,3 @@
+(hasky-extensions
+ :repo "hasky-mode/hasky-extensions"
+ :fetcher github)


### PR DESCRIPTION
Quickly toggle Haskell language extensions.

The repo: https://github.com/hasky-mode/hasky-extensions.