### PR TITLE
Propose to use updated: inkpot-theme

### DIFF
--- a/recipes/inkpot-theme
+++ b/recipes/inkpot-theme
@@ -1,3 +1,3 @@
 (inkpot-theme
- :repo "siovan/emacs24-inkpot"
+ :repo "ideasman42/emacs-inkpot-theme"
  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Update to a theme

### Direct link to the package repository

https://github.com/ideasman42/emacs-inkpot-theme

### Your association with the package

Offering to take over as maintainer to (unmaintained package). since author isnt responding.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

----

Contacted the author and submitted PR's - but this hasn't been updated since 2012.

Heres a comparison showing (the emacs theme as it is, the original theme in gvim, and my updated theme in emacs).
http://members.iinet.net.au/~ideasman42/pics/inkpot_theme_compare.png

Summary:

- Match original theme colors for: Cursor, selection, parenthesis, highlighted-line, (keyword, constant, error & function) terms, secondary selection and isearch.
- Add colors for ivy.
- Add document comment color.
- Correct mode-line variable names.