### PR TITLE
Add standardfmt package

### DIFF
--- a/recipes/standardfmt
+++ b/recipes/standardfmt
@@ -1,0 +1,1 @@
+(standardfmt :repo "jimeh/standardfmt.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs minor-mode to format JavaScript with [standard](https://github.com/feross/standard) / [semistandard](https://github.com/Flet/semistandard) on save.

### Direct link to the package repository

https://github.com/jimeh/standardfmt.el

### Your association with the package

Author/maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
