### PR TITLE
Add obfusurl.el

### DIFF
--- a/recipes/obfusurl
+++ b/recipes/obfusurl
@@ -1,0 +1,1 @@
+(obfusurl :fetcher github :repo "davep/obfusurl.el")


### PR DESCRIPTION
### Brief summary of what the package does

`obfusurl.el` provides `obfusurl`, a command that will obfuscate an
URL under the cursor. This might be useful if you are writing out an URL
for someone but the URL itself might spoil the surprise.

For example, this:

```
<URL:http://www.davep.org/emacs/>
```

is turned into this:

```
<URL:http://www.davep.org/%65%6d%61%63%73/>
```
### Direct link to the package repository

https://github.com/davep/obfusurl.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
