### PR TITLE
[new] debian-changelog-mode + debian-bug recipes

### DIFF
--- a/recipes/debian-bug
+++ b/recipes/debian-bug
@@ -1,0 +1,4 @@
+(debian-bug :fetcher cvs
+            :url ":pserver:anonymous@cvs.alioth.debian.org:/cvs/pkg-goodies-el"
+            :module "emacs-goodies-el"
+            :files ("elisp/debian-el/debian-bug.el"))

--- a/recipes/debian-changelog-mode
+++ b/recipes/debian-changelog-mode
@@ -1,0 +1,4 @@
+(debian-changelog-mode :fetcher cvs
+            :url ":pserver:anonymous@cvs.alioth.debian.org:/cvs/pkg-goodies-el"
+            :module "emacs-goodies-el"
+            :files ("elisp/dpkg-dev-el/debian-changelog-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This is a major mode for Debian changelog files.
### Direct link to the package repository

https://github.com/pcarrier/debian-changelog-mode
### Your association with the package

I use and like the package.
### Relevant communications with the upstream package maintainer
- [X] [Notified the upstream maintainer ](https://github.com/pcarrier/debian-changelog-mode/issues/1)
### Checklist
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md) - C-c C-c method.

Cheers,
