### PR TITLE
Added malyon

### DIFF
--- a/recipes/malyon
+++ b/recipes/malyon
@@ -1,0 +1,1 @@
+(malyon :repo "speedenator/malyon" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a basic interpreter for version 3, 5, 8 z code
story files as generated by Inform (C) Graham Nelson and Infocom.

### Direct link to the package repository

https://github.com/speedenator/malyon.git

### Your association with the package

I'm just a fan, wanting to create a MELPA-based repository from the original EmacsWiki (https://www.emacswiki.org/emacs/MalyonMode) for better package portability

### Relevant communications with the upstream package maintainer

Have sent request to author / maintainer Peter Ilberg, but he hasn't responded yet. From comments, he states he is unable to maintain this anymore.

### Checklist

- [X ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

