### PR TITLE
Delete frame-restore

### DIFF
--- a/recipes/frame-restore
+++ b/recipes/frame-restore
@@ -1,1 +1,0 @@
-(frame-restore :repo "lunaryorn/frame-restore.el" :fetcher github)


### PR DESCRIPTION
frame-restore is a kludge for a missing feature in Emacs 24.3 and earlier.  Since Emacs 24.4 the built-in Desktop Mode can restore frames in a much better and more powerful way than this package.

As such, I'm not maintaining frame-restore.el anymore since I've got no intention of ever using Emacs 24.3 again 8)

I've anyone wants to take the package fine with me, but if no one steps up I'll be making the repository private at some point and eventually delete it.

@tarsius I guess you're mirroring the repo anyway so that would do no harm would it?