### PR TITLE
Summary: Run mbsync from Emacs

### DIFF
--- a/recipes/mbsync
+++ b/recipes/mbsync
@@ -1,3 +1,2 @@
 (mbsync :fetcher github
-                 :repo "dimitri/mbsync-el"
-                 :files ("mbsync.el"))
+                 :repo "dimitri/mbsync-el")

--- a/recipes/mbsync
+++ b/recipes/mbsync
@@ -1,0 +1,3 @@
+(mbsync :fetcher github
+                 :repo "dimitri/mbsync-el"
+                 :files ("mbsync.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This Emacs Lisp package allows to easily call the mbsync command line from the isync tool directly from within Emacs, for syncing a local Maildir with an IMAP server.


### Direct link to the package repository

https://github.com/dimitri/mbsync-el

### Your association with the package

Contributor


### Relevant communications with the upstream package maintainer

https://github.com/dimitri/mbsync-el/issues/6 

(also, [waiting](https://github.com/dimitri/mbsync-el/pull/5#issuecomment-273063655) for write access so I can fix some checkdoc issues)

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
