### PR TITLE
Add ox-minutes

### DIFF
--- a/recipes/ox-minutes
+++ b/recipes/ox-minutes
@@ -1,0 +1,2 @@
+(ox-minutes :fetcher github
+            :repo "kaushalmodi/ox-minutes")


### PR DESCRIPTION
### Brief summary of what the package does

 The aim of this exporter to generate meeting minutes plain text that is
 convenient to send via email.
  - Unnecessary blank lines are removed from the final exported plain text.
  - Header decoration and section numbers done in the default ASCII exports
    is prevented.
  - Also TOC and author name are not exported.

 This is an ox-ascii derived backed for org exports.

### Direct link to the package repository

https://github.com/kaushalmodi/ox-minutes

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 **But I faced some issues -- Details are [here](https://github.com/melpa/melpa/issues/4648).**
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)