### PR TITLE
Remove theme-changer recipe

### DIFF
--- a/recipes/theme-changer
+++ b/recipes/theme-changer
@@ -1,1 +1,0 @@
-(theme-changer :fetcher github :repo "hadronzoo/theme-changer")


### PR DESCRIPTION
The package uses un-prefixed symbols and the maintainer has not responded to my pull request intended to fix that in a month. https://github.com/hadronzoo/theme-changer/pull/8

Because using un-prefixed symbols is a big no-no, we should remove this package and only add it back again once this issue has been addressed.

/cc @hadronzoo