### PR TITLE
Add recipe for gulp-task-runner

### DIFF
--- a/recipes/gulp-task-runner
+++ b/recipes/gulp-task-runner
@@ -1,0 +1,1 @@
+(gulp-task-runner :fetcher github :repo "NicolasPetton/gulp-task-runner")


### PR DESCRIPTION
This package provides a straightforward integration of [Gulp](http://gulpjs.com/) in Emacs. 

Evaluate `M-x gulp` to get the list of gulp tasks of a project and run a task.

- [x] I'm the author of the package
- [x] The package is on github: https://github.com/NicolasPetton/gulp-task-runner
- [x] The package builds (`C-c C-c` in the recipe buffer)
- [x] The package installs properly via `package-install-file`