### PR TITLE
Added recipe org-brain

### DIFF
--- a/recipes/org-brain
+++ b/recipes/org-brain
@@ -1,0 +1,1 @@
+(org-brain :repo "Kungsgeten/org-brain" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Uses org-mode files to create a concept map. Its like a combination of a wiki and a mind map. It is heavily inspired by the software The Brain.

### Direct link to the package repository

https://github.com/Kungsgeten/org-brain

### Your association with the package

I'm the developer and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

The byte-compiles (and package-lint) complains about using `goto-line`, since it is meant for interactive use only. The documentation says that its "usually wrong", but in my use case (generate a buffer's content from scratch) it works fine.