### PR TITLE
Add recipe for evil-opener

### DIFF
--- a/recipes/evil-opener
+++ b/recipes/evil-opener
@@ -1,0 +1,4 @@
+(evil-opener
+  :fetcher github
+  :repo "0robustus1/opener.el"
+  :files ("evil-opener.el" "evil-opener.texi"))


### PR DESCRIPTION
### Brief summary of what the package does

The opener package allows evil users to open the resource
behind a http(s) URL in a buffer. It utilizes the opener-package (see #4314) to
do this. This package provides commands and remappings in evil-mode for convenience purposes. It governs this with a minor-mode.

### Direct link to the package repository

https://github.com/0robustus1/opener.el

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

**None**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
