### PR TITLE
Add recipe for ede-php-autoload

### DIFF
--- a/recipes/ede-php-autoload
+++ b/recipes/ede-php-autoload
@@ -1,0 +1,3 @@
+(ede-php-autoload :fetcher github
+                  :repo "stevenremot/ede-php-autoload"
+                  :files (:defaults "ede-php-autoload"))


### PR DESCRIPTION

### Brief summary of what the package does

ede-php-autoload is an implementation of PHP autoloading in Emacs Lisp, that can be used as a SemanticDB backend.

### Direct link to the package repository

https://github.com/stevenremot/ede-php-autoload

### Your association with the package

I am the package maintainer

### Relevant communications with the upstream package maintainer

**None**

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

