### PR TITLE
Add recipe for ivy-xcdoc

### DIFF
--- a/recipes/ivy-xcdoc
+++ b/recipes/ivy-xcdoc
@@ -1,0 +1,1 @@
+(ivy-xcdoc :repo "hex2010/emacs-ivy-xcdoc" :fetcher github)


### PR DESCRIPTION
ivy-xcdoc provide functions to search Xcode documents with ivy interface.