### PR TITLE
add coin-ticker recipe

### DIFF
--- a/recipes/coin-ticker
+++ b/recipes/coin-ticker
@@ -1,0 +1,1 @@
+(coin-ticker :fetcher github :repo "eklitzke/coin-ticker-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This adds a cryptocurrency price ticker (for Bitcoin, Ethereum, etc.). It's implemented as a minor mode that adds the ticker to the mode line.

### Direct link to the package repository

https://github.com/eklitzke/coin-ticker-mode

### Your association with the package

I'm the upstream author/maintainer.

### Relevant communications with the upstream package maintainer

None needed (I am upstream).

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
