### PR TITLE
Add php-cs-fixer recipe

### DIFF
--- a/recipes/php-cs-fixer
+++ b/recipes/php-cs-fixer
@@ -1,0 +1,1 @@
+(php-cs-fixer :repo "OVYA/php-cs-fixer" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

[php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) wrapper for the Emacs editor.

### Direct link to the package repository

https://github.com/OVYA/php-cs-fixer

### Your association with the package

I'am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [ x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [ x] `M-x checkdoc` is happy with my docstrings
- [ x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
