### PR TITLE
Ignore `plantuml-mode` test files

### DIFF
--- a/recipes/plantuml-mode
+++ b/recipes/plantuml-mode
@@ -1,2 +1,3 @@
 (plantuml-mode :fetcher github
-               :repo "skuro/plantuml-mode")
+               :repo "skuro/plantuml-mode"
+               :files ("plantuml-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

The package is already included in MELPA, but in future releases more files will be added to support testing, including the PlantUML JAR file itself. To avoid killing MELPA with useless files, the recipe now has a `:files` whitelist including just the `plantuml-mode.el` file.

### Direct link to the package repository

https://github.com/skuro/plantuml-mode

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)