### PR TITLE
Add csound-mode recipie

### DIFF
--- a/recipes/csound-mode
+++ b/recipes/csound-mode
@@ -1,0 +1,4 @@
+(csound-mode :fetcher github
+	     :repo "hlolli/csound-mode"
+	     :files (:defaults "*.el" "csoundAPI_emacsLisp"
+		     (:exclude ".dir-locals.el")))


### PR DESCRIPTION
### Brief summary of what the package does

A Major mode for editing csound files with repl functionality via comint+emacs-module.

### Direct link to the package repository

https://github.com/hlolli/csound-mode

### Your association with the package

Author/maintainer

### Relevant communications with the upstream package maintainer

none needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
