### PR TITLE
Change repo for goose-theme

### DIFF
--- a/recipes/goose-theme
+++ b/recipes/goose-theme
@@ -1,1 +1,1 @@
-(goose-theme :repo "thwg/goose-theme" :fetcher github)
+(goose-theme :repo "tokenrove/goose-theme" :fetcher github)


### PR DESCRIPTION
I have taken over maintainership, with @thwg's blessing, per the
discussion here:
  https://github.com/melpa/melpa/commit/818b526f3e633cf9922c011f3db5d3db7e17ee5d

### Brief summary of what the package does

A gray color theme.

### Direct link to the package repository

https://github.com/tokenrove/goose-theme

### Your association with the package

New maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Note that `package-lint` fails on this package because it uses `provide-theme` and does not contain a `(provide 'goose-theme)` entry.  Because I have made no changes from the previous version which was in melpa, I am going to assume this is ok.