### PR TITLE
winum: move repo name to 'emacs-winum' to follow conventions

### DIFF
--- a/recipes/winum
+++ b/recipes/winum
@@ -1,1 +1,1 @@
-(winum :fetcher github :repo "deb0ch/winum.el")
+(winum :fetcher github :repo "deb0ch/emacs-winum")


### PR DESCRIPTION
I realized not long after first submitting the recipe that a widely used convention for naming Emacs packages was to use "emacs-" as a prefix to the package name.

It gives more visiblity when searching on Google and Github, gives a standardized way of finding emacs packages, and IMO is just a better name.

Currently, I can't find even find the package on Google when searching for `github deb0ch emacs winum`.

For the transition to be seamless, here is my strategy:
- I created a new repo `emacs-winum`, which is a mirror of the original repo
- This PR points to that mirror
- when this PR is merged, I will quickly between two `melpa` builds:
  - delete the mirror
  - rename the `winum.el` repo to `emacs-winum`, so that the melpa recipe will still be valid
  - update the file header with the correct address of the repo

I think that it is still time to make this change, as this package release is still very fresh.
