### PR TITLE
Add doom-theme

### DIFF
--- a/recipes/doom-theme
+++ b/recipes/doom-theme
@@ -1,0 +1,3 @@
+(doom-theme :repo "hlissner/emacs-doom-theme"
+            :fetcher github
+            :files (:defaults (:exclude "doom-modeline.el")))

--- a/recipes/doom-theme
+++ b/recipes/doom-theme
@@ -1,3 +1,0 @@
-(doom-theme :repo "hlissner/emacs-doom-theme"
-            :fetcher github
-            :files (:defaults (:exclude "doom-modeline.el")))

--- a/recipes/doom-themes
+++ b/recipes/doom-themes
@@ -1,0 +1,1 @@
+(doom-themes :repo "hlissner/emacs-doom-theme" :fetcher github)


### PR DESCRIPTION
An opinionated UI plugin/theme extracted from my [emacs.d](https://github.com/hlissner/.emacs.d), inspired by the One Dark/Light UI theme in Atom. Includes optional dimming of non-source buffers & minibuffer, a neotree theme with font icons, and (soon) a mode-line config.

* I am the author
* Repo: https://github.com/hlissner/emacs-doom-theme
* ~~Note: The recipe intentionally excludes a file that doesn't exist yet.~~