### PR TITLE
Add gtk-pomodoro-indicator

### DIFF
--- a/recipes/gtk-pomodoro-indicator
+++ b/recipes/gtk-pomodoro-indicator
@@ -1,0 +1,3 @@
+(gtk-pomodoro-indicator :fetcher github
+                        :repo "abo-abo/gtk-pomodoro-indicator"
+                        :files ("*.el" "*.py" "icons"))


### PR DESCRIPTION
### Brief summary of what the package does

A pomodoro indicator for the GTK tray.

### Direct link to the package repository

https://github.com/abo-abo/gtk-pomodoro-indicator

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
