### PR TITLE
Change helm-company's repository.

### DIFF
--- a/recipes/helm-company
+++ b/recipes/helm-company
@@ -1,1 +1,1 @@
-(helm-company :repo "manuel-uberti/helm-company" :fetcher github)
+(helm-company :repo "Sodel-the-Vociferous/helm-company" :fetcher github)


### PR DESCRIPTION
`helm-company`'s maintainer has changed from manuel-uberti to Sodel-the-Vociferous:
https://github.com/manuel-uberti/helm-company/issues/10#issuecomment-302644821

The new repository is on GitHub, at Sodel-the-Vociferous/helm-company .