### PR TITLE
Updated the yasnippet repo path

### DIFF
--- a/recipes/yasnippet
+++ b/recipes/yasnippet
@@ -1,4 +1,3 @@
-(yasnippet :repo "capitaomorte/yasnippet"
+(yasnippet :repo "joaotavora/yasnippet"
            :fetcher github
            :files ("yasnippet.el" "snippets"))
-


### PR DESCRIPTION
### Brief summary of what the package does

Not a new package, but a 'fix' for the existing package. See below.

### Direct link to the package repository

https://github.com/joaotavora/yasnippet


The previous path for yasnippet was: **capitaomorte/yasnippet** which when
you try to access:

```shell
curl -I https://github.com/capitaomorte/yasnippet
```
you get `HTTP/1.1 301 Moved Permanently`

Which redirects you to: **joaotavora/yasnippet**

Why rely on GitHub's redirection, why not just go and fetch the package
from the authoritative repo?