### PR TITLE
org-mru-clock

### DIFF
--- a/recipes/org-mru-clock
+++ b/recipes/org-mru-clock
@@ -1,0 +1,2 @@
+(org-mru-clock :fetcher github
+               :repo "unhammer/org-mru-clock")


### PR DESCRIPTION
### Brief summary of what the package does

Summary: This package replaces functions like `org-clock-select-task'
and `org-clock-in-last' with ones that first ensure that
`org-clock-history' is filled with your `org-mru-clock-how-many' most
recent tasks, and lets you pick from a list before clocking in.

### Direct link to the package repository

Link: https://github.com/unhammer/org-mru-clock

### Your association with the package

Association: Author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
