### PR TITLE
Add sword-to-org recipe

### DIFF
--- a/recipes/sword-to-org
+++ b/recipes/sword-to-org
@@ -1,0 +1,2 @@
+(sword-to-org :fetcher github :repo "alphapapa/sword-to-org")
+              


### PR DESCRIPTION
### Brief summary of what the package does

This package uses the `diatheke` program to convert Sword modules to Org-mode outlines.

### Direct link to the package repository

https://github.com/alphapapa/sword-to-org

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

Thanks.