### PR TITLE
Fix: counsel-spotify bad repo name

### DIFF
--- a/recipes/counsel-spotify
+++ b/recipes/counsel-spotify
@@ -1,0 +1,1 @@
+(counsel-spotify :fetcher github :repo "Lautaro-Garcia/counsel-spotify.el")

--- a/recipes/counsel-spotify
+++ b/recipes/counsel-spotify
@@ -1,1 +1,1 @@
-(counsel-spotify :fetcher github :repo "Lautaro-Garcia/counsel-spotify.el")
+(counsel-spotify :fetcher github :repo "Lautaro-Garcia/counsel-spotify")


### PR DESCRIPTION
The repo url was wrong, it had the file extension