### PR TITLE
Add html-to-hiccup recipe

### DIFF
--- a/recipes/html-to-hiccup
+++ b/recipes/html-to-hiccup
@@ -1,0 +1,2 @@
+(html-to-hiccup :repo "plexus/html-to-hiccup"
+                :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package allows you to convert HTML to Hiccup syntax, as used in
Clojure/ClojureScript.
### Direct link to the package repository

https://github.com/plexus/html-to-hiccup
### Your association with the package

I am the author/maintainer.
### Relevant communications with the upstream package maintainer

**None needed**
### Checklist
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
