### PR TITLE
Add autothemer

### DIFF
--- a/recipes/autothemer
+++ b/recipes/autothemer
@@ -1,0 +1,2 @@
+(autothemer :fetcher github :repo "sebastiansturm/autothemer")
+


### PR DESCRIPTION
### Brief summary of what the package does

Autothemer provides a facespec wrapper for deftheme.  Essentially it thins down the overhead needed to implement a color-class based theme correctly.  

Face specs and a palette are simpler to write and arbitrary code that also needs to use the palette can be included easily.

### Direct link to the package repository

https://github.com/sebastiansturm/autothemer/

### Your association with the package

Enthusiastic user / interested party.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
