### PR TITLE
Add initial recipe for ob-sql-mode.

### DIFF
--- a/recipes/ob-sql-mode
+++ b/recipes/ob-sql-mode
@@ -1,0 +1,1 @@
+(ob-sql-mode :repo "nikclayton/ob-sql-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Allows sql-mode to be used as an SQL backend for Org Babel SRC blocks. This allows all the SQL backends that sql-mode supports to be used instead of the smaller subset Org Babel currently supports.

### Direct link to the package repository

https://github.com/nikclayton/ob-sql-mode

### Your association with the package

Maintainer / author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

package-lint flagged some issues that I'll mention here.

One variable has a ":" in the name. This is how org-babel works -- it expects to find a variable of the name `org-babel-header-args:[package]`, so there's nothing I can do about that.

The others are the discrepancy between the package name (ob-sql-mode) and the variable prefixes (org-babel-sql-mode-...). This is something else that's customary in Org Babel packages -- see the various ob-* files in http://orgmode.org/cgit.cgi/org-mode.git/tree/lisp, for example:

- http://orgmode.org/cgit.cgi/org-mode.git/tree/lisp/ob-lua.el (org-babel-lua-...)
- http://orgmode.org/cgit.cgi/org-mode.git/tree/lisp/ob-python.el (org-babel-python-...)
- http://orgmode.org/cgit.cgi/org-mode.git/tree/lisp/ob-clojure.el (org-babel-clojure-...)

I hope to get this rolled in to the official distribution at some point, so I've elected to follow their existing coding and naming style.