### PR TITLE
Transfer org-jira project to ahungry.

### DIFF
--- a/recipes/org-jira
+++ b/recipes/org-jira
@@ -1,1 +1,1 @@
-(org-jira :fetcher github :repo "baohaojun/org-jira" :files ("jiralib.el" "org-jira.el"))
+(org-jira :fetcher github :repo "ahungry/org-jira" :files ("jiralib.el" "org-jira.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Use Jira in Emacs org-mode.

### Direct link to the package repository

https://github.com/ahungry/org-jira

### Your association with the package

I am the old maintainer, now transferring the project to ahungry.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [Y] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [Y] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [Y] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

See https://github.com/baohaojun/org-jira/issues/53 and
https://github.com/baohaojun/org-jira/issues/52.