### PR TITLE
Add recipe for kubernetes-el

### DIFF
--- a/recipes/kubernetes
+++ b/recipes/kubernetes
@@ -1,0 +1,1 @@
+(kubernetes :repo "chrisbarrett/kubernetes-el" :fetcher github)


### PR DESCRIPTION
This package adds a live-updating interactive UI for managing Kubernetes pods. It uses Magit's rendering and popup systems, and usage should be pretty self-explanatory for Magit users.

I'm the maintainer. Repo here: https://github.com/chrisbarrett/kubernetes-el

- I've run checkdoc and purcell's package linter, and only get a spurious warning about explicitly specifying the Emacs version.

- I've verified the melpa recipe builds locally on my fork.

Let me know if you need any more information to proceed here. :)