### PR TITLE
Add eve-mode recipe

### DIFF
--- a/recipes/eve-mode
+++ b/recipes/eve-mode
@@ -1,0 +1,1 @@
+(eve-mode :repo "witheve/emacs-eve-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
eve-mode is a major mode for editing [Eve documents][1] built on top of [polymode][2]. It provides syntax highlighting and simple eve-construct-aware indentation for authoring Eve documents (GFM-flavored markdown with code embedded as fenced code blocks).

### Direct link to the package repository
https://github.com/witheve/emacs-eve-mode

### Your association with the package
Maintainer of both `eve-mode` and Eve itself.

### Relevant communications with the upstream package maintainer
My therapist informs me that conversing with myself in public is seen as unhealthy. ;)
**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

### Notes
As Eve documents are embedded in markdown, this package is intrinsically dependent on polymode. I originally patterned all of the polymode-related names (the three `defcustom`s) in the same fashion that polymode-markdown did, but this displeased package-lint. I attempted to address package-lint's feedback entirely, but with the most minimal changes possible. If I should do more or less, please let me know.

[1]: http://witheve.com/
[2]: https://github.com/vspinu/polymode
