### PR TITLE
Add recipe for vdiff-magit

### DIFF
--- a/recipes/vdiff-magit
+++ b/recipes/vdiff-magit
@@ -1,0 +1,1 @@
+(vdiff-magit :repo "justbur/emacs-vdiff-magit" :fetcher github)


### PR DESCRIPTION
I am the author of this package. I recently broke this file, which integrates my
vdiff package into magit, out into a separate repository. vdiff-magit.el used to be on melpa because it was included in the vdiff package before this change. 

See https://github.com/justbur/emacs-vdiff and
https://github.com/justbur/emacs-vdiff-magit

Thanks