### PR TITLE
Add recipe for frames-only-mode

### DIFF
--- a/recipes/frames-only-mode
+++ b/recipes/frames-only-mode
@@ -1,0 +1,1 @@
+(frames-only-mode :repo "davidshepherd7/frames-only-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Makes Emacs use Emacs frames (i.e. OS windows) instead of Emacs windows where possible. 
### Direct link to the package repository

https://github.com/davidshepherd7/frames-only-mode
### Your association with the package

Maintainer
### Relevant communications with the upstream package maintainer

**None needed**
### Checklist
- [x ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
