### PR TITLE
Add recipe for lcb-mode (LiveCode Builder major mode)

### DIFF
--- a/recipes/lcb-mode
+++ b/recipes/lcb-mode
@@ -1,0 +1,2 @@
+(lcb-mode :repo "peter-b/lcb-mode"
+          :fetcher github)


### PR DESCRIPTION
I'm the author of [lcb-mode](https://github.com/peter-b/lcb-mode), a major mode for LiveCode Builder (LCB) programming.  LiveCode Builder is a compiled language with English-like syntax that was originally developed for developing extensions for the [LiveCode](https://github/livecode) engine and IDE.  This patch adds a recipe for packaging it in MELPA.