### PR TITLE
Add auto-read-only recipe

### DIFF
--- a/recipes/auto-read-only
+++ b/recipes/auto-read-only
@@ -1,0 +1,1 @@
+(auto-read-only :fetcher github :repo "zonuexe/auto-read-only.el")


### PR DESCRIPTION
### Brief summary of what the package does

Automatically make the buffer-file to read-only based on buffer-file-name. For example, it can protect library code provided by third parties.

### Direct link to the package repository

https://github.com/zonuexe/auto-read-only.el

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
