### PR TITLE
Update evil-search-highlight-persist Recipe

### DIFF
--- a/recipes/evil-search-highlight-persist
+++ b/recipes/evil-search-highlight-persist
@@ -1,3 +1,3 @@
 (evil-search-highlight-persist
   :fetcher github
-  :repo "juanjux/evil-search-highlight-persist")
+  :repo "naclander/evil-search-highlight-persist")


### PR DESCRIPTION
As per the original package's README, the original is no longer maintained:
https://github.com/juanjux/evil-search-highlight-persist/blob/master/README.md
I have interest in adopting this package.

### Brief summary of what the package does

This Emacs extension will make isearch and evil-ex-search-incremental (the "slash search") to highlight the search term (taken as a regexp) in all the buffer and persistently until you make another search or clear the highlights with the search-highlight-persist-remove-all command (default binding to C-x SPC)

### Direct link to the package repository

https://github.com/naclander/evil-search-highlight-persist

### Your association with the package

( hopefully ) new maintainer. 

### Relevant communications with the upstream package maintainer

Maintainer has abandoned package in README:
https://github.com/juanjux/evil-search-highlight-persist/blob/master/README.md

Maintainer has stated this package is abandoned and I have proposed adoption:
https://github.com/juanjux/evil-search-highlight-persist/issues/18

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
