### PR TITLE
Add po-mode, included in the gettext repository

### DIFF
--- a/recipes/po-mode
+++ b/recipes/po-mode
@@ -1,4 +1,4 @@
 (po-mode
  :fetcher git
  :url "git://git.savannah.gnu.org/gettext.git"
- :files ("gettext-tools/misc/*.el"))
+ :files ("gettext-tools/misc/po-mode.el"))

--- a/recipes/po-mode
+++ b/recipes/po-mode
@@ -1,0 +1,4 @@
+(po-mode
+ :fetcher git
+ :url "git://git.savannah.gnu.org/gettext.git"
+ :files ("gettext-tools/misc/*.el"))


### PR DESCRIPTION
`po-mode` is included in the gettext repository which is too huge (just to clone) for such a small piece of elisp software.  So if you put it in your local Cask file, it takes a long time to install or check for updates for the single package.

It seems there have been some interest in putting it into GNU ELPA, but there has not been much progress as of yet.
https://lists.gnu.org/archive/html/bug-gettext/2015-07/msg00040.html

There are some elisp libraries that depend on po-mode, such as po-mode+ and mo-mode which are currently not packaged, so it would be beneficial to have it in MELPA.