### PR TITLE
Add cheat-sh.el

### DIFF
--- a/recipes/cheat-sh
+++ b/recipes/cheat-sh
@@ -1,0 +1,1 @@
+(cheat-sh :fetcher github :repo "davep/cheat-sh.el")


### PR DESCRIPTION
### Brief summary of what the package does

`cheat-sh.el` provides a simple Emacs interface for looking things up on [cheat.sh](http://cheat.sh).

### Direct link to the package repository

https://github.com/davep/cheat-sh.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
