### PR TITLE
emagician-fix-spell-memory: upgrade, move repo, rename

### DIFF
--- a/recipes/emagician-fix-spell-memory
+++ b/recipes/emagician-fix-spell-memory
@@ -1,3 +1,0 @@
-(emagician-fix-spell-memory :repo "jonnay/emagicians-starter-kit"
-                            :fetcher github
-                            :files ("emagician-fix-spell-memory.el"))

--- a/recipes/fix-muscle-memory
+++ b/recipes/fix-muscle-memory
@@ -1,0 +1,4 @@
+(fix-muscle-memory :repo "jonnay/fix-muscle-memory"
+                   :fetcher github
+                   :files ("fix-muscle-memory.el")
+                   :old-names (emagician-fix-spell-memory))


### PR DESCRIPTION
https://github.com/jonnay/fix-muscle-memory

- Old package was in my starter kit dir, now has it's own github repo
- Old package name was kind of goofy, has a new name now

This commit also deletes the old recipe.  I set :old-names in the new
recipe.

Let me know if I need to do anything differently with the rename.  Thank you!