### PR TITLE
orgnav -- Navigate org files

### DIFF
--- a/recipes/orgnav
+++ b/recipes/orgnav
@@ -1,0 +1,2 @@
+(orgnav :repo "facetframer/orgnav"
+      :fetcher github)


### PR DESCRIPTION
*Note* There are some `checkdoc` errors that I would prefer to leave in for the readability of documentation (line length and one piece of documentation). The line length warnings are due to a sentence that is over 80 characters long which I am not allowed to split with a newline.
I don't know what your position on such things is.

### Brief summary of what the package does

Navigates org files using helm. 

(see https://asciinema.org/a/1r0fp33xgwh48lfgsh7mllw4u for examples)

### Direct link to the package repository

https://github.com/facetframer/orgnav/

### Your association with the package

Maintainer and author.

### Relevant communications with the upstream package maintainer

N/A I am the package maintainer

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback*
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings *
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md) * 

* I have warnings related to long lines that I don't want to fix.
* I have warnings related to not placing one variable in backticks. This is necessary to include working configuration information within the docstring (capture functions)
* package-lint returns errors when I ran it. But all of them relate to missing version information. The version information is contained within `orgnav-pkg.el`.
* I could not find build instructions in this file. Instead I used those in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md) namely:

```
make release/orgnav
EMACS_COMMAND=/path/to/emacs make sandbox INSTALL=package-name
```