### PR TITLE
ADD/MOD: Split rtags elisp packages into separate MELPA packages

### DIFF
--- a/recipes/ac-rtags
+++ b/recipes/ac-rtags
@@ -1,0 +1,3 @@
+(ac-rtags :repo "Andersbakken/rtags"
+          :fetcher github
+          :files ("src/ac-rtags.el"))

--- a/recipes/company-rtags
+++ b/recipes/company-rtags
@@ -1,0 +1,3 @@
+(company-rtags :repo "Andersbakken/rtags"
+               :fetcher github
+               :files ("src/company-rtags.el"))

--- a/recipes/flycheck-rtags
+++ b/recipes/flycheck-rtags
@@ -1,0 +1,3 @@
+(flycheck-rtags :repo "Andersbakken/rtags"
+                :fetcher github
+                :files ("src/flycheck-rtags.el"))

--- a/recipes/helm-rtags
+++ b/recipes/helm-rtags
@@ -1,0 +1,3 @@
+(helm-rtags :repo "Andersbakken/rtags"
+            :fetcher github
+            :files ("src/helm-rtags.el"))

--- a/recipes/ivy-rtags
+++ b/recipes/ivy-rtags
@@ -1,0 +1,3 @@
+(ivy-rtags :repo "Andersbakken/rtags"
+           :fetcher github
+           :files ("src/ivy-rtags.el"))

--- a/recipes/rtags
+++ b/recipes/rtags
@@ -1,4 +1,3 @@
 (rtags :repo "Andersbakken/rtags"
        :fetcher github
-       :files ("src/*.el"
-               (:exclude "src/compile-shim.el")))
+       :files ("src/rtags.el"))


### PR DESCRIPTION
### Brief summary of what the package does

rtags was already a MELPA package and will be. But will only contain rtags.el file from now on, and everything else will now be in a separate package, company-rtags.el, flycheck-rtags.el, helm-rtags.el, ac-rtags.el and ivy-rtags.el.

RTags is clang based parser based an LLVM/Clang like irony but more feature rich.

### Direct link to the package repository

https://github.com/Andersbakken/rtags

### Your association with the package

I'm a contributor.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
