### PR TITLE
Recipe: helm-sql-mode

### DIFF
--- a/recipes/helm-sql-mode
+++ b/recipes/helm-sql-mode
@@ -1,0 +1,1 @@
+(helm-sql-mode :repo "eric-hansen/helm-sql-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Integrates Helm with sql-mode to let the user choose which DB to connect to (right now only Postgres is supported).

### Direct link to the package repository

https://github.com/eric-hansen/helm-sql-mode

### Your association with the package

Maintainer/author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
