### PR TITLE
Add ereader

### DIFF
--- a/recipes/ereader
+++ b/recipes/ereader
@@ -1,0 +1,2 @@
+(ereader :fetcher github
+         :repo "bddean/emacs-ereader")


### PR DESCRIPTION
Ereader.el provides ereader-mode to view epub ebooks. Org-ebook.el provides functions for linking to epub books from Org and opening them in ereader-mode. I think they belong in the same package because they are pretty tightly coupled.

I wrote it and maintain it.

See repository at https://github.com/bddean/emacs-ereader

Thanks