### PR TITLE
[add] receipe for multitran, initial import

### DIFF
--- a/recipes/multitran
+++ b/recipes/multitran
@@ -1,0 +1,1 @@
+(multitran :fetcher github :repo "zevlg/multitran.el")


### PR DESCRIPTION
### Brief summary of what the package does

Nifty Emacs interface to http://multitran.com

Supports multiple languages, including Esperanto, Latin and Luxembourgish.

### Direct link to the package repository

https://github.com/zevlg/multitran.el

### Your association with the package

I'm author

### Relevant communications with the upstream package maintainer

None

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

Also checked for byte compilation
