### PR TITLE
Add mtg-deck-mode recipe

### DIFF
--- a/recipes/mtg-deck-mode
+++ b/recipes/mtg-deck-mode
@@ -1,0 +1,3 @@
+(mtg-deck-mode :fetcher github
+               :repo "mattiasb/mtg-deck-mode"
+               :files ( :defaults "formats" ))


### PR DESCRIPTION
### Brief summary of what the package does

A major-mode for editing Magic: The Gathering decks. 

### Direct link to the package repository

https://github.com/mattiasb/mtg-deck-mode

### Your association with the package

I'm the maintainer.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

Regarding the last point: I can't seem to get it to build properly. I get an Error 255 which I just can't grok. :/

Here's the output:
```
 • Building recipe mtg-deck-mode ...
/bin/timeout -k 60 600 emacs --no-site-file --batch -l package-build/package-build.el --eval "(let ((package-build-stable nil) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"./packages\" package-build--melpa-base))) (package-build-archive 'mtg-deck-mode))"

;;; mtg-deck-mode

Fetcher: github
Source: mattiasb/mtg-deck-mode

Updating /home/mattiasb/Code/github/melpa/melpa/working/mtg-deck-mode/
Wrong type argument: stringp, nil
Makefile:91: recipe for target 'recipes/mtg-deck-mode' failed
make: [recipes/mtg-deck-mode] Error 255 (ignored)
ls: cannot access './packages/mtg-deck-mode-*': No such file or directory
 ✓ Wrote  
 Sleeping for 0 ...
sleep 0
```
