### PR TITLE
Added the emacs-dokuwiki recipe.

### DIFF
--- a/recipes/dokuwiki
+++ b/recipes/dokuwiki
@@ -1,3 +1,3 @@
-(emacs-dokuwiki
+(dokuwiki
  :fetcher github
  :repo "accidentalrebel/emacs-dokuwiki")

--- a/recipes/emacs-dokuwiki
+++ b/recipes/emacs-dokuwiki
@@ -1,0 +1,3 @@
+(emacs-dokuwiki
+ :fetcher github
+ :repo "accidentalrebel/emacs-dokuwiki")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a way to edit a remote Dokuwiki wiki on Emacs.  Uses Dokuwiki's XML-RPC API.

### Direct link to the package repository

https://github.com/accidentalrebel/emacs-dokuwiki

### Your association with the package

I am the creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
