### PR TITLE
Add snippets for ES-mode

### DIFF
--- a/recipes/es-mode
+++ b/recipes/es-mode
@@ -1,3 +1,4 @@
 (es-mode
  :fetcher github
- :repo "dakrone/es-mode")
+ :repo "dakrone/es-mode"
+ :files ("*.el" "snippets"))


### PR DESCRIPTION
This was previously an elisp-only repo, but now includes optional snippets for
yasnippet.

Relates to https://github.com/dakrone/es-mode/issues/36
