### PR TITLE
Add auto-minor-mode recipe.

### DIFF
--- a/recipes/auto-minor-mode
+++ b/recipes/auto-minor-mode
@@ -1,0 +1,1 @@
+(auto-minor-mode :repo "joewreschnig/auto-minor-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package lets you enable minor modes based on file name and contents. To find the right modes, it checks filenames against patterns in `auto-minor-mode-alist` and file contents against
`auto-minor-mode-magic-list`. These work like the built-in Emacs variables `auto-mode-alist` and `magic-mode-alist`.

(Versions of something like this have been swapped around for a long time, but usually without the magic alist equivalent, missing handling for some special cases, or requiring manual activation or activating at odd times.)

### Direct link to the package repository

https://github.com/joewreschnig/auto-minor-mode

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
