### PR TITLE
Makefile: Add INSTALL argument to sandbox target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,12 @@ packages will be available for installation along with those already
 in MELPA:
 
 ```
-EMACS_COMMAND=/path/to/emacs make sandbox
+EMACS_COMMAND=/path/to/emacs make sandbox INSTALL=package-name
 ```
 
-then `M-x package-list-packages`, install and test as
-appropriate. This is a useful way to discover missing dependencies!
+where `package-name` is the name of the package you want to install
+into the sandbox, then install and test as appropriate. This is a
+useful way to discover missing dependencies!
 
 ## Submitting
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,9 @@ sandbox: packages/archive-contents
 		--eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
 		--eval "(add-to-list 'package-archives '(\"sandbox\" . \"$(shell pwd)/$(PKGDIR)/\") t)" \
 		--eval "(package-refresh-contents)" \
-		--eval "(package-initialize)"
+		--eval "(package-initialize)" \
+		--eval '(setq sandbox-install-package "$(INSTALL)")' \
+		--eval "(unless (string= \"\" sandbox-install-package) (package-install (intern sandbox-install-package)))"
 
 .PHONY: clean build index html json sandbox
 .FORCE:


### PR DESCRIPTION
e.g. run `make sandbox INSTALL=helm` to make the sandbox and automatically install the "helm" package.  This saves the user from having to wait for `package-initialize` to finish, manually run `package-install`, and finally type in the package name and hit `RET`.

When trying to debug issues with packages installed into a sandbox, it becomes tedious doing all that manually over and over again.  This makes it much faster, since you can just run it directly from the shell history.