### PR TITLE
Added a recipe for gxref package

### DIFF
--- a/recipes/gxref
+++ b/recipes/gxref
@@ -1,0 +1,1 @@
+(gxref :fetcher github :repo "dedi/gxref")


### PR DESCRIPTION
### Brief summary of what the package does

A pretty simple (but, at least for me effective) backend for emacs 25 xref
library, using GNU Global.

### Direct link to the package repository

https://github.com/dedi/gxref

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

N/A/

### Checklist

- [Y ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ Y] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

