### PR TITLE
Add env-var-import

### DIFF
--- a/recipes/env-var-import
+++ b/recipes/env-var-import
@@ -1,0 +1,2 @@
+(env-var-import :repo "ajsquared/env-var-import"
+:fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

On OS X, a GUI Emacs instance will have a different environment from one started in the shell. This library works around that by copying environment variables from the shell.

### Direct link to the package repository

https://github.com/ajsquared/env-var-import

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

