### PR TITLE
Add ox-tufte recipe

### DIFF
--- a/recipes/ox-tufte
+++ b/recipes/ox-tufte
@@ -1,0 +1,1 @@
+(ox-tufte :fetcher github :repo "dakrone/ox-tufte")


### PR DESCRIPTION
This adds the recipe for the ox-tufte org-mode export backend -
https://github.com/dakrone/ox-tufte

This is a specialized HTML backend supporting an unmodified Tufte CSS
stylesheet - https://edwardtufte.github.io/tufte-css/