### PR TITLE
Add recipe for org-table-sticky-header

### DIFF
--- a/recipes/org-table-sticky-header
+++ b/recipes/org-table-sticky-header
@@ -1,0 +1,2 @@
+(org-table-sticky-header :repo "cute-jumper/org-table-sticky-header"
+                         :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A minor mode to show the sticky header for org-mode tables.

### Direct link to the package repository

https://github.com/cute-jumper/org-table-sticky-header

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
