### PR TITLE
add test-c (package to quickly test C snippets)

### DIFF
--- a/recipes/test-c
+++ b/recipes/test-c
@@ -1,0 +1,1 @@
+ (test-c :repo "aaptel/test-c" :fetcher github) 


### PR DESCRIPTION
### Brief summary of what the package does

Quickly test C snippets from Emacs

### Direct link to the package repository

https://github.com/aaptel/test-c

### Your association with the package

I am the author.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
