### PR TITLE
Move evil-org recipe repository to Somelauw/evil-org-mode

### DIFF
--- a/recipes/evil-org
+++ b/recipes/evil-org
@@ -1,1 +1,1 @@
-(evil-org :fetcher github :repo "edwtjo/evil-org-mode")
+(evil-org :fetcher github :repo "Somelauw/evil-org-mode")


### PR DESCRIPTION
This pull request is an update on https://github.com/melpa/melpa/pull/4695. See the relevant discussion there.

### Brief summary of what the package does

Integrate evil-mode and org-mode by defining key bindings and motions.

### Direct link to the package repository
https://github.com/Somelauw/evil-org-mode

This repo will have all the commits that were originally pushed to https://github.com/Somelauw/evil-org-improved.

### Your association with the package

I'll be maintaining the new evil-org-mode repo. The original is https://github.com/edwtjo/evil-org-mode by @edwtjo.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
