### PR TITLE
Add recipe for magithub

### DIFF
--- a/recipes/magithub
+++ b/recipes/magithub
@@ -1,4 +1,4 @@
 (magithub :fetcher github
           :repo "vermiculus/magithub"
-          :files ("lisp/magithub.el"
+          :files ("lisp/magithub*.el"
                   "LICENSE"))

--- a/recipes/magithub
+++ b/recipes/magithub
@@ -1,0 +1,4 @@
+(magithub :fetcher github
+          :repo "vermiculus/magithub"
+          :files ("lisp/magithub.el"
+                  "LICENSE"))

--- a/recipes/magithub
+++ b/recipes/magithub
@@ -1,4 +1,4 @@
 (magithub :fetcher github
           :repo "vermiculus/magithub"
-          :files ("lisp/magithub*.el"
+          :files ("magithub*.el"
                   "LICENSE"))


### PR DESCRIPTION
Magithub is basic integration of the 'hub' GitHub client into Magit's
popup interface.  See hub.github.com for more details.

I'm also submitting this PR for more selfish reasons: this is officially
testing the fork/pull-request flow with the package :smile:

Here's to a successful test :beers: