### PR TITLE
add fluxus-mode

### DIFF
--- a/recipes/fluxus-mode
+++ b/recipes/fluxus-mode
@@ -1,0 +1,3 @@
+(fluxus-mode
+ :fetcher github
+ :repo "defaultxr/fluxus-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Fluxus-mode is a mode for interfacing with the Fluxus live coding environment. Fluxus can be used to program VJ-style 3D graphics or full games in real-time using a Racket-based language with functions for creating 3D graphics, as well as sound, among other things. This package allows you to use Emacs to write code for Fluxus instead of having to use Fluxus's built-in editor. Fluxus-mode connects to Fluxus using the OSC (open sound control) protocol and can send code to it to be evaluated by its interpreter. It also has functions to redirect Fluxus's error output to a buffer within Emacs, among other convenience utilities. Fluxus's home page is located at http://www.pawfal.org/fluxus/ .

### Direct link to the package repository

https://github.com/defaultxr/fluxus-mode

### Your association with the package

I created and maintain this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

