### PR TITLE
Add rust-playground recipe

### DIFF
--- a/recipes/rust-playground
+++ b/recipes/rust-playground
@@ -1,0 +1,1 @@
+(rust-playground :repo "grafov/rust-playground" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

GNU/Emacs mode that setup local playground for code snippets in Rust
language similar to play.rust-lang.org.

### Direct link to the package repository

https://github.com/grafov/rust-playground

### Your association with the package

I am author of the package.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
