### PR TITLE
Show commit information if available

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -40,7 +40,7 @@
   melpa.rootURL = window.location.protocol + "//" + window.location.host;
 
   melpa.Package = function(data) {
-    ["name", "description", "version", "dependencies", "source",
+    ["name", "description", "version", "dependencies", "source", "commit",
      "downloads", "fetcher", "recipeURL", "packageURL", "sourceURL", "oldNames"].map(function(p) {
       this[p] = data[p];
     }.bind(this));
@@ -150,6 +150,7 @@
       pkgs.push(new melpa.Package({
         name: name,
         version: version,
+        commit: built.props.commit,
         dependencies: deps,
         description: built.desc.replace(/\s*\[((?:source: )?\w+)\]$/, ""),
         source: recipe.fetcher,
@@ -406,7 +407,8 @@
             ]),
             m("dt", "Source"),
             m("dd", [
-              pkg.sourceURL ? m("a", {href: pkg.sourceURL}, pkg.source) : pkg.source
+              pkg.sourceURL ? m("a", {href: pkg.sourceURL}, pkg.source + pkg.commit) : pkg.source,
+              pkg.commit ? m("span.muted", " (" + pkg.commit.substring(0,6) + ")") : []
             ]),
             m("dt", "Dependencies"),
             m("dd", intersperse(_.sortBy(pkg.dependencies, 'name').map(this.depLink), " / ")),


### PR DESCRIPTION
<img width="360" alt="screen shot 2017-05-06 at 10 12 16 pm" src="https://cloud.githubusercontent.com/assets/2082195/25777685/fee218d2-32a9-11e7-82c1-55467801f3ed.png">

I haven't been able to test this thoroughly since I can't seem to get MELPA running locally on my machine, but this *should* work. At least, lots of trial/error hacking with Chrome suggests it does 😉

This is the UI counterpart to melpa/package-build#6; fixes #3363