### PR TITLE
add: js-format recipes

### DIFF
--- a/recipes/js-format
+++ b/recipes/js-format
@@ -1,3 +1,3 @@
 (js-format :fetcher github
            :repo "futurist/js-format.el"
-           :files (:defaults "*.js" "*.json"))
+           :files (:defaults "*.js" "*.json" "styles"))

--- a/recipes/js-format
+++ b/recipes/js-format
@@ -1,3 +1,3 @@
 (js-format :fetcher github
            :repo "futurist/js-format.el"
-           :files ("*.js" "*.el" "*.json"))
+           :files (:defaults "*.js" "*.json"))

--- a/recipes/js-format
+++ b/recipes/js-format
@@ -1,0 +1,3 @@
+(js-format :fetcher github
+           :repo "futurist/js-format.el"
+           :files ("*.js" "*.el" "*.json"))


### PR DESCRIPTION
### Brief summary of what the package does

Format js code using node, by region/buffer to local http server and then back, quickly and customizable.

### Direct link to the package repository

https://github.com/futurist/js-format.el

### Your association with the package

I'm the Creator and Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

# js-format 

Format js code (region/buffer) using js, the default formatter is [standard](http://standardjs.com/), but you can add more.

See the README.md file for details:

https://github.com/futurist/js-format.el