### PR TITLE
Remove bzr, cvs, darcs, fossil and svn support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,13 @@ language: ruby
 addons:
   apt:
     packages:
-    - bzr
     - git
     - mercurial
-    - subversion
-    - cvs
-    - darcs
-    - fossil
     - texinfo
 
 before_install:
   - sudo apt-get -yq update
-  - sudo apt-get -yq install bzr git mercurial subversion cvs darcs fossil texinfo
+  - sudo apt-get -yq install git mercurial texinfo
 
   - git clone https://github.com/rejeep/evm.git $HOME/.evm
   - export PATH=$HOME/.evm/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -105,42 +105,43 @@ the following form (`[...]` denotes optional or conditional values),
 
 ```lisp
 (<package-name>
- :fetcher [git|github|gitlab|bitbucket|bzr|hg|darcs|fossil|svn|cvs|wiki]
+ :fetcher [git|github|gitlab|bitbucket|hg|wiki]
  [:url "<repo url>"]
  [:repo "github-gitlab-or-bitbucket-user/repo-name"]
  [:version-regexp "<regexp>"]
- [:module "cvs-module"]
  [:files ("<file1>" ...)])
 ```
 
 - `package-name`
 a lisp symbol that has the same name as the package being specified.
 
-- `:fetcher` (one of `git, github, gitlab, bitbucket, bzr, hg, darcs,
-fossil, svn, cvs, wiki`) specifies the type of repository that `:url`
-points to. Right now package-build supports [git][git],
-[github][github], [gitlab][gitlab], [bitbucket][bitbucket],
-[bazaar (bzr)][bzr], [mercurial (hg)][hg], [subversion (svn)][svn],
-[cvs][cvs], [darcs][darcs], [fossil][fossil], and
-[EmacsWiki (deprecated)][emacswiki] as possible mechanisms for checking out
-the repository. (Note: `bitbucket` assumes `hg`: `git` repos hosted on
-bitbucket should use the `git` fetcher.)
+- `:fetcher` specifies the type of repository that `:url` or `:repo`
+  points to.  Melpa supports [`git`][git], [`github`][github],
+  [`gitlab`][gitlab], [`hg`][hg] (Mercurial), and [`wiki`][emacswiki]
+  (for packages from Emacswiki.org).
 
-    *package-build* uses
-the corresponding application to update files before building the
-package. In the case of the `github`
-fetcher, use `:repo` instead of `:url`; the git URL will then be
-deduced.
+  - The `bitbucket` fetcher derives from `hg`, so you have to use
+    `git` for Git repositories hosted on Bitbucket.
 
-    The Emacs Wiki fetcher gets the latest version of the package
-from `http://www.emacswiki.org/emacs/download/<NAME>.el` where `NAME`
-is the package name. Note that the `:url` property is not needed for
-the `wiki` engine unless the name of the package file on the EmacsWiki
-differs from the package name being built.
+  - The `wiki` fetcher gets the latest version from
+    `http://www.emacswiki.org/emacs/download/<NAME>.el` where `NAME`
+    is the package name.  Note that the `:url` property is not needed
+    for the `wiki` fetcher unless the name of the package file on the
+    EmacsWiki differs from the package name being built.  This fetcher
+    is deprecated due to security concerns.  Please distribute your
+    packages using a `git` or `hg` repository.
+
+  - Bazaar, CVS, Darcs, Fossil and Subversion used to be supported,
+    until only a dozen packages remained on Melpa that used one of
+    these five version control systems.  These packages are now
+    imported from the Emacsorphanage, which features semi-regularly
+    updated Git mirrors of the upstream non-Git repositories.  (The
+    latest stable `package-build.el` release actually still supports
+    these vcs.)
 
 - `:url`
 specifies the URL of the version control repository. *required for
-the `git`, `bzr`, `hg`, `darcs`, `fossil`, `svn` and `cvs` fetchers.*
+the `git`, and `hg` fetchers.*
 
 - `:repo` specifies the github/gitlab/bitbucket repository and is of the form
 `user/repo-name`. *required for the `github`, `gitlab`, and `bitbucket` fetchers*.
@@ -163,10 +164,6 @@ it adds the "origin/" prefix automatically.
   "OTP-18.1.5", we might add `:version-regexp "[^0-9]*\\(.*\\)"` to
   strip the "OTP-" prefix.  The captured portion of the regexp must be
   parseable by Emacs' `version-to-list` function.
-
-- `:module`
-specifies the module of a CVS repository to check out.  Defaults to to
-`package-name`.  Only used with `:fetcher cvs`, and otherwise ignored.
 
 - `:files` optional property specifying the elisp and info files used to build the
 package. Please do not override this if the default value (below) is adequate, which
