### PR TITLE
Add RedPRL mode to MELPA

### DIFF
--- a/recipes/redprl
+++ b/recipes/redprl
@@ -1,0 +1,4 @@
+(redprl
+ :fetcher github
+ :repo "RedPRL/sml-redprl"
+ :files ("emacs/*.el"))


### PR DESCRIPTION
RedPRL is a proof assistant in the tradition of NuPRL, with support for
features such as nominal reasoning and dependent refinement.

The Emacs support is now developed as part of the proof assistant, at
https://github.com/RedPRL/sml-redprl/ .

I am a minor contributor to `redprl-mode`, but the maintainer (@jonsterling) understands
that I am submitting this to MELPA. We discussed it here: https://github.com/RedPRL/sml-redprl/pull/105