### PR TITLE
Add postcss-sorting

### DIFF
--- a/recipes/postcss-sorting
+++ b/recipes/postcss-sorting
@@ -1,0 +1,1 @@
+(postcss-sorting :repo "P233/postcss-sorting.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides an interactive command `postcss-sorting-buffer` to sort CSS buffer using postcss with [postcss-sorting plugin](https://github.com/hudochenkov/postcss-sorting).

### Direct link to the package repository

https://github.com/P233/postcss-sorting.el

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
