### PR TITLE
Install all .el files for elpy

### DIFF
--- a/recipes/elpy
+++ b/recipes/elpy
@@ -1,9 +1,7 @@
 (elpy
  :fetcher github
  :repo "jorgenschaefer/elpy"
- :files ("elpy.el"
-         "elpy-refactor.el"
-         "elpy-pkg.el.in"
+ :files ("*.el"
          "NEWS.rst"
          "snippets"
          "elpy"))


### PR DESCRIPTION
Elpy added another .el file, breaking the MELPA install. Should not be a problem to just install all *.el files. There is no elpy-pkg.el.in anymore, either.

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

