### PR TITLE
Add lockfile-mode

### DIFF
--- a/recipes/lockfile-mode
+++ b/recipes/lockfile-mode
@@ -1,0 +1,3 @@
+(lockfile-mode
+  :repo "preetpalS/emacs-lockfile-mode"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for .lock files that are typically generated by tools. This major mode derives from fundamental mode and opens these files as read-only since they typically should not be edited by hand.

### Direct link to the package repository

https://github.com/preetpalS/emacs-lockfile-mode

### Your association with the package

I am the original author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
