### PR TITLE
Add markdown-edit-indirect recipe

### DIFF
--- a/recipes/markdown-edit-indirect
+++ b/recipes/markdown-edit-indirect
@@ -1,0 +1,1 @@
+(markdown-edit-indirect :fetcher github :repo "emacs-pe/markdown-edit-indirect.el")


### PR DESCRIPTION
### Brief summary of what the package does

Allows edit markdown mode code blocks in a indirect buffer, similar to `org-edit-src-code`.

### Direct link to the package repository

https://github.com/emacs-pe/markdown-edit-indirect.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
