### PR TITLE
Added recipe for playerctl.el

### DIFF
--- a/recipes/playerctl
+++ b/recipes/playerctl
@@ -1,0 +1,1 @@
+(playerctl :repo "thomasluquet/playerctl.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

- [Playerctl](https://github.com/acrisci/playerctl) let you control your music player (Spotify, vlc, audacious, bmp, xmms2, and others) from shell.
- playerctl.el is just a simple binding to play your music from emacs

### Direct link to the package repository

https://github.com/thomasluquet/playerctl.el

### Your association with the package

Creator

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
