### PR TITLE
Add flycheck-swift recipe

### DIFF
--- a/recipes/flycheck-swift
+++ b/recipes/flycheck-swift
@@ -1,0 +1,1 @@
+(flycheck-swift :repo "swift-emacs/flycheck-swift" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Flycheck extension for Apple's Swift programming language.

It compiles Swift files using `swiftc` and repoert errors.

### Direct link to the package repository

https://github.com/swift-emacs/flycheck-swift

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None

### Did you read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)?

Yes
