### PR TITLE
Add recipe for rjsx-mode

### DIFF
--- a/recipes/rjsx-mode
+++ b/recipes/rjsx-mode
@@ -1,0 +1,4 @@
+(rjsx-mode
+ :fetcher github
+ :repo "felipeochoa/rjsx-mode")
+ 


### PR DESCRIPTION
### Brief summary of what the package does

This mode implements a JSX parser according to the spec [here](https://facebook.github.io/jsx/). When enabled, it plugs the JSX parser into js2-mode's own parser to build the JSX AST. Currently the mode handles syntax checking and highlighting, and when you use js2-jsx-mode (bundled with j2-mode), also indentation.

### Direct link to the package repository

https://github.com/felipeochoa/rjsx-mode

### Your association with the package

I'm the author of the package

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

