### PR TITLE
Replace direnv package with alternative implementation

### DIFF
--- a/recipes/direnv
+++ b/recipes/direnv
@@ -1,1 +1,1 @@
-(direnv :fetcher github :repo "jml/direnv-el")
+(direnv :fetcher github :repo "wbolster/emacs-direnv")


### PR DESCRIPTION
This changes the direnv package to use this one instead:

https://github.com/wbolster/emacs-direnv

...which is fine according to the author of the current melpa direnv package:

https://github.com/jml/direnv-el/issues/3#issuecomment-284720244