### PR TITLE
Add uptimes.el

### DIFF
--- a/recipes/uptimes
+++ b/recipes/uptimes
@@ -1,0 +1,1 @@
+(uptimes :fetcher github :repo "davep/uptimes.el")


### PR DESCRIPTION
### Brief summary of what the package does

uptimes.el provides a simple system for tracking and displaying the uptimes of your Emacs sessions. Simply loading uptimes.el from your ~/.emacs file (or equivalent) will start the tracking of any session.

### Direct link to the package repository

https://github.com/davep/uptimes.el

### Your association with the package

Maintainer?

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
