### PR TITLE
Add recipe for org-evil

### DIFF
--- a/recipes/org-evil
+++ b/recipes/org-evil
@@ -1,0 +1,1 @@
+(org-evil :fetcher github :repo "GuiltyDolphin/org-evil")


### PR DESCRIPTION
Continuation of #4225 (with a new package name).

---
Repo: https://github.com/GuiltyDolphin/org-evil
Summary: Provides Evil integration for Org (including context-sensitive bindings).
Relation: I am the maintainer/creator.