### PR TITLE
Add package lsp-mode

### DIFF
--- a/recipes/lsp-mode
+++ b/recipes/lsp-mode
@@ -1,1 +1,1 @@
-(lsp-mode :repo "vibhavp/emacs-lsp" :fetcher github :files ("*.el"))
+(lsp-mode :repo "vibhavp/emacs-lsp" :fetcher github)

--- a/recipes/lsp-mode
+++ b/recipes/lsp-mode
@@ -1,0 +1,1 @@
+(lsp-mode :repo "vibhavp/emacs-lsp" :fetcher github :files ("*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

lsp-mode links several emacs frameworks (like xref and completion-at-point) with the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)

### Direct link to the package repository

https://github.com/vibhavp/emacs-lsp

### Your association with the package

Author/Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (The only issue is that lsp-mode uses the prefix `lsp--` instead of `lsp-`). 
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
