### PR TITLE
Add recipe for comint-intercept

### DIFF
--- a/recipes/comint-intercept
+++ b/recipes/comint-intercept
@@ -1,0 +1,1 @@
+(comint-intercept :repo "hying-caritas/comint-intercept" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Intercept the input in comint-mode.  This can be used to run eshell command, or run some command in a terminal buffer from the command line in shell buffer.

### Direct link to the package repository

https://github.com/hying-caritas/comint-intercept

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
