### PR TITLE
add recipe for atomic-chrome

### DIFF
--- a/recipes/atomic-chrome
+++ b/recipes/atomic-chrome
@@ -1,0 +1,1 @@
+(atomic-chrome :repo "alpha22jp/atomic-chrome" :fetcher github)

--- a/recipes/emacs-chrome
+++ b/recipes/emacs-chrome
@@ -1,0 +1,1 @@
+(emacs-chrome :repo "alpha22jp/emacs-chrome" :fetcher github)

--- a/recipes/emacs-chrome
+++ b/recipes/emacs-chrome
@@ -1,1 +1,0 @@
-(emacs-chrome :repo "alpha22jp/emacs-chrome" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is an Emacs version of [Atomic Chrome](https://atom.io/packages/atomic-chrome) which is an extension for Google Chrome browser that allows you to edit text areas of the browser in Emacs. It's similar to [Edit with Emacs](https://www.emacswiki.org/emacs/Edit_with_Emacs), but has some advantages as below with the help of websocket.

* The input on Emacs is reflected to the browser instantly and continuously.
* You can use both the browser and Emacs at the same time. They are updated to the same content bi-directionally.

### Direct link to the package repository

https://github.com/alpha22jp/atomic-chrome.git

### Your association with the package

I'm a maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)