### PR TITLE
Add thinks.el

### DIFF
--- a/recipes/thinks
+++ b/recipes/thinks
@@ -1,0 +1,1 @@
+(thinks :fetcher github :repo "davep/thinks.el")


### PR DESCRIPTION
### Brief summary of what the package does

`thinks.el` is a little bit of silliness inspired by the think bubbles you see in cartoons. It allows you to

```
. o O ( insert text that looks like this )
```

into a buffer. This could possibly be handy for use in email and usenet
postings.

### Direct link to the package repository

https://github.com/davep/thinks.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
