### PR TITLE
Don't exclude jdee-test.el

### DIFF
--- a/recipes/jdee
+++ b/recipes/jdee
@@ -1,3 +1,1 @@
-(jdee :fetcher github :repo "jdee-emacs/jdee"
-      :files ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
-              (:exclude ".dir-locals.el")))
+(jdee :fetcher github :repo "jdee-emacs/jdee" :files (:defaults "jdee-test.el"))

--- a/recipes/jdee
+++ b/recipes/jdee
@@ -1,1 +1,3 @@
-(jdee :fetcher github :repo "jdee-emacs/jdee")
+(jdee :fetcher github :repo "jdee-emacs/jdee"
+      :files ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
+              (:exclude ".dir-locals.el")))


### PR DESCRIPTION
This is an update to the current JDEE recipe to not exclude *test.el, because it's name of our core modules.

JDEE keeps tests in test/*, but uses jdee-test.el as one of packages. Default files recipe excludes one of core file, breaking the whole package.