### PR TITLE
Recipe programming-mode

### DIFF
--- a/recipes/programming-mode
+++ b/recipes/programming-mode
@@ -1,0 +1,1 @@
+(programming-mode :repo "Liu233w/programming-mode.el" :fetcher github)


### PR DESCRIPTION
https://github.com/Liu233w/programming-mode.el

Input method to exchange your number line with the mark above it.

For example, when you press 1, ! will be entered. If ! was binding to function other than self-insert-command, it will be called. But if Emacs have evil installed, it's only worked at insert-state. Pressing S+1 will enter 1, etc.

It's a input method, so it's only worked on insert mode in current buffer, so chords like C-x 2 will act as normal, and the key won't be translated in minibuffer.

