### PR TITLE
Add flycheck-demjsonlint recipe

### DIFF
--- a/recipes/flycheck-demjsonlint
+++ b/recipes/flycheck-demjsonlint
@@ -1,0 +1,1 @@
+(flycheck-demjsonlint :repo "z4139jq/flycheck-demjsonlint" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a [flycheck][flycheck-ref] checker for [json-mode][json-mode-ref] using jsonlint from [demjson][demjson-ref].
The built in JSON checker uses [zaach/jsonlint][jsonlint-ref] which has no rules support, but jsonlint from demjson has a set of options let you control which checks are to be performed, e.g. trailing-comma is allowed in .eslintrc but forbidden in package.json.

### Direct link to the package repository

https://github.com/z4139jq/flycheck-demjsonlint

### Your association with the package

I am the maintainer and the contributor of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [ ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

[demjson-ref]: https://github.com/dmeranda/demjson "demjson"
[json-mode-ref]: https://github.com/joshwnj/json-mode "json-mode"
[jsonlint-ref]: https://github.com/zaach/jsonlint "jsonlint"
[flycheck-ref]: http://www.flycheck.org "Flycheck"