### PR TITLE
add helm-etags-plus recipe

### DIFF
--- a/recipes/ctags-update
+++ b/recipes/ctags-update
@@ -1,3 +1,2 @@
-(ctags-update :repo "jixiuf/helm-etags-plus"
-              :fetcher github
-              :files ("ctags-update.el"))
+(ctags-update :repo "jixiuf/ctags-update"
+              :fetcher github)

--- a/recipes/helm-etags-plus
+++ b/recipes/helm-etags-plus
@@ -1,0 +1,2 @@
+(helm-etags-plus :repo "jixiuf/helm-etags-plus"
+              :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
Another Etags helm.el interface, it support multiple tag files.


### Direct link to the package repository

https://github.com/jixiuf/helm-etags-plus

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer
 

 