### PR TITLE
add universal-indent-size

### DIFF
--- a/recipes/universal-indent-size
+++ b/recipes/universal-indent-size
@@ -1,0 +1,3 @@
+(universal-indent-size
+ :fetcher github
+ :repo "CodeFalling/universal-indent-size")


### PR DESCRIPTION
### Brief summary of what the package does

Set all indent size in emacs at once.

### Direct link to the package repository

https://github.com/CodeFalling/universal-indent-size

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
