### PR TITLE
Added recipe for digit-groups

### DIFF
--- a/recipes/digit-groups
+++ b/recipes/digit-groups
@@ -1,0 +1,1 @@
+(digit-groups :fetcher bitbucket :repo "adamsmd/digit-groups")


### PR DESCRIPTION
Hi, I recently developed the `digit-groups` package and would like to release it on MELPA.

# Brief summary of what the package does.

The `digit-groups` Emacs package makes it easier to read large numbers by
highlighting digits at selected place-value positions (e.g., thousands place,
millions place, billions place, etc.).

For example, in the text `9876543210.123456789`, the default configuration
formats in bold the 3, 6, and 9 before the decimal (`.`) because they are in
the thousands, millions, and billions positions as well as the 3, 6, and 9
after the decimal (`.`) because they are in the thousandths, millionths, and
billionths positions.

# Direct link to the package repository.

https://bitbucket.org/adamsmd/digit-groups

# My association with the package

I am the developer of this package

# Relevant communications with the upstream package maintainer

None.
