### PR TITLE
Add rg.el recipe

### DIFF
--- a/recipes/rg
+++ b/recipes/rg
@@ -1,4 +1,3 @@
 (rg
  :fetcher github
- :repo "dajva/rg.el"
- :branch "melpa")
+ :repo "dajva/rg.el")

--- a/recipes/rg
+++ b/recipes/rg
@@ -1,0 +1,4 @@
+(rg
+ :fetcher github
+ :repo "dajva/rg.el"
+ :branch "melpa")


### PR DESCRIPTION
### Brief summary of what the package does

This is an Emacs frontend to grep/ag replacement ripgrep. It mimics (and reuses) the Emacs builtin rgrep command.

### Direct link to the package repository

https://github.com/dajva/rg.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
