### PR TITLE
Add recipe for eziam-theme

### DIFF
--- a/recipes/eziam-theme
+++ b/recipes/eziam-theme
@@ -1,0 +1,1 @@
+(eziam-theme :repo "thblt/eziam-theme-emacs" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A mostly monochrome color theme, inspired by Tao and Leuven.  Comes with dark and light background.

### Direct link to the package repository

https://github.com/thblt/eziam-theme-emacs

### Your association with the package

Author and maintener

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

    I don't know what to do with the warnings that functions defined in the shared package eziam-common.el don't have eziam-common as a prefix.  What I've done (package common functions in eziam-common.el, use the name of the theme as a prefix) seems in wide use (see spacemacs-theme).  If this is not OK, please tell me how you'd address this.
    
    Package-lint reports no other issues.

- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
