### PR TITLE
Update github repo for evil-magit and evil-ediff

### DIFF
--- a/recipes/evil-ediff
+++ b/recipes/evil-ediff
@@ -1,1 +1,1 @@
-(evil-ediff :repo "justbur/evil-ediff" :fetcher github)
+(evil-ediff :repo "emacs-evil/evil-ediff" :fetcher github)

--- a/recipes/evil-magit
+++ b/recipes/evil-magit
@@ -1,1 +1,1 @@
-(evil-magit :repo "justbur/evil-magit" :fetcher github)
+(evil-magit :repo "emacs-evil/evil-magit" :fetcher github)


### PR DESCRIPTION
I transferred ownership of my packages [evil-magit](https://github.com/emacs-evil/evil-magit) and [evil-ediff](https://github.com/emacs-evil/evil-ediff) to the emacs-evil organization. I'm now a member at this organization, too. 

This PR just updates the links in the recipes. Thanks