### PR TITLE
Added haxe-imports recipe

### DIFF
--- a/recipes/haxe-imports
+++ b/recipes/haxe-imports
@@ -1,0 +1,3 @@
+(haxe-imports
+ :fetcher github
+ :repo "accidentalrebel/emacs-haxe-imports")


### PR DESCRIPTION
Code for dealing with Haxe imports

This package is based on java-imports by Mathew Lee Hinman found here http://www.github.com/dakrone/emacs-java-imports.

This package adds the import-haxe-class function, which will prompt for the class at point, then the package, then add the required import statement for the class and cache a "class-name -> package" relationship for any future importing of the class.

URL: http://www.github.com/dakrone/emacs-haxe-imports
