### PR TITLE
Add editorconfig-charset-extras recipe

### DIFF
--- a/recipes/editorconfig-charset-extras
+++ b/recipes/editorconfig-charset-extras
@@ -1,0 +1,2 @@
+(editorconfig-charset-extras :fetcher github
+                             :repo "10sr/editorconfig-charset-extras-el")


### PR DESCRIPTION
### Brief summary of what the package does

Add extra charset supports to [editorconfig-emacs](https://melpa.org/#/editorconfig)

### Direct link to the package repository

https://github.com/10sr/editorconfig-charset-extras-el

### Your association with the package

The maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
