### PR TITLE
Add salt-mode again with a new maintainer

### DIFF
--- a/recipes/salt-mode
+++ b/recipes/salt-mode
@@ -1,0 +1,1 @@
+(salt-mode :repo "glynnforrest/salt-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for saltstack states, using mmm-jinja2.

The recipe for mmm-jinja2 should be merged first. https://github.com/melpa/melpa/pull/4525

### Direct link to the package repository

https://github.com/glynnforrest/salt-mode

### Your association with the package

New maintainer, see https://github.com/melpa/melpa/issues/4424

### Relevant communications with the upstream package maintainer

I have emailed @deybhayden to let him know I'm going to maintain the package. His comment on https://github.com/syl20bnr/spacemacs/issues/8225 shows he is open to this.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
