### PR TITLE
Add literal-string-mode package

### DIFF
--- a/recipes/literal-string
+++ b/recipes/literal-string
@@ -1,0 +1,1 @@
+(literal-string :fetcher github :repo "joodie/literal-string-mode")


### PR DESCRIPTION
This package provides a minor mode for editing long string
literals (especially docstrings) in a dedicated buffer.

The source repository is at
https://github.com/joodie/literal-string-mode

I am the author of the literal-string-mode package.

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
