### PR TITLE
Remove matrix-client from Recipes

### DIFF
--- a/recipes/matrix-client
+++ b/recipes/matrix-client
@@ -1,1 +1,0 @@
-(matrix-client :url "https://fort.kickass.systems/git/rrix/matrix-client.git" :fetcher git)


### PR DESCRIPTION
This is broken and unmaintained. I don't have time to refactor it enough to be functional and would
rather not provide a poor user experience. I'm not sure how to decomm a recipe other than git rm'ing it, feel free to point this in the right direction.