### PR TITLE
Use new path for lsp-mode, add various other lsp packages

### DIFF
--- a/recipes/lsp-go
+++ b/recipes/lsp-go
@@ -1,0 +1,1 @@
+(lsp-go :repo "emacs-lsp/lsp-go" :fetcher github)

--- a/recipes/lsp-haskell
+++ b/recipes/lsp-haskell
@@ -1,0 +1,1 @@
+(lsp-haskell :repo "emacs-lsp/lsp-haskell" :fetcher github)

--- a/recipes/lsp-java
+++ b/recipes/lsp-java
@@ -1,0 +1,1 @@
+(lsp-java :repo "emacs-lsp/lsp-java" :fetcher github)

--- a/recipes/lsp-mode
+++ b/recipes/lsp-mode
@@ -1,1 +1,1 @@
-(lsp-mode :repo "vibhavp/emacs-lsp" :fetcher github)
+(lsp-mode :repo "emacs-lsp/lsp-mode" :fetcher github)

--- a/recipes/lsp-python
+++ b/recipes/lsp-python
@@ -1,0 +1,1 @@
+(lsp-python :repo "emacs-lsp/lsp-python" :fetcher github)

--- a/recipes/lsp-rust
+++ b/recipes/lsp-rust
@@ -1,0 +1,1 @@
+(lsp-rust :repo "emacs-lsp/lsp-rust" :fetcher github)


### PR DESCRIPTION
I've made the lsp-mode recipe use it's new URL: https://github.com/emacs-lsp/lsp-mode
Language support in lsp-mode has been shifted to their own individual packages to avoid circular dependencies. I have thus added package recipes for:

- [lsp-rust](https://github.com/emacs-lsp/lsp-rust)
- [lsp-go](https://github.com/emacs-lsp/lsp-go)
- [lsp-python](https://github.com/emacs-lsp/lsp-python)
- [lsp-haskell](https://github.com/emacs-lsp/lsp-haskell)
- [lsp-java](https://github.com/emacs-lsp/lsp-java)

Thanks!