### PR TITLE
Add recipe for flycheck-title

### DIFF
--- a/recipes/flycheck-title
+++ b/recipes/flycheck-title
@@ -1,0 +1,2 @@
+(flycheck-title :repo "Wilfred/flycheck-title"
+                :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

flycheck-title is a small package that allows you to see flycheck messages in the Emacs frame title, keeping the minibuffer free for other things.

### Direct link to the package repository

https://github.com/Wilfred/flycheck-title

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)