### PR TITLE
remove ttrss package

### DIFF
--- a/recipes/ttrss
+++ b/recipes/ttrss
@@ -1,1 +1,0 @@
-(ttrss :fetcher github :repo "pedros/ttrss.el" :files ("ttrss.el"))


### PR DESCRIPTION
This is abandonware at this point. It should be removed from the available recipes.

### Brief summary of what the package does

Tiny Tiny RSS elisp bindings Edit

### Direct link to the package repository

https://github.com/pedros/ttrss.el

### Your association with the package

Developer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
