### PR TITLE
Add recipe for Russian holidays for Emacs calendar

### DIFF
--- a/recipes/russian-holidays
+++ b/recipes/russian-holidays
@@ -1,0 +1,1 @@
+(russian-holidays :repo "grafov/russian-holidays" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This mode adds Russian holidays for GNU/Emacs calendar. Russian Federation is multinational country with own holidays in different regions. The package has info about official state holidays and official regional holidays.

### Direct link to the package repository

https://github.com/grafov/russian-holidays

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
