### PR TITLE
add bar-cursor

### DIFF
--- a/recipes/bar-cursor
+++ b/recipes/bar-cursor
@@ -1,3 +1,2 @@
 (bar-cursor :repo "ajsquared/bar-cursor"
-            :fetcher github
-            :files ("bar-cursor.el"))
+            :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

bar-cursor is an Emacs Lisp package that changes the Emacs cursor from a block into a bar. In overwrite-mode, the cursor will change into a block.

@ajsquared forked bar-cursor from the file by Joseph L. Casadonte Jr. found on his [webpage](http://www.northbound-train.com/emacs.html#MyPackages).

### Direct link to the package repository

https://github.com/ajsquared/bar-cursor

### Your association with the package

I am not a maintainer, I have not contributed, I just like the package.

### Relevant communications with the upstream package maintainer

None

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

