### PR TITLE
Update omnisharp: remove override on :files, not needed anymore

### DIFF
--- a/recipes/omnisharp
+++ b/recipes/omnisharp
@@ -1,6 +1,3 @@
 (omnisharp :repo "OmniSharp/omnisharp-emacs"
            :fetcher github
-           :branch "master"
-           :files ("*.el"
-                   "src/*.el"
-                   "src/actions/*.el"))
+           :branch "master")


### PR DESCRIPTION
This is a small update on the omnisharp recipe where it has been refactored to have a little bit more canonical file structure with all the files on this multi-file package having now moved to the root directory of the repo.

See https://github.com/OmniSharp/omnisharp-emacs