### PR TITLE
Add coq commenter package

### DIFF
--- a/recipes/coq-commenter
+++ b/recipes/coq-commenter
@@ -1,0 +1,3 @@
+(coq-commenter
+ :repo "ailrun/coq-commenter"
+ :fetcher github)


### PR DESCRIPTION
Add new package for comment supporting for [coq](https://coq.inria.fr/) proof assistant.

Fix some issues of [previous pr](https://github.com/melpa/melpa/pull/4112)