### PR TITLE
Rename el-exiftool to exiftool

### DIFF
--- a/recipes/el-exiftool
+++ b/recipes/el-exiftool
@@ -1,3 +1,0 @@
-(el-exiftool
- :fetcher git
- :url "https://git.systemreboot.net/el-exiftool/")

--- a/recipes/exiftool
+++ b/recipes/exiftool
@@ -1,3 +1,4 @@
 (exiftool
  :fetcher git
- :url "https://git.systemreboot.net/exiftool.el/")
+ :url "https://git.systemreboot.net/exiftool.el/"
+ :old-names (el-exiftool))

--- a/recipes/exiftool
+++ b/recipes/exiftool
@@ -1,0 +1,3 @@
+(exiftool
+ :fetcher git
+ :url "https://git.systemreboot.net/exiftool.el/")


### PR DESCRIPTION
I've renamed `el-exiftool` to `exiftool` as discussed in #4592 