### PR TITLE
Add shx recipe

### DIFF
--- a/recipes/shx
+++ b/recipes/shx
@@ -1,3 +1,2 @@
 (shx :repo "riscy/shx-for-emacs"
-     :fetcher github
-     :files ("shx.el"))
+     :fetcher github)

--- a/recipes/shx
+++ b/recipes/shx
@@ -1,0 +1,3 @@
+(shx :repo "riscy/shx-for-emacs"
+     :fetcher github
+     :files ("shx.el"))


### PR DESCRIPTION
### Brief summary of what the package does

shx or "shell-extras" extends comint-mode.  It parses simple markup in the output stream (enabling plots and graphics to be embedded in the shell) and adds several command-line functions which plug into Emacs (for example, use :e <filename> to edit a file).

### Direct link to the package repository

https://github.com/riscy/shx-for-emacs/

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
