### PR TITLE
Add org-edit-latex package

### DIFF
--- a/recipes/org-edit-latex
+++ b/recipes/org-edit-latex
@@ -1,0 +1,1 @@
+(org-edit-latex :repo "et2010/org-edit-latex" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

org-edit-latex is an extension for org-mode. It let you edit a latex fragment just like editing a src block.

### Direct link to the package repository

https://github.com/et2010/org-edit-latex

### Your association with the package

[Are you the maintainer? A contributor? An enthusiastic user?]

Yes, I'm the maintainer, the contributor and an enthusiastic user 😄 

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
