### PR TITLE
Add recipe for dr-racket-like-unicode

### DIFF
--- a/recipes/dr-racket-like-unicode
+++ b/recipes/dr-racket-like-unicode
@@ -1,0 +1,3 @@
+(dr-racket-like-unicode
+ :fetcher github
+ :repo "david-christiansen/dr-racket-like-unicode")


### PR DESCRIPTION
### Brief summary of what the package does

This package implements the Unicode input interface from DrRacket, the editor shipped with Racket. In this interface, one writes a TeX-style shortcut, then presses a key to transform the TeX-code immediately to the left of point into its Unicode equivalent.

This is nice when only using a few characters not on one's keyboard, as it doesn't get in the way as much as a separate input method.

### Direct link to the package repository

https://github.com/david-christiansen/dr-racket-like-unicode

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

This is a package for performing unicode input in the style of DrRacket,
which can be convenient when only occaisionally using characters not on
one's keyboard.