### PR TITLE
Add coq commentor package

### DIFF
--- a/recipes/coq-commenter
+++ b/recipes/coq-commenter
@@ -1,0 +1,3 @@
+(coq-commentor
+ :repo "ailrun/coq-commenter"
+ :fetcher github)


### PR DESCRIPTION
Add new package for comment supporting for [coq](https://coq.inria.fr/) proof assistant.