### PR TITLE
Add ob-blockdiag recipe

### DIFF
--- a/recipes/ob-blockdiag
+++ b/recipes/ob-blockdiag
@@ -1,0 +1,3 @@
+(ob-blockdiag
+  :fetcher github
+  :repo "corpix/ob-blockdiag.el")


### PR DESCRIPTION
### Brief summary of what the package does

Org-babel support for [blockdiag](http://blockdiag.com).

### Direct link to the package repository

https://github.com/corpix/ob-blockdiag.el

### Your association with the package

I am owner and maintainer of this package.

### Relevant communications with the upstream package maintainer

Wat? None needed.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
