### PR TITLE
add helm-frame recipe

### DIFF
--- a/recipes/helm-frame
+++ b/recipes/helm-frame
@@ -1,0 +1,1 @@
+(helm-frame :fetcher gitlab :repo "chee/helm-frame")


### PR DESCRIPTION
### Brief summary of what the package does

it opens your helm buffer in a dedicated frame in the middle of the screen, similar to rofi or Alfred.

### Direct link to the package repository

https://gitlab.com/chee/helm-frame

### Your association with the package

I am the maintainer and contributor and an enthusiastic user.

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
_**note,** i used a non-standard separator `/` for the commands; there is a potential for conflict with `helm-frame-$command` between `helm-frame` and a possible `helm` command. ie, if i had a command called `dog` and helm added a command called `frame-dog`, both would be called `helm-frame-dog`_
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
