### PR TITLE
Add frame-mode

### DIFF
--- a/recipes/frame-mode
+++ b/recipes/frame-mode
@@ -1,0 +1,1 @@
+(frame-mode :fetcher github :repo "IvanMalison/frame-mode")


### PR DESCRIPTION
`frame-mode ` configures `display-buffer-alist` so that calls to display-buffer that result in a buffer being displayed somewhere that does not replace the current buffer always use a different frame instead of using a different window.

I am aware of the existence of https://github.com/davidshepherd7/frames-only-mode , but that package did not suit my needs.

This package differs from that one in a few ways:

- frame-mode uses display-buffer-alist which would seem to be a less brittle way to approach the problem than installing a bunch of hooks everywhere
- frame-mode doesnt try to destroy frames as agressively as frames-only-mode
- frames-only-mode seems to include a lot of preferences that are peculiar to the author's setup. frame-mode seeks to be more general and it really only provides the frames instead of windows behavior

### Direct link to the package repository

https://github.com/IvanMalison/frame-mode

### Your association with the package

Maintainer

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README]