### PR TITLE
Add recipe for wotd

### DIFF
--- a/recipes/wotd
+++ b/recipes/wotd
@@ -1,0 +1,2 @@
+(wotd :repo "cute-jumper/emacs-word-of-the-day"
+      :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Show word-of-the-day from various online sources

### Direct link to the package repository

https://github.com/cute-jumper/emacs-word-of-the-day

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
**QUESTION**: I use the acronym `wotd` as the package prefix since I think `word-of-the-day` is a little bit too long. `package-lint` complains about that. Is this not acceptable?
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
