### PR TITLE
Add multiple elisp modules and banner files

### DIFF
--- a/recipes/dashboard
+++ b/recipes/dashboard
@@ -1,3 +1,5 @@
 (dashboard :fetcher github
 	   :repo "rakanalh/emacs-dashboard"
-	   :files ("dashboard.el" "banner.txt"))
+	   :files ("dashboard*.el"
+		   "banners/*.png"
+		   "banners/*.txt"))

--- a/recipes/dashboard
+++ b/recipes/dashboard
@@ -1,5 +1,4 @@
 (dashboard :fetcher github
 	   :repo "rakanalh/emacs-dashboard"
 	   :files ("dashboard*.el"
-		   "banners/*.png"
-		   "banners/*.txt"))
+		   "banners"))


### PR DESCRIPTION
### Brief summary of what the package does
Dashboard is an extraction of Spacemacs-buffer into a standalone package.

This modification enables the packaging of multiple lisp files and multiple banner files that the new implementation is providing. The code base has not been merged into master as i don't want to break installations for existing users. However, the new implementation exists in the following PR: https://github.com/rakanalh/emacs-dashboard/pull/29

Once this has been approved and merged, i will merge my change into master so that we're in sync.

### Direct link to the package repository

https://github.com/rakanalh/emacs-dashboard

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)