### PR TITLE
Add recipe for winum

### DIFF
--- a/recipes/winum
+++ b/recipes/winum
@@ -1,0 +1,1 @@
+(winum :fetcher github :repo "deb0ch/winum.el")


### PR DESCRIPTION
### Brief summary of what the package does

Window numbers for Emacs: Navigate windows and frames using numbers !

This package is an extended and actively maintained version of the https://github.com/nschum/window-numbering.el package by Nikolaj Schumacher, with some ideas and code taken from https://github.com/abo-abo/ace-window.

This version brings, among other things, support for number sets across multiple frames, giving the user a smoother experience of multi-screen Emacs.

### Direct link to the package repository

https://github.com/deb0ch/winum.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

