### PR TITLE
Add password-mode

### DIFF
--- a/recipes/password-mode
+++ b/recipes/password-mode
@@ -1,0 +1,3 @@
+(password-mode
+ :fetcher github
+ :repo "juergenhoetzel/password-mode")


### PR DESCRIPTION
See https://github.com/juergenhoetzel/password-mode

### Brief summary of what the package does

An Emacs minor mode to hide sensitive information in buffers (passwords) using overlays.

### Direct link to the package repository

https://github.com/juergenhoetzel/password-mode

### Your association with the package

I'm user of this package and find it generally useful.

### Relevant communications with the upstream package maintainer

None needed. I will do a pull request on the package with MELPA installation instructions if added.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

Package-lint recommends adding a Version header. Checkdoc has some documentation style issues. Nothing serious in my opinion, though.