### PR TITLE
Add creamsody-theme

### DIFF
--- a/recipes/creamsody-theme
+++ b/recipes/creamsody-theme
@@ -1,0 +1,1 @@
+(creamsody-theme :fetcher github :repo "emacsfodder/emacs-theme-creamsody")


### PR DESCRIPTION
### Brief summary of what the package does

Creamsody is a color theme for Emacs

### Direct link to the package repository

https://github.com/emacsfodder/emacs-theme-creamsody

### Your association with the package

I'm the package author

### Relevant communications with the upstream package maintainer

n/a

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

