### PR TITLE
Add cpanfile-mode

### DIFF
--- a/recipes/cpanfile-mode
+++ b/recipes/cpanfile-mode
@@ -1,0 +1,1 @@
+(cpanfile-mode :repo "zakame/cpanfile-mode" :fetcher github)


### PR DESCRIPTION
This is a simple mode I wrote (originally coming from just a simple `generic-x` mode,) and have been using to help me manage `cpanfile`s in my Perl projects.  It provides basic syntax highlighting and navigation/indexing via `imenu`.

https://github.com/zakame/cpanfile-mode