### PR TITLE
Remove rustfmt recipe

### DIFF
--- a/recipes/rustfmt
+++ b/recipes/rustfmt
@@ -1,2 +1,0 @@
-(rustfmt :fetcher github
-         :repo "fbergroth/emacs-rustfmt")


### PR DESCRIPTION
This package has been deprecated by the author as the functionality is
now part of rust-mode.