### PR TITLE
add gift-mode recipe

### DIFF
--- a/recipes/gift-mode
+++ b/recipes/gift-mode
@@ -1,0 +1,1 @@
+(gift-mode :fetcher github :repo "csrhodes/gift-mode")


### PR DESCRIPTION
### Brief summary of what the package does

GIFT is a format recognized by the Moodle Virtual Learning
Environment, among other software.  The support for it at the time
of writing this recipe is minimal, consisting of some non-trivial
font-lock keywords and an extension for auto-mode-alist.  Support
for custom editing commands is planned.

### Direct link to the package repository

https://github.com/csrhodes/gift-mode

### Your association with the package

I wrote it!  (And will continue to develop it)

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
