### PR TITLE
add recipe for add-node-modules-path

### DIFF
--- a/recipes/add-node-modules-path
+++ b/recipes/add-node-modules-path
@@ -1,0 +1,1 @@
+(add-node-modules-path :repo "codesuki/add-node-modules-path" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
Provides a function that searches for and adds the node_modules/.bin directory to the buffer exec_path. E.g. support project local eslint (and other tools) installations.

### Direct link to the package repository

https://github.com/codesuki/add-node-modules-path

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)