### PR TITLE
Add recipe for org-notebook

### DIFF
--- a/recipes/org-notebook
+++ b/recipes/org-notebook
@@ -1,0 +1,1 @@
+(org-notebook :fetcher github :repo "Rahi374/org-notebook")


### PR DESCRIPTION
### Brief summary of what the package does

Eases use of org-mode for note-taking.

The main functionality is to be able to easily and quickly insert a new image and draw it without having to think of what to call it, figure out where it is an what it's called, and typing out the link.

There is also functionality to create a new "notebook" populated with customized headers.

### Direct link to the package repository

https://github.com/Rahi374/org-notebook

### Your association with the package

I am the creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
