### PR TITLE
Add frames-only-mode recipe

### DIFF
--- a/recipes/frames-only-mode
+++ b/recipes/frames-only-mode
@@ -1,0 +1,2 @@
+(frames-only-mode :repo "davidshepherd7/frames-only-mode"
+                  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

frames-only-mode is a minor mode that, when enabled, changes commands to
open new frames where they otherwise would have opened new Emacs windows.d

### Direct link to the package repository

https://github.com/davidshepherd7/frames-only-mode

### Your association with the package

I am a user who has read some of the code from this package.

### Relevant communications with the upstream package maintainer

See https://github.com/davidshepherd7/frames-only-mode/issues/6

No changes needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

