### PR TITLE
Add mips-mode

### DIFF
--- a/recipes/mips-mode
+++ b/recipes/mips-mode
@@ -1,0 +1,1 @@
+(mips-mode :repo "hlissner/emacs-mips-mode" :fetcher github)


### PR DESCRIPTION
A simple major mode for MIPS assembly code, based off haxor-mode, and written [mainly] for the MIPS Assembly track on [exercism.io](http://exercism.io/).

* I am the author
* Repo: https://github.com/hlissner/emacs-mips-mode

