### PR TITLE
recipes: Add csgo-conf-mode

### DIFF
--- a/recipes/csgo-conf-mode
+++ b/recipes/csgo-conf-mode
@@ -1,0 +1,2 @@
+(csgo-conf-mode :fetcher github
+                :repo "wynro/emacs-csgo-conf-mode")


### PR DESCRIPTION
### Brief summary of what the package does

The package offers syntax highlighting in Counter Strike: Global Offensive configuration files.

### Direct link to the package repository

https://github.com/wynro/emacs-csgo-conf-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

