### PR TITLE
Fix not including examples subdirectory

### DIFF
--- a/recipes/async-await
+++ b/recipes/async-await
@@ -1,0 +1,1 @@
+(async-await :repo "chuntaro/emacs-async-await" :fetcher github)

--- a/recipes/async-await
+++ b/recipes/async-await
@@ -1,1 +1,2 @@
-(async-await :repo "chuntaro/emacs-async-await" :fetcher github)
+(async-await :repo "chuntaro/emacs-async-await" :fetcher github
+             :files ("async-await.el" ("examples" "examples/async-await-examples.el")))

--- a/recipes/promise
+++ b/recipes/promise
@@ -1,1 +1,2 @@
-(promise :repo "chuntaro/emacs-promise" :fetcher github)
+(promise :repo "chuntaro/emacs-promise" :fetcher github
+         :files ("*.el" ("examples" "examples/*.el")))


### PR DESCRIPTION
Since the examples subdirectory is not included, please merge.
