### PR TITLE
Add bifocal recipe

### DIFF
--- a/recipes/bifocal
+++ b/recipes/bifocal
@@ -1,0 +1,2 @@
+(bifocal :repo "riscy/bifocal-mode"
+         :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

In bifocal-mode, paging up causes a comint-mode buffer to be split in two windows with a larger window on top (the head) and a smaller input window preserved on the bottom (the tail).  This helps with monitoring new output and entering text at the prompt (in the tail window), while reviewing previous output (in the head window).  Paging down all the way causes the split to disappear.

### Direct link to the package repository

https://github.com/riscy/bifocal-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
