### PR TITLE
ieure/scratch-el s not maintained since 20122, fix issue 4 of origin…

### DIFF
--- a/recipes/scratch
+++ b/recipes/scratch
@@ -1,1 +1,1 @@
-(scratch :fetcher github :repo "ieure/scratch-el")
+(scratch :fetcher github :repo "zhengjiezxxy/scratch-el")


### PR DESCRIPTION
### Brief summary of what the package does

Scratch buffers for Emacs

### Direct link to the package repository

https://github.com/zhengjiezxxy/scratch-el
https://github.com/ieure/scratch-el
### Your association with the package

I want to maintain scratch-el.

### Relevant communications with the upstream package maintainer

maintainer is not active since 2012.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

…al repository