### PR TITLE
Add recipe for flow-mode

### DIFF
--- a/recipes/flow-mode
+++ b/recipes/flow-mode
@@ -1,0 +1,1 @@
+(flow-mode :fetcher github :repo "an-sh/flow-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for flowtype.org derived from web-mode. Very minimal, but better than nothing.

### Direct link to the package repository

https://github.com/an-sh/flow-mode

### Your association with the package

Maintainer + enthusiastic user. Some code is borrowed from the original [flow-for-emacs](https://github.com/flowtype/flow-for-emacs) snippet, hence the original licence is left intact.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
