### PR TITLE
Added version-regexp for enh-ruby-mode

### DIFF
--- a/recipes/enh-ruby-mode
+++ b/recipes/enh-ruby-mode
@@ -1,3 +1,4 @@
 (enh-ruby-mode :repo "zenspider/enhanced-ruby-mode"
                :fetcher github
+               :version-regexp "[^0-9]*\\(.*\\)"
                :files ("*.el" ("ruby" "ruby/erm.rb" "ruby/erm_buffer.rb")))


### PR DESCRIPTION
I think this should fix the issue for stable? @Trevoke ?

I tested this via the usual path. But I'm unsure that it also tests the stable packaging/data...