### PR TITLE
Renamed package auto-img-link-insert to org-easy-img-insert

### DIFF
--- a/recipes/auto-img-link-insert
+++ b/recipes/auto-img-link-insert
@@ -1,2 +1,0 @@
-
-(auto-img-link-insert :fetcher github :repo "tashrifsanil/auto-img-link-insert")

--- a/recipes/org-easy-img-insert
+++ b/recipes/org-easy-img-insert
@@ -1,0 +1,2 @@
+
+(org-easy-img-insert :fetcher github :repo "tashrifsanil/org-easy-img-insert" :old-names (auto-img-link-insert))


### PR DESCRIPTION
Hi,

I recently renamed a package I submitted earlier, from `auto-img-link-insert` to `org-easy -img-insert` so that it would be easier for users to find. 