### PR TITLE
Add qt-pro-mode

### DIFF
--- a/recipes/qt-pro-mode
+++ b/recipes/qt-pro-mode
@@ -1,0 +1,1 @@
+(qt-pro-mode :fetcher github :repo "EricCrosson/qt-pro-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a major-mode for editing Qt build-system files.

### Direct link to the package repository

https://github.com/ericcrosson/qt-pro-mode

### Your association with the package

Maintainer, contributor, user

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
