### PR TITLE
add sourcerer-theme to melpa

### DIFF
--- a/recipes/sourcerer-theme
+++ b/recipes/sourcerer-theme
@@ -1,0 +1,1 @@
+(sourcerer-theme :fetcher github :repo "gilbertw1/sourcerer-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

This package includes an implementation of the "Sourcerer" color theme for emacs.

### Direct link to the package repository

https://github.com/gilbertw1/sourcerer-emacs

### Your association with the package

I am the maintainer.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

