### PR TITLE
Add recipe for rc-mode

### DIFF
--- a/recipes/rc-mode
+++ b/recipes/rc-mode
@@ -1,0 +1,1 @@
+(rc-mode :repo "mrhmouse/rc-mode.el" :fetcher github)


### PR DESCRIPTION
This is a major mode for the Plan9 rc shell.