### PR TITLE
Add recipe for ghub+

### DIFF
--- a/recipes/ghub+
+++ b/recipes/ghub+
@@ -1,0 +1,1 @@
+(ghub+ :fetcher github :repo "vermiculus/ghub-plus")


### PR DESCRIPTION
### Brief summary of what the package does

Uses [apiwrap](https://github.com/vermiculus/apiwrap.el) to provide functions that wrap GitHub's API endpoints with [ghub](https://github.com/tarsius/ghub) calls.

### Direct link to the package repository

https://github.com/vermiculus/ghub-plus

### Your association with the package

Creator/maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
