### PR TITLE
Add recipe for makefile-executor

### DIFF
--- a/recipes/makefile-executor
+++ b/recipes/makefile-executor
@@ -1,0 +1,1 @@
+(makefile-executor :repo "thiderman/makefile-executor.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Various extensions to makefile-mode! Currently aimed at working with Makefile targets from a project perspective. If there are multiple makefiles, a `completing-read` between them is shown! When a Makefile is selected, another selection with all the possible targets is shown.

### Direct link to the package repository

https://github.com/thiderman/makefile-executor.el

### Your association with the package

Maintainer!

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
