### PR TITLE
Add recipe for flycheck-plantuml

### DIFF
--- a/recipes/flycheck-plantuml
+++ b/recipes/flycheck-plantuml
@@ -1,0 +1,1 @@
+(flycheck-plantuml :fetcher github :repo "alexmurray/flycheck-plantuml")


### PR DESCRIPTION
### Brief summary of what the package does
Integrates plantuml with flycheck for automatic syntax errors highlighting for plantuml documents in Emacs

### Direct link to the package repository

https://github.com/alexmurray/flycheck-plantuml

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

I am the maintainer :smile: 

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

