### PR TITLE
Remove flycheck-protobuf

### DIFF
--- a/recipes/flycheck-protobuf
+++ b/recipes/flycheck-protobuf
@@ -1,3 +1,0 @@
-(flycheck-protobuf
-    :fetcher github
-    :repo "edvorg/flycheck-protobuf")


### PR DESCRIPTION
The protobuf checker is already part of flycheck upstream

See:
+ https://github.com/edvorg/flycheck-protobuf/issues/3 
+ https://github.com/flycheck/flycheck/issues/790
+ https://github.com/flycheck/flycheck/pull/1125 

cc: @edvorg, @lunaryorn 

