### PR TITLE
adding go-guru.el and go-rename.el

### DIFF
--- a/recipes/go-mode
+++ b/recipes/go-mode
@@ -1,5 +1,5 @@
 (go-mode
  :repo "dominikh/go-mode.el"
  :fetcher github
- :files ("go-mode.el"))
+ :files ("go-mode.el" "go-guru.el" "go-rename.el"))
 


### PR DESCRIPTION
Since guru has moved elisp files from golang.org/x/tools to go-mode
please add these files to go-mode package 