### PR TITLE
Add solaire-mode

### DIFF
--- a/recipes/solaire-mode
+++ b/recipes/solaire-mode
@@ -1,0 +1,1 @@
+(solaire-mode :repo "hlissner/emacs-solaire-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`solaire-mode` is an aesthetic plugin that helps visually distinguish
file-visiting windows from other types of windows (like popups or sidebars) by
giving them a slightly different -- often brighter -- background.

### Direct link to the package repository

https://github.com/hlissner/emacs-solaire-mode

### Your association with the package

I am the maintainer.

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
