### PR TITLE
Add number-lock.el recipe

### DIFF
--- a/recipes/number-lock
+++ b/recipes/number-lock
@@ -1,0 +1,1 @@
+(number-lock :fetcher github :repo "Liu233w/number-lock.el")


### PR DESCRIPTION
URL: https://github.com/Liu233w/number-lock.el

I'm the maintainer of the package.

An emacs package to exchange your number line with the mark above it.

For example, when you press `1`, `!` will be entered. If `!` was binding to function other than `self-insert-command`, it will be called. But if Emacs have evil installed, it's only worked at insert-state. Pressing `S+1` will enter `1`, etc.

It's a input method, so it's only worked on insert mode in current buffer, so chords like `C-x 2` will act as normal, and the key won't be translated in minibuffer.