### PR TITLE
add org-parser.

### DIFF
--- a/recipes/org-parser
+++ b/recipes/org-parser
@@ -1,0 +1,1 @@
+(org-parser :fetcher bitbucket :repo "zck/org-parser.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package parses an org file into a list of structure objects, so it can be programmatically worked with.

### Direct link to the package repository

https://bitbucket.org/zck/org-parser.el

### Your association with the package

I'm the creator/maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback -- All errors fixed but some naming recommendations.
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
