### PR TITLE
adds the github theme

### DIFF
--- a/recipes/github-theme
+++ b/recipes/github-theme
@@ -1,0 +1,3 @@
+(github-theme
+ :repo "philiparvidsson/emacs-github-theme"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The package provides the GitHub color theme, trying to stay true to the theme used for syntax highlighting on the GitHub website.

### Direct link to the package repository

https://github.com/xxxxx/emacs-github-theme

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed*

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
