### PR TITLE
Add direnv to MELPA

### DIFF
--- a/recipes/direnv
+++ b/recipes/direnv
@@ -1,0 +1,1 @@
+(direnv :fetcher github :repo "jml/direnv-el")


### PR DESCRIPTION
### Brief summary of what the package does

The direnv package loads environment variables from direnv into the
file-local environment variables for a buffer. This is mostly useful
when the environment variables defined in direnv control compiler or
test behaviour.

### Direct link to the package repository

https://github.com/jml/direnv-el

### Your association with the package

I am the author & maintainer of the direnv Emacs package, although not of [direnv](http://direnv.net/) itself.

### Relevant communications with the upstream package maintainer

**None**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
