### PR TITLE
Add remember-last-theme recipe

### DIFF
--- a/recipes/remember-last-theme
+++ b/recipes/remember-last-theme
@@ -1,0 +1,1 @@
+(remember-last-theme :repo "anler/remember-last-theme" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package makes Emacs remember the last used theme, so nex time is opened it uses that same theme.

### Direct link to the package repository

https://github.com/anler/remember-last-theme

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
