### PR TITLE
Added flatui-dark-theme

### DIFF
--- a/recipes/flatui-dark-theme
+++ b/recipes/flatui-dark-theme
@@ -1,0 +1,1 @@
+(flatui-dark-theme :repo "theasp/flatui-dark-theme" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Dark color theme for Emacs with flatui colors.

### Direct link to the package repository

https://github.com/theasp/flatui-dark-theme

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
