### PR TITLE
Adding recipe for org-sync-snippets

### DIFF
--- a/recipes/org-sync-snippets
+++ b/recipes/org-sync-snippets
@@ -1,0 +1,1 @@
+(org-sync-snippets :repo "abrochard/org-sync-snippets" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Simple extension to export snippets to org-mode and vice versa.

### Direct link to the package repository

https://github.com/abrochard/org-sync-snippets

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

NB: follow up to [#4631](https://github.com/melpa/melpa/pull/4631) to remove exta commits.