### PR TITLE
Add recipe for emacs-async-await

### DIFF
--- a/recipes/async-await
+++ b/recipes/async-await
@@ -1,0 +1,1 @@
+(async-await :repo "chuntaro/emacs-async-await" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a simple implementation of Async/Await.  
Inspired by the Async/Await implementation of TypeScript.

This implementation uses generator.el included in Emacs 25.

### Direct link to the package repository

https://github.com/chuntaro/emacs-async-await

### Your association with the package

Author, maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
