### PR TITLE
Extract kubernetes-evil package

### DIFF
--- a/recipes/kubernetes
+++ b/recipes/kubernetes
@@ -1,1 +1,5 @@
-(kubernetes :repo "chrisbarrett/kubernetes-el" :fetcher github)
+(kubernetes :repo "chrisbarrett/kubernetes-el"
+            :fetcher github
+            :files
+            (:defaults
+             (:exclude "kubernetes-evil.el")))

--- a/recipes/kubernetes-evil
+++ b/recipes/kubernetes-evil
@@ -1,0 +1,3 @@
+(kubernetes-evil :repo "chrisbarrett/kubernetes-el"
+                 :fetcher github
+                 :files ("kubernetes-evil.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Splits `kubernetes` and `kubernetes-evil` into separate packages, as discussed in #4666.

### Direct link to the package repository

https://github.com/chrisbarrett/kubernetes-el

### Your association with the package

Maintainer

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
