### PR TITLE
add dante

### DIFF
--- a/recipes/dante
+++ b/recipes/dante
@@ -1,0 +1,3 @@
+(dante :repo "jyp/dante"
+       :fetcher github
+       :files ("dante.el"))

--- a/recipes/dante
+++ b/recipes/dante
@@ -1,3 +1,2 @@
 (dante :repo "jyp/dante"
-       :fetcher github
-       :files ("dante.el"))
+       :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs mode for Interactive Haskell

[[http://stable.melpa.org/packages/dante-badge.svg]]

Dante is a fork of Intero mode. It steals many good ideas from Intero,
it aims for light weightedness. Dante has no dependency on "Stack" nor
on any custom Haskell code. Dante's Emacs code is about half as long
as that of Intero. Flychecking is optional (yet recommended).

### Direct link to the package repository

https://github.com/jyp/dante

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

