### PR TITLE
Adding recipe for schrute-mode

### DIFF
--- a/recipes/schrute
+++ b/recipes/schrute
@@ -1,0 +1,1 @@
+(schrute :fetcher git :url "https://bitbucket.org/shackra/dwight-k.-schrute")


### PR DESCRIPTION
### Brief summary of what the package does

Dwight K. Schrute-mode or `schrute-mode` for short, is a minor global mode that will help you to remember that there is a better way to do something. By better I mean using commands like `avy-goto-line` instead of making several invocations of `next-line` in a row with either `C-<down>` or `C-n` keybindings. If your memory is like mine, you'll often forget those features are available, if you commit the mistake of taking the long route, `schrute-mode` will be there to save the day... just don't forget to configure it!.

### Direct link to the package repository

https://bitbucket.org/shackra/dwight-k.-schrute/

### Your association with the package

Creator and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

