### PR TITLE
Add hamburger-menu recipe

### DIFF
--- a/recipes/hamburger-menu
+++ b/recipes/hamburger-menu
@@ -1,0 +1,1 @@
+(hamburger-menu :repo "iain/hamburger-menu-mode" :fetcher gitlab)


### PR DESCRIPTION
* **package summary:** A hamburger menu button for the Emacs mode line.  Use instead of
`menu-bar-mode' to save vertical space.

* **URL:** https://gitlab.com/iain/hamburger-menu-mode

* **submitter relationship to package:** author
