### PR TITLE
persp-mode-projectile-bridge recipe

### DIFF
--- a/recipes/persp-mode-projectile-bridge
+++ b/recipes/persp-mode-projectile-bridge
@@ -1,0 +1,2 @@
+(persp-mode-projectile-bridge :repo "Bad-ptr/persp-mode-projectile-bridge.el"
+                              :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Integrates persp-mode and projectile-mode, such that each projectile package has a perspective.
Both persp-mode and projectile-mode are already in MELPA.

### Direct link to the package repository

https://github.com/Bad-ptr/persp-mode-projectile-bridge.el

### Your association with the package

Requested this integration from the persp-mode maintainer.

### Relevant communications with the upstream package maintainer

https://github.com/Bad-ptr/persp-mode.el/issues/40#issuecomment-285876565
The maintainer @Bad-ptr created the github repo, and stated happy to have it submitted to MELPA.

### Checklist

Please confirm with `x`:

- [x ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x ] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
