### PR TITLE
Add fsbot-data-browser recipe

### DIFF
--- a/recipes/fsbot-data-browser
+++ b/recipes/fsbot-data-browser
@@ -1,0 +1,1 @@
+(fsbot-data-browser :repo "benaiah/fsbot-data-browser" :fetcher github)


### PR DESCRIPTION
Simple package to view the entry database of the resident bot at #emacs on Freenode.