### PR TITLE
Add org-sticky-header recipe

### DIFF
--- a/recipes/org-sticky-header
+++ b/recipes/org-sticky-header
@@ -1,0 +1,1 @@
+(org-sticky-header :fetcher github :repo "alphapapa/org-sticky-header")


### PR DESCRIPTION
This package displays in the header-line the Org heading for the node that's at the top of the window.  This way, if the heading for the text at the top of the window is beyond the top of the window, you don't forget which heading the text belongs to.

https://github.com/alphapapa/org-sticky-header

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
 - [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback 
- [x] My elisp byte-compiles cleanly 
- [x] `M-x checkdoc` is happy with my docstrings 
-  [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)

Thanks.