### PR TITLE
Add recipe for refs.el

### DIFF
--- a/recipes/elisp-refs
+++ b/recipes/elisp-refs
@@ -1,0 +1,3 @@
+(elisp-refs :repo "Wilfred/refs.el"
+            :fetcher github
+            :files (:defaults (:exclude "elisp-refs-bench.el")))

--- a/recipes/refs
+++ b/recipes/refs
@@ -1,0 +1,3 @@
+(refs :repo "Wilfred/refs.el"
+      :fetcher github
+      :files ("refs.el"))

--- a/recipes/refs
+++ b/recipes/refs
@@ -1,3 +1,3 @@
 (refs :repo "Wilfred/refs.el"
       :fetcher github
-      :files ("refs.el"))
+      :files (:defaults (:exclude "refs-bench.el")))

--- a/recipes/refs
+++ b/recipes/refs
@@ -1,3 +1,0 @@
-(refs :repo "Wilfred/refs.el"
-      :fetcher github
-      :files (:defaults (:exclude "refs-bench.el")))


### PR DESCRIPTION
### Brief summary of what the package does

refs.el is an Emacs package for finding references to functions, macros or variables. It works by parsing the elisp and analysing it.

![refs_screenshot](https://cloud.githubusercontent.com/assets/70800/18821463/470ec212-8374-11e6-94ac-abc7525a0183.png)

### Direct link to the package repository

https://github.com/Wilfred/refs.el

### Your association with the package

I'm the author.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

