### PR TITLE
Add go-add-tags

### DIFF
--- a/recipes/go-add-tags
+++ b/recipes/go-add-tags
@@ -1,0 +1,1 @@
+(go-add-tags :repo "syohex/emacs-go-add-tags" :fetcher github)


### PR DESCRIPTION
`go-add-tags` is a command inspired by vim-go GoAddTags command. It inserts go struct tags.

https://github.com/syohex/emacs-go-add-tags