### PR TITLE
Add evil-lion package

### DIFF
--- a/recipes/evil-lion
+++ b/recipes/evil-lion
@@ -1,0 +1,3 @@
+(evil-lion :repo "edkolev/evil-lion"
+           :fetcher github
+           :files ("evil-lion.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Defines a minor mode (evil-lion-mode) which adds two evil-mode operators `gl` and `gL` for left and right align. Port of [vim-lion](https://github.com/tommcdo/vim-lion)

### Direct link to the package repository

https://github.com/edkolev/evil-lion

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
