### PR TITLE
Added recipe for transfer-sh package

### DIFF
--- a/recipes/transfer-sh
+++ b/recipes/transfer-sh
@@ -1,0 +1,1 @@
+(transfer-sh :fetcher github :repo "brillow/transfer-sh")


### PR DESCRIPTION
Please consider adding this package to melpa. It includes a function to upload regions or buffers to the open-source file-sharing service transfer.sh.