### PR TITLE
Add monokai alt theme

### DIFF
--- a/recipes/monokai-alt-theme
+++ b/recipes/monokai-alt-theme
@@ -1,0 +1,3 @@
+(monokai-alt-theme
+ :repo "dawidof/emacs-monokai-theme"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Theme with a dark background. Based on sublime monokai theme.

### Direct link to the package repository

https://github.com/dawidof/emacs-monokai-theme

### Your association with the package

creator/maintainer

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
