### PR TITLE
Add recipe for sensible-defaults

### DIFF
--- a/recipes/sensible-defaults
+++ b/recipes/sensible-defaults
@@ -1,0 +1,2 @@
+(sensible-defaults :repo "hrs/sensible-defaults.el"
+                   :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

sensible-defaults is a collection of well-named functions that tweak some of Emacs' settings. These functions are intended to be called from a user's `.emacs` file, and do things like ensure that files end in newlines, enable syntax highlighting everywhere, and make `dired` file sizes human-readable.

### Direct link to the package repository

https://github.com/hrs/sensible-defaults.el

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

(As a warning, `package-lint` errors since there are `/`s in the function names. I'm reluctant to change that, since those names are part of the public interface and we have a few users, but I'm open to it.)

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

sensible-defaults is a collection of functions that tweak some of Emacs'
settings. These functions are intended to be called from a user's .emacs
file, and do things like ensure that files end in newlines, enable
syntax highlighting everywhere, and make dired file sizes
human-readable.