### PR TITLE
Add magit-tbdiff

### DIFF
--- a/recipes/magit-tbdiff
+++ b/recipes/magit-tbdiff
@@ -1,0 +1,1 @@
+(magit-tbdiff :fetcher github :repo "magit/magit-tbdiff")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a Magit interface to [git-tbdiff].

[git-tbdiff]: https://github.com/trast/tbdiff

### Direct link to the package repository

https://github.com/magit/magit-tbdiff

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
  No, but I am.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Thanks!
