### PR TITLE
Drop relative-line-numbers

### DIFF
--- a/recipes/relative-line-numbers
+++ b/recipes/relative-line-numbers
@@ -1,1 +1,0 @@
-(relative-line-numbers :fetcher github :repo "Fanael/relative-line-numbers")


### PR DESCRIPTION
It's buggy and unmaintained, and will be superseded by the display engine line numbering feature when it lands.