### PR TITLE
Add mode for editing JastAdd AST files

### DIFF
--- a/recipes/jastadd-ast-mode
+++ b/recipes/jastadd-ast-mode
@@ -1,0 +1,1 @@
+(jastadd-ast-mode :fetcher github :repo "rudi/jastadd-ast-mode")


### PR DESCRIPTION
This mode adds support for JastAdd's AST definition files
(see http://jastadd.org/)

Upstream is at https://github.com/rudi/jastadd-ast-mode

I'm the author of the package.  package-lint and flycheck-package don't seem
to complain.