### PR TITLE
adds the zweilight theme

### DIFF
--- a/recipes/zweilight-theme
+++ b/recipes/zweilight-theme
@@ -1,0 +1,3 @@
+(zweilight-theme
+ :repo "philiparvidsson/emacs-zweilight-theme"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides the Zweilight theme.

### Direct link to the package repository

https://github.com/xxxxx/emacs-zweilight-theme

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed*

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
