### PR TITLE
Added ipcalc.el

### DIFF
--- a/recipes/ipcalc
+++ b/recipes/ipcalc
@@ -1,0 +1,1 @@
+(ipcalc :fetcher github :repo "dotemacs/ipcalc.el")


### PR DESCRIPTION
### Brief summary of what the package does

IP calculator in Emacs Lisp.

When given an IP and subnet e.g. **192.168.0.23/21** it produces:

```
Address:   192.168.0.23         11000000101010000000000000010111
Netmask:   255.255.248.0 = 21   11111111111111111111100000000000
Wildcard:  0.0.7.255            00000000000000000000011111111111
=>
Network:   192.168.0.0          11000000101010000000000000000000
HostMin:   192.168.0.1          11000000101010000000000000000001
HostMax:   192.168.7.254        11000000101010000000011111111110
Broadcast: 192.168.7.255        11000000101010000000011111111111
Hosts/Net: 2046
```

### Direct link to the package repository

https://github.com/dotemacs/ipcalc.el

### Your association with the package

I'm the author and the maintainer.

### Relevant communications with the upstream package maintainer

**None**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

Added ipcalc.el package recipe