### PR TITLE
Add org-mime

### DIFF
--- a/recipes/org-mime
+++ b/recipes/org-mime
@@ -1,0 +1,2 @@
+(org-mime :repo "org-mime/org-mime" :fetcher github)
+


### PR DESCRIPTION
### Brief summary of what the package does

org html export for text/html MIME emails

### Direct link to the package repository

https://github.com/org-mime/org-mime

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

For now, I'm the only maintainer. I contacted the org guy Nicolas Goaziou who agreed that original org-mime was a little bit of outdated. He suggest the better way was to manage org-mime as an independent package and org site would update link to org-mime when it were publicized.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
