### PR TITLE
Add counsel-spotify to melpa

### DIFF
--- a/recipes/counsel-spotify
+++ b/recipes/counsel-spotify
@@ -1,0 +1,1 @@
+(counsel-spotify :fetcher github :repo "Lautaro-Garcia/counsel-spotify.el")


### PR DESCRIPTION
### Brief summary of what the package does

Allows the user to search for tracks, albums and artists in the Spotify API and play those with
the Spotify App. The frontend interface to narrow the possible results is Ivy.
It is simply a fork of `helm-spotify` but with Ivy as the interface and the possibility to search by
artist and album

### Direct link to the package repository

https://github.com/Lautaro-Garcia/counsel-spotify

### Your association with the package

I am the mantainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in the [README](https://github.com/melpa/melpa/blob/master/README.md)
