### PR TITLE
Contributing addition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ New recipe submissions should adhere to the following guidelines,
 * The package name should match the name of the feature provided.  See
   the `package` function for more information.
 
+* The package should follow the conventions of [Emacs Lisp](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html)
+
 * Packages should adhere to the `package.el` format as specified by
   `(info "(elisp) Packaging")`. More information on this format is
   provided by the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,11 @@ process and expedite the recipe review process,
 * Use [flycheck-package](https://github.com/purcell/flycheck-package)
   to help you identify common errors in your package metadata.
 
+* Use *checkdoc* to make sure that your package follows the
+  conventions for documentation strings. See the official
+  [Emacs manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Documentation-Tips.html#Documentation-Tips) for
+  details.
+
 * Include the following information in the pull request:
 
     * A brief summary of what the package does.


### PR DESCRIPTION
This is **not** a new package PR.

This PR adds a few comments & pointers, to **CONTRIBUTING.md**, on where to look and what to do to ensure that your package follows Emacs Lisp style guide and how to run **checkdoc** to ensure that the documentation strings conform to the expected convention.
