### PR TITLE
Add protocols.el

### DIFF
--- a/recipes/protocols
+++ b/recipes/protocols
@@ -1,0 +1,1 @@
+(protocols :fetcher github :repo "davep/protocols.el")


### PR DESCRIPTION
### Brief summary of what the package does

`protocols.el` provides a command for easily looking up a protocol as found in `/etc/protocols`.

### Direct link to the package repository

https://github.com/davep/protocols.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
