### PR TITLE
Add recipe for emacs-promise

### DIFF
--- a/recipes/promise
+++ b/recipes/promise
@@ -1,0 +1,1 @@
+(promise :repo "chuntaro/emacs-promise" :fetcher github)


### PR DESCRIPTION
This is a simple implementation of Promises/A+.  

This implementation ported the following Promises/A+ implementation faithfully.  
https://github.com/then/promise

* The same API as JavaScript version Promise can be used.
 * then, catch, resolve, reject, all, race, etc...
* supports "thenable"
* supports "Inheritance of Promise"
* supports "rejection-tracking"