### PR TITLE
Modify sage-shell-mode recipe

### DIFF
--- a/recipes/sage-shell-mode
+++ b/recipes/sage-shell-mode
@@ -1,3 +1,2 @@
-(sage-shell-mode :repo "stakemori/sage-shell-mode"
-                 :fetcher github
-                 :files ("sage-shell-mode.el" "*.py"))
+(sage-shell-mode :repo "sagemath/sage-shell-mode" :fetcher github
+                 :files (:defaults "*.py" (:exclude "*test.py")))


### PR DESCRIPTION
I set the :files keyword of [sage-shell-mode](https://github.com/stakemori/sage-shell-mode) too strict. Unexpectedly, my package is growing. So I would like to change the :files keyword.

