### PR TITLE
Simplify the ox-jira recipe

### DIFF
--- a/recipes/ox-jira
+++ b/recipes/ox-jira
@@ -1,3 +1,1 @@
-(ox-jira :repo "stig/ox-jira.el"
-         :fetcher github
-         :files ("ox-jira.el"))
+(ox-jira :repo "stig/ox-jira.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This module plugs into the regular Org Export Engine and transforms Org files to JIRA markup for pasting into JIRA tickets & comments.

My last three jobs I've had to use JIRA, and had to deal with its (to me) incredibly unintuitive markup format. Having discovered---and fallen in love with---Org mode I now find myself writing everything in Org and exporting to various other formats (html, markdown, plain text) but I haven't been able to find a way to export to JIRA. So I am attempting to write one, and learn about Emacs package development at the same time.

I've changed the module to remove the org tangle step, so this recipe
can now be simplified.

### Direct link to the package repository

https://github.com/stig/ox-jira.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
