### PR TITLE
Add org-recent-headings

### DIFF
--- a/recipes/org-recent-headings
+++ b/recipes/org-recent-headings
@@ -1,0 +1,1 @@
+(org-recent-headings :fetcher github :repo "alphapapa/org-recent-headings")


### PR DESCRIPTION
This package lets you quickly jump to recently used Org headings using Helm, Ivy, or plain-ol' `completing-read`.

https://github.com/alphapapa/org-recent-headings

Author and maintainer.

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md) 
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)