### PR TITLE
Uncaught TypeError: Cannot read property 'totalPackages' of undefined

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -151,7 +151,7 @@
       pkgs.push(new melpa.Package({
         name: name,
         version: version,
-        commit: built.props.commit,
+        commit: props.commit || '',
         dependencies: deps,
         description: built.desc.replace(/\s*\[((?:source: )?\w+)\]$/, ""),
         source: recipe.fetcher,

--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -140,6 +140,7 @@
     var listed = _.intersection(_.keys(archive), _.keys(recipes));
     return new melpa.PackageList(_(listed).reduce(function(pkgs, name) {
       var built = archive[name];
+      var props = built.props || {};
       var recipe = recipes[name];
       var version = built.ver.join(".");
       var deps = _.map(built.deps || [], function (ver, name) {


### PR DESCRIPTION
Fixes #4738.

I started to have this error and a broken homepage recently. I've investigated the error message.

Error is thrown in the callback passed to `_.reduce` call [here](https://github.com/melpa/melpa/blob/a372bd61b8e09086124f4b5ae3a837d6220def38/html/js/melpa.js#L141).

I've figured the actual error is `actually some (~23) packages missing `props` property in the archive data by debugging. Error is swallowed for some reason.

Underlying error message can be reproduced by loading a package page directly.

```
Uncaught TypeError: Cannot read property 'commit' of null
```

Reference to `props` property introduced [here](https://github.com/melpa/melpa/pull/4736/files#diff-16a4b1562f252501410d42a063023b9fR153) breaks the execution.