### PR TITLE
adding `choice-program` recipe

### DIFF
--- a/recipes/choice-program
+++ b/recipes/choice-program
@@ -1,0 +1,1 @@
+(choice-program :fetcher github :repo "plandes/choice-program" :files ("lisp/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Invokes a command line program that requires an a string of enumerations as input.

### Direct link to the package repository

https://github.com/plandes/choice-program

### Your association with the package

Original author/maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ X I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)