### PR TITLE
Add picpocket recipe

### DIFF
--- a/recipes/picpocket
+++ b/recipes/picpocket
@@ -1,0 +1,1 @@
+(picpocket :fetcher github :repo "johanclaesson/picpocket")


### PR DESCRIPTION
### Brief summary of what the package does

Picpocket is an image viewer which requires GNU Emacs 24.4+ compiled with ImageMagick.
It have commands for adding tags to images.  The tags are saved to disk.

### Direct link to the package repository

https://github.com/johanclaesson/picpocket

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [not really] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

Regarding package-lint i use the prefix picp- as well as picpocket- since picpocket- is rather long.
package-lint does not like this.  This is probably unacceptable.  But personally i feel it makes sense.
Therefore i like to ask one thing before i change it.  I am thinking of changing package-lint so that it would accept the prefixes listed in a file local variable (say package-lint-prefixes) in addition to the package name.  Unless you think this is a terrible idea then i might attempt to add this behaviour to 
package-lint.

This is not a big deal.  If you don't like the idea then i will just change to use picpocket- prefix everywhere. 

