### PR TITLE
Add recipe for shr-tag-pre-highlight

### DIFF
--- a/recipes/shr-tag-pre-highlight
+++ b/recipes/shr-tag-pre-highlight
@@ -1,0 +1,3 @@
+(shr-tag-pre-highlight
+ :fetcher github
+ :repo "xuchunyang/shr-tag-pre-highlight.el")


### PR DESCRIPTION
### Brief summary of what the package does

Add syntax highlighting to code block of HTML for `shr.el` (a built-in library for rendering HTML in an Emacs buffer).

### Direct link to the package repository

https://github.com/xuchunyang/shr-tag-pre-highlight.el

### Your association with the package

Author & maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
