### PR TITLE
Add ssass-mode

### DIFF
--- a/recipes/ssass-mode
+++ b/recipes/ssass-mode
@@ -1,0 +1,1 @@
+(ssass-mode :fetcher github :repo "AdamNiederer/ssass-mode")


### PR DESCRIPTION
### Brief summary of what the package does

ssass-mode (simpler sass mode) is a clone of sass-mode which works in mmm-mode, but makes a few concessions on syntax highlighting to support it.

### Direct link to the package repository

https://github.com/AdamNiederer/ssass-mode

### Your association with the package

I wrote it.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

My fork of MELPA is ancient, so I might be missing a few boxes. It passes package-lint, byte-compile-file, and checkdoc.

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
