### PR TITLE
Preparing to the merge with `plantuml-mode`

### DIFF
--- a/recipes/puml-mode
+++ b/recipes/puml-mode
@@ -1,1 +1,1 @@
-(puml-mode :fetcher github :repo "skuro/puml-mode")
+(puml-mode :fetcher github :repo "skuro/plantuml-mode" :branch "puml-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This PR is to update the location of the existing package `puml-mode`. The repository got renamed to `plantuml-mode` and the old code is now in a dedicated `puml-mode`.

See #4310 for more details.

### Direct link to the package repository

https://github.com/skuro/plantuml-mode/tree/puml-mode

### Your association with the package

I'm the maintainer of the package

### Relevant communications with the upstream package maintainer

None

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)