@@ -198,12 +195,7 @@ subdirectories to keep packaging simple.
 [github]: https://github.com/
 [gitlab]: https://gitlab.com/
 [bitbucket]: https://bitbucket.org/
-[bzr]: http://bazaar.canonical.com/en/
 [hg]: https://www.mercurial-scm.org/
-[svn]: http://subversion.apache.org/
-[cvs]: http://www.nongnu.org/cvs/
-[darcs]: http://darcs.net/
-[fossil]: http://www.fossil-scm.org/
 [emacswiki]: http://www.emacswiki.org/
 
 

--- a/html/partials/getting-started.html
+++ b/html/partials/getting-started.html
@@ -148,7 +148,9 @@
       <p><a href="https://github.com/melpa/melpa">https://github.com/melpa/melpa</a></p>
       <p>
         Contributions are welcome. Currently, the builder supports
-        packages using Git, Subversion, Mercurial, Bazaar, CVS, Darcs, Fossil and
-        EmacsWiki (deprecated).
+        packages using Git, Mercurial, and EmacsWiki (deprecated
+        due to security concerns). Support for Bazaar, CVS, Darcs,
+        Fossil and Subversion has been removed due to very limited
+        use.
       </p>
     </section>

--- a/recipes/cg
+++ b/recipes/cg
@@ -1,4 +1,1 @@
-(cg
- :fetcher svn
- :url "https://beta.visl.sdu.dk/svn/visl/tools/vislcg3/trunk/emacs"
- :files ("cg.el"))
+(cg :fetcher github :repo "emacsorphanage/cg")

--- a/recipes/clang-format
+++ b/recipes/clang-format
@@ -1,4 +1,1 @@
-(clang-format
- :fetcher svn
- :url "https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format"
- :files ("clang-format.el"))
+(clang-format :fetcher github :repo "emacsorphanage/clang-format")

--- a/recipes/color-theme
+++ b/recipes/color-theme
@@ -1,3 +1,1 @@
-(color-theme :url "https://bzr.savannah.gnu.org/r/color-theme/trunk"
-             :fetcher bzr
-             :files ("*.el" "themes"))
+(color-theme :fetcher github :repo "emacsorphanage/color-theme")

--- a/recipes/confluence
+++ b/recipes/confluence
@@ -1,4 +1,4 @@
 (confluence
- :fetcher svn
- :url "https://svn.code.sf.net/p/confluence-el/code/trunk/"
+ :fetcher github
+ :repo "emacsorphanage/confluence"
  :files ("confluence*.el" "*.dtd" "*.xsl"))

--- a/recipes/darcsum
+++ b/recipes/darcsum
@@ -1,2 +1,2 @@
-(darcsum :url "https://hub.darcs.net/simon/darcsum" :fetcher darcs)
+(darcsum :fetcher github :repo "emacsorphanage/darcsum")
 

--- a/recipes/dic-lookup-w3m
+++ b/recipes/dic-lookup-w3m
@@ -1,3 +1,1 @@
-(dic-lookup-w3m
- :url "https://svn.osdn.jp/svnroot/dic-lookup-w3m/"
- :fetcher svn)
+(dic-lookup-w3m :fetcher github :repo "emacsorphanage/dic-lookup-w3m")

--- a/recipes/dsvn
+++ b/recipes/dsvn
@@ -1,1 +1,1 @@
-(dsvn :fetcher svn :url "https://svn.apache.org/repos/asf/subversion/trunk/contrib/client-side/emacs/" :files ("dsvn.el"))
+(dsvn :fetcher github :repo "emacsorphanage/dsvn" :files ("dsvn.el"))

--- a/recipes/helm-ls-svn
+++ b/recipes/helm-ls-svn
@@ -1,1 +1,1 @@
-(helm-ls-svn :fetcher svn :url "https://svn.macports.org/repository/macports/users/chunyang/helm-ls-svn.el")
+(helm-ls-svn :fetcher github :repo "emacsorphanage/helm-ls-svn")

