### PR TITLE
Take releases off the "stable" branch

### DIFF
--- a/recipes/htmlize
+++ b/recipes/htmlize
@@ -1,4 +1,5 @@
 (htmlize
  :repo "hniksic/emacs-htmlize"
  :fetcher github
- :version-regexp "release/\\(.*\\)")
+ :version-regexp "release/\\(.*\\)"
+ :branch "stable")


### PR DESCRIPTION
MELPA seems to always use the latest htmlize commit from "master", which is incorrect - those commits can be unstable and are not meant to be used by end users - except contributors and those who want to test the bleeding-edge code.

Added the :branch "stable" to instruct the fetcher to take releases as they appear on the stable branch.