### PR TITLE
add recipe for smart-hungry-delete

### DIFF
--- a/recipes/smart-hungry-delete
+++ b/recipes/smart-hungry-delete
@@ -1,0 +1,1 @@
+(smart-hungry-delete :repo "hrehfeld/emacs-smart-hungry-delete" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Hungrily deletes whitespace between cursor and next word, paren or delimiter while honoring some rules about where space should be left to separate words and parentheses.

### Direct link to the package repository

https://github.com/hrehfeld/emacs-smart-hungry-delete

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 (however, I've left package-name/function-name instead of package-name-function-name, as other packages (hydra mc use-package yas) seem to do it as well and I find it to be much clearer)
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)


Thanks!