### PR TITLE
recipes/x-path-walker: Include xpathwalker module

### DIFF
--- a/recipes/x-path-walker
+++ b/recipes/x-path-walker
@@ -1,2 +1,3 @@
 (x-path-walker   :fetcher github
-                 :repo "lompik/x-path-walker")
+                 :repo "lompik/x-path-walker"
+                 :files (:defaults "xpathwalker"))


### PR DESCRIPTION
x-path-walker needs the `xpathwalker` which is added to [python path](https://github.com/lompik/x-path-walker/blob/6c6d839/x-path-walker.el#L36-L39) before calling the command

cc: @Lompik 