### PR TITLE
Add recipe for evil-org

### DIFF
--- a/recipes/evil-Org
+++ b/recipes/evil-Org
@@ -1,0 +1,1 @@
+(evil-Org :fetcher github :repo "GuiltyDolphin/evil-org")


### PR DESCRIPTION
Unfortunately, "evil-org" is already taken by "evil-org-mode", so I've used "evil-Org" instead.

It looks like this might cause some issues? The `provide` is `evil-org` - (which is the same as for `evil-org-mode`).

Would you recommend re-naming _everything_ (package-wise) to `evil-Org` - bit of a pain :/? Perhaps just the main `provide` needs to change, and everything else can stay the same? That being said, it does seem to compile quite happily with the [testing](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md#testing) instructions.

---

Repo: https://github.com/GuiltyDolphin/evil-org
Summary: Provides Evil integration for Org (including context-sensitive bindings).
Relation: I am the maintainer/creator.