### PR TITLE
y-ret-or-n-p recipe

### DIFF
--- a/recipes/y-ret-or-n-p
+++ b/recipes/y-ret-or-n-p
@@ -1,0 +1,1 @@
+(y-ret-or-n-p :fetcher github :repo "sancoder-q/y-ret-or-n-p.el")


### PR DESCRIPTION
**y-ret-or-n-p.el** is a simple emacs plugin for replacing the original function `yes-or-no-p` and `y-or-n-p` in order to make your agreement faster.

https://github.com/SanCoder-Q/y-ret-or-n-p.el