### PR TITLE
Add helm-elscreen

### DIFF
--- a/recipes/helm-elscreen
+++ b/recipes/helm-elscreen
@@ -1,0 +1,1 @@
+(helm-elscreen :repo "emacs-helm/helm-elscreen" :fetcher github)


### PR DESCRIPTION
helm-elscreen.el was moved by https://github.com/emacs-helm/helm/commit/6193cc4d5928156180a279e73bd38633dd7e5bee to https://github.com/emacs-helm/helm-elscreen. So I want to add it to melpa.

### Brief summary of what the package does

[Elscreen](https://github.com/knu/elscreen) with Helm interface

### Direct link to the package repository

https://github.com/emacs-helm/helm-elscreen

### Your association with the package

I'm an enthusiastic user.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
