### PR TITLE
Delete flycheck-google-cpplint

### DIFF
--- a/recipes/flycheck-google-cpplint
+++ b/recipes/flycheck-google-cpplint
@@ -1,1 +1,0 @@
-(flycheck-google-cpplint :repo "flycheck/flycheck-google-cpplint" :fetcher github)


### PR DESCRIPTION
There's no one in Flycheck who still maintains this extensions; it hasn't been touched since years.

I'll move it out of Flycheck org into my account for archiving purpose in case someone's still interested, but if none steps up I'll eventually make it private to avoid the hassle of having yet another public repo in my account that I don't care for.  

@tarsius Iirc you're maintaining the emacs-mirror.  Do you per chance also have a place for repos that aren't maintained anymore?

/cc @cpitclaudel 