### PR TITLE
Add recipe for neato-graph-bar

### DIFF
--- a/recipes/neato-graph-bar
+++ b/recipes/neato-graph-bar
@@ -1,0 +1,3 @@
+(neato-graph-bar :fetcher gitlab
+                 :repo "RobertCochran/neato-graph-bar"
+                 :branch "release")


### PR DESCRIPTION
### Brief summary of what the package does

Provides updating graph bars for CPU and memory/swap, inspired by `htop`.
Useful to have in an Emacs window to quickly eyeball CPU or memory usage.

### Direct link to the package repository

https://gitlab.com/RobertCochran/neato-graph-bar

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

Well, that's me, so **None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

I didn't try the build in the sandbox, but it worked on my normal Emacs session.
I only depend on Emacs 24.3 and `cl-lib`, so there shouldn't be any dependency problems,
but you never know.

Please let me know if there's anything I need to do or fix.

Thanks!