### PR TITLE
Please rename cssfmt to stylefmt

### DIFF
--- a/recipes/cssfmt
+++ b/recipes/cssfmt
@@ -1,1 +1,0 @@
-(cssfmt :repo "KeenS/cssfmt.el" :fetcher github)

--- a/recipes/stylefmt
+++ b/recipes/stylefmt
@@ -1,1 +1,1 @@
-(stylefmt :repo "KeenS/stylefmt.el" :fetcher github)
+(stylefmt :repo "KeenS/stylefmt.el" :fetcher github :old-names (cssfmt))

--- a/recipes/stylefmt
+++ b/recipes/stylefmt
@@ -1,0 +1,1 @@
+(stylefmt :repo "KeenS/stylefmt.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a simple emacs integration of [stylefmt](https://github.com/morishitter/stylefmt) (was cssfmt).
Though upstream command was renamed a while ago, this haven't caught up the change.
(first PR is [this](https://github.com/melpa/melpa/pull/3019))

### Direct link to the package repository

https://github.com/KeenS/stylefmt.el

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

no problem

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

