### PR TITLE
Add color-theme-x

### DIFF
--- a/recipes/color-theme-x
+++ b/recipes/color-theme-x
@@ -1,0 +1,2 @@
+(color-theme-x :repo "ajsquared/color-theme-x"
+:fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Color-theme-x is an Emacs Lisp package that converts Emacs color themes to X11 resource settings. Applying color themes in this way allows Emacs to start up significantly faster than by loading the theme from Lisp code.

### Direct link to the package repository

https://github.com/ajsquared/color-theme-x

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

