### PR TITLE
dired-icon: Add get-icon-path-macos.m to the file list.

### DIFF
--- a/recipes/dired-icon
+++ b/recipes/dired-icon
@@ -2,4 +2,5 @@
  :repo "xuhdev/dired-icon"
  :fetcher gitlab
  :files (:defaults
-         "get-icon-path-gtk3.py"))
+         "get-icon-path-gtk3.py"
+         "get-icon-path-macos.m"))


### PR DESCRIPTION
### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

To fully support MacOS, a new file get-icon-path-macos.m is added.

### Checklist

- [ X ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ X ] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
