### PR TITLE
Add recipe for helm-navi

### DIFF
--- a/recipes/helm-navi
+++ b/recipes/helm-navi
@@ -1,0 +1,1 @@
+(helm-navi :fetcher github :repo "emacs-helm/helm-navi")


### PR DESCRIPTION
### Brief summary of what the package does

This package lets you navigate through a buffer using the headings and keywords provided by `outshine` and `navi-mode`, presented in a Helm buffer.

### Direct link to the package repository
https://github.com/emacs-helm/helm-navi

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)