### PR TITLE
Fetch dot-mode from github instead of wiki

### DIFF
--- a/recipes/dot-mode
+++ b/recipes/dot-mode
@@ -1,1 +1,1 @@
-(dot-mode :fetcher wiki)
+(dot-mode :repo "wyrickre/dot-mode" :fetcher github)


### PR DESCRIPTION
The author of dot-mode.el has it in a github repo. There have been some recent updates on it and I thought it would be nice to point the MELPA recipe to that instead of the wiki version.

It can be found here https://github.com/wyrickre/dot-mode

I've recently asked the author if he minded me updating the recipe on MELPA and he's happy with that.
