### PR TITLE
Adds a recipe for the "node" package

### DIFF
--- a/recipes/node-tools
+++ b/recipes/node-tools
@@ -1,0 +1,3 @@
+(node-tools
+ :repo "cowboyd/node-tools.el"
+ :fetcher github)


### PR DESCRIPTION
https://github.com/cowboyd/node.el

My experience working with Node JS in Emacs has been that it's not as
good as working with other languages. There's nothing terrible, but it's
just a bunch of paper cuts, so I decided to collect my various functions
and hacks into a single place that can be shared.

this package currently adds support for node stack traces for `(next-error)` and
`(previous-error)` navigation within compilation buffers. Planned
features also include:
- cleaning the crap out of compilation buffers when npm / mocha and
  friends don't pay attention to the TERM=dumb
- lookup local executables for running commands within `node_modules`
- less yak shaving for setting up the debugger.
### Checklist
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
