### PR TITLE
Add recipe for org-wiki.

### DIFF
--- a/recipes/org-wiki
+++ b/recipes/org-wiki
@@ -1,0 +1,1 @@
+(org-wiki :repo "caiorss/org-wiki" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Org-wiki is an org-mode extension that provides tools to manage and build a desktop wiki where each wiki page is an org-mode file.
### Direct link to the package repository

https://github.com/caiorss/org-wiki
### Your association with the package

Author and maintainer. 
### Relevant communications with the upstream package maintainer

None
### Checklist
- [ x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
