### PR TITLE
Update Jade's recipe to include texinfo documentation

### DIFF
--- a/recipes/jade
+++ b/recipes/jade
@@ -1,1 +1,3 @@
-(jade :fetcher github :repo "NicolasPetton/jade")
+(jade :fetcher github
+      :repo "NicolasPetton/jade"
+      :files ("*.el" "doc/texinfo/*"))


### PR DESCRIPTION
### Brief summary of what the package does

A JavaScript development environment for Emacs.

### Direct link to the package repository

https://github.com/NicolasPetton/jade

### Your association with the package

I'm the author of the package.

### Relevant communications with the upstream package maintainer

The recipe is already in MELPA, this updates it so include Jade's documentation.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
