### PR TITLE
auto-org-md added

### DIFF
--- a/recipes/auto-org-md
+++ b/recipes/auto-org-md
@@ -1,0 +1,1 @@
+(auto-org-md :repo "jamcha-aa/auto-org-md" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

auto-org-md.el export a markdown file automatically when you save an org-file

### Direct link to the package repository

https://github.com/jamcha-aa/auto-org-md

### Your association with the package

I am a maintainer.

### Relevant communications with the upstream package maintainer

None.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

