### PR TITLE
Add recipe for company-bibtex -- corrected

### DIFF
--- a/recipes/company-bibtex
+++ b/recipes/company-bibtex
@@ -1,0 +1,1 @@
+(company-bibtex :fetcher github :repo "gbgar/company-bibtex")


### PR DESCRIPTION
### Brief summary of what the package does

The company-bibtex package provides a bibtex back-end for company mode, which allows for completion of citation keys in pandoc-mode, latex-mode, and org-mode.

### Direct link to the package repository

https://github.com/gbgar/company-bibtex

### Your association with the package

I am the package author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)