### PR TITLE
Add recipe for ede-php-autoload-installers

### DIFF
--- a/recipes/ede-php-autoload-composer-installers
+++ b/recipes/ede-php-autoload-composer-installers
@@ -1,0 +1,2 @@
+(ede-php-autoload-composer-installers :fetcher github
+                                      :repo "xendk/ede-php-autoload-composer-installers")


### PR DESCRIPTION
### Brief summary of what the package does

This package add support for https://github.com/composer/installers to ede-php-autoload, allowing it to locate class files when composer/installers has relocated the package.

### Direct link to the package repository

https://github.com/xendk/ede-php-autoload-composer-installers

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
