### PR TITLE
Skip unneeded files in skewer-reload-stylesheets recipe

### DIFF
--- a/recipes/skewer-reload-stylesheets
+++ b/recipes/skewer-reload-stylesheets
@@ -1,4 +1,4 @@
 (skewer-reload-stylesheets
  :fetcher github
  :repo "NateEag/skewer-reload-stylesheets"
- :files ("*.el" "*.js"))
+ :files ("skewer-reload-stylesheets.el" "*.js"))

--- a/recipes/skewer-reload-stylesheets
+++ b/recipes/skewer-reload-stylesheets
@@ -1,4 +1,4 @@
 (skewer-reload-stylesheets
  :fetcher github
  :repo "NateEag/skewer-reload-stylesheets"
- :files ("skewer-reload-stylesheets.el" "*.js"))
+ :files (:defaults "*.js"))


### PR DESCRIPTION
I added a lame test helper file a while ago, and only recently noticed
that the original recipe picked it up for packaging, where it has no
use.