### PR TITLE
Remove ebib-handy

### DIFF
--- a/recipes/ebib-handy
+++ b/recipes/ebib-handy
@@ -1,1 +1,0 @@
-(ebib-handy :fetcher github :repo "tumashu/ebib-handy")


### PR DESCRIPTION
ebib-handy cannot work again for the change of ebib, and I have no time and interesting to maintain it , so please remove it
