### PR TITLE
Add copy-as-format

### DIFF
--- a/recipes/copy-as-format
+++ b/recipes/copy-as-format
@@ -1,0 +1,3 @@
+(copy-as-format
+ :repo "sshaw/copy-as-format"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

 Copy buffer locations as GitHub/Slack/JIRA/HipChat/... formatted text

### Direct link to the package repository

https://github.com/sshaw/copy-as-format

### Your association with the package

Maintainer?

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

## Question

[I dynamically create](https://github.com/sshaw/copy-as-format/blob/88cf9135bed5cb343d113c07b80a3eba2d68949d/copy-as-format.el#L162-L167) a few public functions. Should I add explicit autoload cookies for each of these?