### PR TITLE
Add fuff

### DIFF
--- a/recipes/fuff
+++ b/recipes/fuff
@@ -1,0 +1,1 @@
+(fuff :repo "joelmo/fuff" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides a command (fuff-find-file) that lists files with find in completing read. Also provides a hook for ido that switches to fuff-find-file from ido-find-file, when a starting point directory is entered. These starting points can be customized.

### Direct link to the package repository

https://github.com/joelmo/fuff

### Your association with the package

I wrote the package. I did not find any of these to suite my needs: projectile, find-file-in-project, find-file-in-repository. Fuff is similar to these, biggest difference it the ido switch. 

### Relevant communications with the upstream package maintainer

If there is any problems with this package, I will fix it...

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
