### PR TITLE
add podcaster:An Emacs Podcast Client

### DIFF
--- a/recipes/podcaster
+++ b/recipes/podcaster
@@ -1,0 +1,1 @@
+(podcaster :fetcher github :repo "lujun9972/podcaster")


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs Podcast Client which is derived from syohex’s emacs-rebuildfm.

### Direct link to the package repository

https://github.com/lujun9972/podcaster

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

None

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

