### PR TITLE
Add info file to ledger-mode recipe

### DIFF
--- a/recipes/ledger-mode
+++ b/recipes/ledger-mode
@@ -1,1 +1,1 @@
-(ledger-mode :fetcher github :repo "ledger/ledger-mode" :files ("*.el") :old-names (ldg-mode))
+(ledger-mode :fetcher github :repo "ledger/ledger-mode" :old-names (ldg-mode))


### PR DESCRIPTION
### Brief summary of what the package does

This is just a modification to an existing recipe for ledger-mode. This change only adds the "doc/*.texi" files to the recipe so that the ledger-mode.info file can be generated, as well.

### Direct link to the package repository

https://github.com/ledger/ledger-mode

### Your association with the package

I'm just a user, who likes documentation with the code.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
