### PR TITLE
Add seoul256-colors-theme to melpa

### DIFF
--- a/recipes/seoul256-colors-theme
+++ b/recipes/seoul256-colors-theme
@@ -1,0 +1,1 @@
+(seoul256-colors-theme :fetcher github :repo "anandpiyer/seoul256-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

This is an Emacs theme port of seoul256 color scheme for Vim.

### Direct link to the package repository

https://github.com/anandpiyer/seoul256-emacs

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
