### PR TITLE
Add recipe for flycheck-scala-sbt

### DIFF
--- a/recipes/flycheck-scala-sbt
+++ b/recipes/flycheck-scala-sbt
@@ -1,0 +1,3 @@
+(flycheck-scala-sbt
+ :fetcher github
+ :repo "rjmac/flycheck-scala-sbt")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a flycheck checker for Scala, which uses the sbt-mode package to run sbt as a compilation daemon.

### Direct link to the package repository

https://github.com/rjmac/flycheck-scala-sbt

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

