### PR TITLE
Add recipe for org-static-blog

### DIFF
--- a/recipes/org-static-blog
+++ b/recipes/org-static-blog
@@ -1,0 +1,1 @@
+(org-static-blog :repo "bastibe/org-static-blog" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Org-static-blog is an org-mode based static blog generator. 

### Direct link to the package repository

https://github.com/bastibe/org-static-blog

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
