### PR TITLE
Updated `plantuml-mode` after the merge between `skuro/puml-mode` and `zwz/plantuml-mode`

### DIFF
--- a/recipes/plantuml-mode
+++ b/recipes/plantuml-mode
@@ -1,2 +1,2 @@
-(plantuml-mode :repo "zwz/plantuml-mode"
-               :fetcher github)
+(plantuml-mode :fetcher github
+               :repo "skuro/plantuml-mode")

--- a/recipes/puml-mode
+++ b/recipes/puml-mode
@@ -1,1 +1,2 @@
-(puml-mode :fetcher github :repo "skuro/puml-mode")
+(puml-mode :fetcher github
+           :repo "skuro/puml-mode")

--- a/recipes/puml-mode
+++ b/recipes/puml-mode
@@ -1,2 +1,0 @@
-(puml-mode :fetcher github
-           :repo "skuro/puml-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This PR is to update the location of the existing package `plantuml-mode` to its new home and to remove the now deprecated `puml-mode`.

See #4310 for more details.

### Direct link to the package repository

https://github.com/skuro/plantuml-mode

### Your association with the package

I'm the new maintainer of the package

### Relevant communications with the upstream package maintainer

Nope

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
