### PR TITLE
Remove counsel-ripgrep

### DIFF
--- a/recipes/counsel-ripgrep
+++ b/recipes/counsel-ripgrep
@@ -1,1 +1,0 @@
-(counsel-ripgrep :repo "julienXX/counsel-ripgrep" :fetcher github)


### PR DESCRIPTION
Hi I'm the maintainer of counsel-ripgrep and I deleted this this package since ripgrep support is already in counsel. It should be removed from Melpa.