### PR TITLE
Rename Jade recipe to Indium

### DIFF
--- a/recipes/indium
+++ b/recipes/indium
@@ -1,0 +1,1 @@
+(indium :fetcher github :repo "NicolasPetton/indium" :old-names (jade))

--- a/recipes/jade
+++ b/recipes/jade
@@ -1,1 +1,0 @@
-(jade :fetcher github :repo "NicolasPetton/jade")


### PR DESCRIPTION
The project has been renamed due to trademark issues.

### Brief summary of what the package does

Indium (previously known as Jade) is a JavaScript development environment for Emacs.
It is already in MELPA under its former name. 

Indium connects to a browser tab or nodejs process and provides many features for JavaScript development, including:

- a REPL (with auto completion) & object inspection;
- an inspector, with history and navigation;
- a scratch buffer (M-x indium-scratch);
- JavaScript evaluation in JS buffers with indium-interaction-mode;
- a stepping Debugger, similar to edebug, or cider.

### Direct link to the package repository

https://github.com/NicolasPetton/Indium

### Your association with the package

I'm the maintainer of the package.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
