### PR TITLE
Add `spaceline-all-the-icons' theme recipe

### DIFF
--- a/recipes/spaceline-all-the-icons
+++ b/recipes/spaceline-all-the-icons
@@ -1,0 +1,3 @@
+(spaceline-all-the-icons
+ :fetcher github
+ :repo "domtronn/spaceline-all-the-icons.el")


### PR DESCRIPTION
### Brief summary of what the package does

This is a theme for [Spaceline](https://github.com/TheBB/spaceline) using the [All The Icons](https://github.com/domtronn/all-the-icons.el) package.

### Direct link to the package repository

https://github.com/domtronn/spaceline-all-the-icons.el

### Your association with the package

I am the current maintainer

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

The `package-lint` returns some issues with namespacing inside [`spaceline-all-the-icons-segments.el`](https://github.com/domtronn/spaceline-all-the-icons.el/blob/master/spaceline-all-the-icons-segments.el) since the functions don't end in `-segments` but they're all namespaced with `spaceline-all-the-icons` which I wanted to do since it's shorter and it's the main package namespace anyway 😅 
