### PR TITLE
add proportional package

### DIFF
--- a/recipes/proportional
+++ b/recipes/proportional
@@ -1,0 +1,1 @@
+(proportional :repo "ksjogo/proportional" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Globalized minor mode for having a proportional font by default in all buffers, some modes relying on space formatting (tabulated, some popup packages) are switched to mono.

### Direct link to the package repository

https://github.com/ksjogo/proportional

### Your association with the package

Maintainer

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

