### PR TITLE
htmlize: switch to new canonical repository

### DIFF
--- a/recipes/htmlize
+++ b/recipes/htmlize
@@ -1,3 +1,3 @@
 (htmlize
- :repo "dunn/htmlize-mirror"
+ :repo "hniksic/emacs-htmlize"
  :fetcher github)


### PR DESCRIPTION
Hrvoje Nikšić replied to my email from https://github.com/melpa/melpa/issues/4125#issuecomment-239602359, pointing me to the new GitHub repo he created for htmlize.

Closes #4125.