### PR TITLE
Add counsel-gtags

### DIFF
--- a/recipes/counsel-gtags
+++ b/recipes/counsel-gtags
@@ -1,0 +1,1 @@
+(counsel-gtags :fetcher github :repo "syohex/emacs-counsel-gtags")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides [GNU GLOBAL](https://www.gnu.org/software/global/) interfaces of [ivy](https://github.com/abo-abo/swiper/)

### Direct link to the package repository

https://github.com/syohex/emacs-counsel-gtags

### Your association with the package

I'm maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

This package provides GNU Global interfaces of ivy.