### PR TITLE
Add org-babel-eval-in-repl recipe

### DIFF
--- a/recipes/org-babel-eval-in-repl
+++ b/recipes/org-babel-eval-in-repl
@@ -1,0 +1,1 @@
+(org-babel-eval-in-repl :fetcher github :repo "diadochos/org-babel-eval-in-repl" :branch "master")


### PR DESCRIPTION
### Brief summary of what the package does

Send and eval org-mode babel code blocks in various REPLs.

### Direct link to the package repository

https://github.com/diadochos/org-babel-eval-in-repl

### Your association with the package

I'm the creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)