--- a/recipes/ruby-additional
+++ b/recipes/ruby-additional
@@ -1,6 +1,6 @@
 (ruby-additional
- :fetcher svn
- :url "https://svn.ruby-lang.org/repos/ruby/trunk/misc/"
+ :fetcher github
+ :repo "emacsorphanage/ruby-additional"
  :files ("ruby-additional.el"
          "rdoc-mode.el"
          "ruby-style.el"

--- a/recipes/shimbun
+++ b/recipes/shimbun
@@ -1,4 +1,4 @@
-(shimbun :url ":pserver:anonymous@cvs.namazu.org:/storage/cvsroot"
-     :module "emacs-w3m"
-     :fetcher cvs
-     :files ("shimbun/*.el"))
+(shimbun
+ :fetcher github
+ :repo "emacsorphanage/w3m"
+ :files ("shimbun/*.el"))

--- a/recipes/tex-smart-umlauts
+++ b/recipes/tex-smart-umlauts
@@ -1,3 +1,1 @@
-(tex-smart-umlauts
- :fetcher darcs
- :url "https://hub.darcs.net/lyro/tex-smart-umlauts")
+(tex-smart-umlauts :fetcher github :repo "emacsorphanage/tex-smart-umlauts")

--- a/recipes/w3m
+++ b/recipes/w3m
@@ -1,4 +1,4 @@
-(w3m :url ":pserver:anonymous@cvs.namazu.org:/storage/cvsroot"
-     :module "emacs-w3m"
-     :fetcher cvs
-     :files (:defaults "icons" (:exclude "octet.el" "mew-w3m.el" "w3m-xmas.el")))
+(w3m
+ :fetcher github
+ :repo "emacsorphanage/w3m"
+ :files (:defaults "icons" (:exclude "octet.el" "mew-w3m.el" "w3m-xmas.el")))

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -9,18 +9,13 @@ cd ${HOME}
 sudo ${SUDOENV} apt-get -y update
 sudo ${SUDOENV} apt-get -y upgrade
 sudo ${SUDOENV} apt-get -y install \
-    bzr \
     curl \
-    cvs \
-    darcs \
     emacs24 emacs24-el emacs24-common-non-dfsg \
-    fossil \
     git \
     make \
     mercurial \
     nginx \
     runit \
-    subversion \
     texinfo \
     tmux
 


### PR DESCRIPTION
This isn't the first time that I suggest that Melpa should drop support for little used fetchers. Unfortunately I cannot find those discussions anymore. If I remember correctly, @purcell's position was that he is not opposed on principal, but that he sees no reason to do so until these fetchers start causing issues.

The removal of some fetchers has recently come up again in #4798, where @Fuco1 said:

> All complex systems tend to break, this is a given in programming. Reducing complexity promotes experimentation and growth. When rolling out "partial support" is met without much enthusiams, then we should simply drop the support altogether.

I agree with that. I have contributed to `package-build.el` in the past and the existence of little used fetchers was indeed an issue for me.

----

This pull requests attempts to demonstrate how we can drop support for *three* vcs fetchers without losing much. I hope that by making the proposal very concrete, we can actually reach a decision on whether to do this or not.

Please see the commit messages for details. Here is a summary:

* Drop support for the `fossil` fetcher. Not a single package used it.
* Drop support for the `bzr` fetcher. The *two* recipes that still used `bzr` now import from stale repositories on the Emacs*orphanage*. The upstream repositories have not seen any commits in years. But in the unlikely event that upstream decided to resume work, we would *not* automatically notice that.
* Drop support for the `darcs` fetcher. The *two* recipes that still used `darcs` now import from active repositories on the Emacs*mirror*. These repositories are only updated periodically, so there sometimes will be delays.

So by migrating *four* packages we can drop support for *three* fetchers. There are small drawbacks as mentioned, but I think that the reduced complexity outweigh those by far. 

Support for `cvs` and `svn` cannot be dropped yet because this pr only migrates *seven* out of the remaining ~~*thirteen*~~ *twelve* packages to the Emacsmirror.

* *Two* `cvs`-using packages have not been migrated so far. Both of these packages actually live in the same repository and I have asked upstream to consider a move to `git` (but have not gotten a reply yet). If that's what it takes, then I am willing to periodically import the `cvs` repository myself.
* ~~*Four*~~ *Three* `svn`-using packages have not been migrated so far because they consist of more than one library, which means that the Emacsmirror cannot use its `file` fetcher.
  * `caml` last updated two years ago. Let's ask upstream to migrate, but there is a good change that would fail.
  * `confluence` last updated two years ago. Let's ask upstream to migrate.
  * `dic-lookup-w3m` actively maintained. Let's ask upstream to migrate.
  * ~~`ruby-electric` @knu the file in the svn repository contains a link to https://github.com/knu/ruby-electric.el. Is the git repository up-to-date/ahead? Old discussion in #1079.~~ [Given that the url in both the svn and git repository points at the git repository, I decided that lacking a response the git repository should be preferred.]
