### PR TITLE
Added webpaste.el package

### DIFF
--- a/recipes/webpaste
+++ b/recipes/webpaste
@@ -1,0 +1,1 @@
+(webpaste :repo "etu/webpaste.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This mode allows to paste whole buffers or parts of buffers to pastebin-like services. It supports more than one service and will failover if one service fails. More services can easily be added over time and prefered services can easily be configured.

### Direct link to the package repository

https://github.com/etu/webpaste.el

### Your association with the package

I built and maintain it.

### Relevant communications with the upstream package maintainer

**None**

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
