### PR TITLE
Update several recipes to use https

### DIFF
--- a/recipes/bbdb
+++ b/recipes/bbdb
@@ -1,4 +1,4 @@
 (bbdb
- :url "git://git.savannah.nongnu.org/bbdb.git"
+ :url "https://git.savannah.nongnu.org/git/bbdb.git"
  :fetcher git
  :files ("lisp/*.el*" "doc/*.texi"))

--- a/recipes/caml
+++ b/recipes/caml
@@ -1,1 +1,1 @@
-(caml :fetcher svn :url "http://caml.inria.fr/svn/ocaml/trunk/emacs/")
+(caml :fetcher svn :url "https://caml.inria.fr/svn/ocaml/trunk/emacs/")

--- a/recipes/cg
+++ b/recipes/cg
@@ -1,4 +1,4 @@
 (cg
  :fetcher svn
- :url "http://beta.visl.sdu.dk/svn/visl/tools/vislcg3/trunk/emacs"
+ :url "https://beta.visl.sdu.dk/svn/visl/tools/vislcg3/trunk/emacs"
  :files ("cg.el"))

--- a/recipes/color-theme
+++ b/recipes/color-theme
@@ -1,3 +1,3 @@
-(color-theme :url "http://bzr.savannah.gnu.org/r/color-theme/trunk"
+(color-theme :url "https://bzr.savannah.gnu.org/r/color-theme/trunk"
              :fetcher bzr
              :files ("*.el" "themes"))

--- a/recipes/dic-lookup-w3m
+++ b/recipes/dic-lookup-w3m
@@ -1,3 +1,3 @@
 (dic-lookup-w3m
- :url "http://svn.osdn.jp/svnroot/dic-lookup-w3m/"
+ :url "https://svn.osdn.jp/svnroot/dic-lookup-w3m/"
  :fetcher svn)

--- a/recipes/dsvn
+++ b/recipes/dsvn
@@ -1,1 +1,1 @@
-(dsvn :fetcher svn :url "http://svn.apache.org/repos/asf/subversion/trunk/contrib/client-side/emacs/" :files ("dsvn.el"))
+(dsvn :fetcher svn :url "https://svn.apache.org/repos/asf/subversion/trunk/contrib/client-side/emacs/" :files ("dsvn.el"))

--- a/recipes/emms
+++ b/recipes/emms
@@ -1,4 +1,4 @@
 (emms
- :url "git://git.sv.gnu.org/emms.git"
+ :url "https://git.savannah.gnu.org/git/emms.git"
  :fetcher git
  :files ("lisp/*.el" "doc/emms.texinfo"))

--- a/recipes/jabber
+++ b/recipes/jabber
@@ -1,4 +1,4 @@
 (jabber
- :url "git://git.code.sf.net/p/emacs-jabber/git"
+ :url "https://git.code.sf.net/p/emacs-jabber/git"
  :fetcher git
  :files ("*.el" "*.texi" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))

--- a/recipes/jtags
+++ b/recipes/jtags
@@ -1,4 +1,4 @@
 (jtags
  :fetcher git
- :url "git://git.code.sf.net/p/jtags/code"
+ :url "https://git.code.sf.net/p/jtags/code"
  :files ("src/lisp/*.el"))

--- a/recipes/log4j-mode
+++ b/recipes/log4j-mode
@@ -1,4 +1,4 @@
 (log4j-mode
  :fetcher git
- :url "git://git.code.sf.net/p/log4j-mode/code"
+ :url "https://git.code.sf.net/p/log4j-mode/code"
  :files ("src/*.el"))

--- a/recipes/matlab-mode
+++ b/recipes/matlab-mode
@@ -1,5 +1,5 @@
 (matlab-mode
  :fetcher git
- :url "git://git.code.sf.net/p/matlab-emacs/src"
+ :url "https://git.code.sf.net/p/matlab-emacs/src"
  :module "matlab-emacs"
  :files ("*.el" "*.m" ("toolbox" "toolbox/*.m") ("templates" "templates/*.srt")))

--- a/recipes/paredit
+++ b/recipes/paredit
@@ -1,3 +1,3 @@
-(paredit :url "http://mumble.net/~campbell/git/paredit.git"
+(paredit :url "https://mumble.net/~campbell/git/paredit.git"
          :fetcher git
          :files ("paredit.el"))

--- a/recipes/po-mode
+++ b/recipes/po-mode
@@ -1,4 +1,4 @@
 (po-mode
  :fetcher git
- :url "git://git.savannah.gnu.org/gettext.git"
+ :url "https://git.savannah.gnu.org/git/gettext.git"
  :files ("gettext-tools/misc/po-mode.el"))

--- a/recipes/ruby-additional
+++ b/recipes/ruby-additional
@@ -1,6 +1,6 @@
 (ruby-additional
  :fetcher svn
- :url "http://svn.ruby-lang.org/repos/ruby/trunk/misc/"
+ :url "https://svn.ruby-lang.org/repos/ruby/trunk/misc/"
  :files ("ruby-additional.el"
          "rdoc-mode.el"
          "ruby-style.el"

--- a/recipes/ruby-electric
+++ b/recipes/ruby-electric
@@ -1,4 +1,4 @@
 (ruby-electric
  :fetcher svn
- :url "http://svn.ruby-lang.org/repos/ruby/trunk/misc/"
+ :url "https://svn.ruby-lang.org/repos/ruby/trunk/misc/"
  :files ("ruby-electric.el"))

--- a/recipes/stumpwm-mode
+++ b/recipes/stumpwm-mode
@@ -1,2 +1,2 @@
-(stumpwm-mode :url "git://git.savannah.nongnu.org/stumpwm.git" :fetcher git
+(stumpwm-mode :url "https://git.savannah.nongnu.org/git/stumpwm.git" :fetcher git
               :files ("contrib/stumpwm-mode.el"))


### PR DESCRIPTION
Recipes updated:

bzr recipes:
color-theme

git recipes:
bbdb emms jabber jtags log4j-mode matlab-mode paredit
po-mode stumpwm-mode

svn recipes:
caml cg dic-lookup-w3m dsvn ruby-additional ruby-electric

See: #3004 


### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
