### PR TITLE
Add all-the-icons-dired

### DIFF
--- a/recipes/all-the-icons-dired
+++ b/recipes/all-the-icons-dired
@@ -1,0 +1,3 @@
+(all-the-icons-dired
+ :repo "jtbm37/all-the-icons-dired"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Adds dired support for [all-the-icons](https://github.com/domtronn/all-the-icons.el) package.

### Direct link to the package repository

https://github.com/jtbm37/all-the-icons-dired

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

