### PR TITLE
ssh-config-mode-el: Add *.txt to get ssh-config-keywords.txt.

### DIFF
--- a/recipes/ssh-config-mode
+++ b/recipes/ssh-config-mode
@@ -1,1 +1,4 @@
-(ssh-config-mode :fetcher github :repo "jhgorrell/ssh-config-mode-el")
+(ssh-config-mode 
+ :fetcher github 
+ :repo "jhgorrell/ssh-config-mode-el"
+ :files (:defaults "*.txt"))


### PR DESCRIPTION
Includes the `ssh-config-keywords.txt` file which is a new file.

