### PR TITLE
change github source of the speed-type recipe

### DIFF
--- a/recipes/speed-type
+++ b/recipes/speed-type
@@ -1,1 +1,1 @@
-(speed-type :fetcher github :repo "hagleitn/speed-type")
+(speed-type :fetcher github :repo "parkouss/speed-type")


### PR DESCRIPTION
#The original speed-type package is not maintained anymore, and the
author is unresponsive for quite some time now.

So we agreed that I will now be the maintainer of this package, and
the source code is available on my speed-type's fork.

See the original discussion:
https://github.com/hagleitn/speed-type/issues/18

### Brief summary of what the package does

Speed-type is a package to practice touch typing in emacs.

### Direct link to the package repository

https://github.com/parkouss/speed-type

### Your association with the package

I'me an enthusiastic user, and should be the maintainer from now on.

### Relevant communications with the upstream package maintainer

see https://github.com/hagleitn/speed-type/issues/18

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
