### PR TITLE
Add eshell-fixed-prompt recipe

### DIFF
--- a/recipes/eshell-fixed-prompt
+++ b/recipes/eshell-fixed-prompt
@@ -1,0 +1,2 @@
+(eshell-fixed-prompt :fetcher github
+                     :repo "mallt/eshell-fixed-prompt-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Minor mode to restrict eshell to a single fixed prompt

### Direct link to the package repository

https://github.com/mallt/eshell-fixed-prompt-mode

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
