### PR TITLE
Add elisp-docstring-mode

### DIFF
--- a/recipes/elisp-docstring-mode
+++ b/recipes/elisp-docstring-mode
@@ -1,0 +1,1 @@
+(elisp-docstring-mode :fetcher github :repo "Fuco1/elisp-docstring-mode")


### PR DESCRIPTION
### Brief summary of what the package does

#### elisp-docstring-mode

A simple major-mode for editing content of Emacs Lisp docstrings.  Very useful in combination with [string-edit](https://github.com/magnars/string-edit.el).

#### Features

Provides font-lock.  In combination with string-edit, there is support for automatic escaping and unascaping of quotes.

### Direct link to the package repository

https://github.com/Fuco1/elisp-docstring-mode

### Your association with the package

Author/Maintainer