### PR TITLE
Added new recipe for mandoku-tls.

### DIFF
--- a/recipes/mandoku-tls
+++ b/recipes/mandoku-tls
@@ -1,0 +1,1 @@
+(mandoku :fetcher github :repo "mandoku/mandoku-tls" )


### PR DESCRIPTION
### Brief summary of what the package does

This Emacs package provides access to the Thesaurus Linguae Sericae
(TLS) initiated and directed by Christoph Harbsmeier. It will use the
lexicon database from https://github.com/tls-kr/tls-org.

It can be used from Sinomacs (https://github.com/mandoku/sinomacs) or
installed as an Emacs package from Melpa.

### Direct link to the package repository

https://github.com/mandoku/mandoku-tls

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

Not needed.

### Checklist

Please confirm with `x`:

- [ x ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ x ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x ] My elisp byte-compiles cleanly
- [ x ] `M-x checkdoc` is happy with my docstrings
- [ x ] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
