### PR TITLE
Add info-buffer recipe

### DIFF
--- a/recipes/info-buffer
+++ b/recipes/info-buffer
@@ -1,0 +1,3 @@
+(info-buffer
+ :fetcher github
+ :repo "llvilanova/info-buffer")


### PR DESCRIPTION
### Brief summary of what the package does

Interactive command (info-display-manual-in-buffer) for showing each info topic on its own buffer. With prefix, always creates a new buffer even if the topic is already opened.

### Direct link to the package repository

https://github.com/llvilanova/info-buffer

### Your association with the package

Author & maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)