### PR TITLE
Add company-statistics

### DIFF
--- a/recipes/company-statistics
+++ b/recipes/company-statistics
@@ -1,0 +1,1 @@
+(company-statistics :repo "company-mode/company-statistics" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

> Company-statistics is a global minor mode built on top of the in-buffer completion system company-mode. The idea is to keep a log of a certain number of completions you choose, along with some context information, and use that to rank candidates the next time you have to choose — hopefully showing you likelier candidates at the top of the list.

### Direct link to the package repository

https://github.com/company-mode/company-statistics

### Your association with the package

I am a very enthusiastic user. `company-statistics` is already on GNU ELPA, it would make it easier for everyone if it were on MELPA as well.

### Relevant communications with the upstream package maintainer

**None needed** (see https://github.com/company-mode/company-statistics/issues/9)

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

### FYI

I haven't so far been able to figure out the MELPA build process, and `package-lint` doesn't work for me, but I can't imagine there would be any problems with `company-statistics` since it's already on GNU ELPA. (But what do I know—if this is a problem let me know.)