### PR TITLE
Add soji package

### DIFF
--- a/recipes/soji
+++ b/recipes/soji
@@ -1,0 +1,1 @@
+(soji :fetcher github :repo "joecannatti/soji-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

Soji is a Mindful Workday tool for emacs.
it's essentially a combination of the Pomodoro Technique, jounaling, and note taking.

### Direct link to the package repository
[Soji on Github](https://github.com/joecannatti/soji-emacs)


### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
