### PR TITLE
Add pfuture recipe.

### DIFF
--- a/recipes/pfuture
+++ b/recipes/pfuture
@@ -1,4 +1,3 @@
 (pfuture
  :repo "Alexander-Miller/pfuture"
- :fetcher github
- :files (:defaults))
+ :fetcher github)

--- a/recipes/pfuture
+++ b/recipes/pfuture
@@ -1,0 +1,4 @@
+(pfuture
+ :repo "Alexander-Miller/pfuture"
+ :fetcher github
+ :files (:defaults))


### PR DESCRIPTION
### Brief summary of what the package does

Wrapper around `make-process`, stuffing the process and its output into a single struct for convencience. Like `shell-command-to-string`, but async.

### Direct link to the package repository

https://github.com/Alexander-Miller/process-future

### Your association with the package

I made this.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
It's complaining that I shouldn't use `pf-` as my function prefix, but I refuse to believe that naming a function `process-future-process-of` instead of `pf-process-of` is good practice, never mind the `process-future-future`struct and the resulting `process-future-future-process` accessor. I'd rather have the small namespace-y prefix.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
