### PR TITLE
Added recipe for auto-img-link-insert

### DIFF
--- a/recipes/auto-img-link-insert
+++ b/recipes/auto-img-link-insert
@@ -1,0 +1,2 @@
+
+(auto-img-link-insert :fetcher github :repo "tashrifsanil/auto-img-link-insert")


### PR DESCRIPTION
 auto-img-link-insert is an emacs package that makes inserting images from the web much easier and quicker