### PR TITLE
Add org-clock-today recipe

### DIFF
--- a/recipes/org-clock-today
+++ b/recipes/org-clock-today
@@ -1,0 +1,2 @@
+(org-clock-today :fetcher github
+                 :repo "mallt/org-clock-today-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Minor mode to show the total clocked time with org of the current day in the mode line.

### Direct link to the package repository

https://github.com/mallt/org-clock-today-mode

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

