### PR TITLE
add recipes for web-narrow-mode

### DIFF
--- a/recipes/web-narrow-mode
+++ b/recipes/web-narrow-mode
@@ -1,0 +1,1 @@
+(web-narrow-mode :repo "Qquanwei/web-narrow-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

web-narrow is a minor mode for emacs . it will help edit hybrd format file. sach as jsx or vue


### Direct link to the package repository

https://github.com/Qquanwei/web-narrow-mode

### Your association with the package

 maintainer and contributor

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
