### PR TITLE
Update doom-themes recipe

### DIFF
--- a/recipes/doom-themes
+++ b/recipes/doom-themes
@@ -1,1 +1,1 @@
-(doom-themes :repo "hlissner/emacs-doom-theme" :fetcher github)
+(doom-themes :repo "hlissner/emacs-doom-themes" :fetcher github :files (:defaults "themes/*.el"))


### PR DESCRIPTION
To prepare for a coming overhaul of my plugin (including a move of all its current and prospective color themes into the `themes/` sub-directory), I am updating [doom-themes](https://github.com/hlissner/emacs-doom-themes)' recipe.