### PR TITLE
add helm spotify plus to melpa

### DIFF
--- a/recipes/helm-spotify-plus
+++ b/recipes/helm-spotify-plus
@@ -1,0 +1,2 @@
+(helm-spotify-plus :repo "wandersoncferreira/helm-spotify-plus"
+                   :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
Improved version of a old package called `helm-spotify. 
Helm is used only here to narrow the candidates we get from the Spotify API instead of directing communicating to the API through the candidate buffer.

### Direct link to the package repository

https://github.com/wandersoncferreira/helm-spotify-plus


### Your association with the package
I am one of the maintainers.

### Relevant communications with the upstream package maintainer
None needed.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
