### PR TITLE
Add nlinum-hl

### DIFF
--- a/recipes/nlinum-hl
+++ b/recipes/nlinum-hl
@@ -1,0 +1,1 @@
+(nlinum-hl :repo "hlissner/emacs-nlinum-hl" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Extends nlinum to provide current-line-number highlighting, plus other minor fixes.

### Direct link to the package repository

https://github.com/hlissner/emacs-nlinum-hl

### Your association with the package

I am the maintainer.

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
