### PR TITLE
Add helm-directory

### DIFF
--- a/recipes/helm-directory
+++ b/recipes/helm-directory
@@ -1,0 +1,3 @@
+(helm-directory
+ :repo "masasam/emacs-helm-directory"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

You can select directory before select the file with helm interface.
Since the directory has important meanings at the framework,
I want to complement with helm only the files that is in the meaningful directory.
This package provide it.
When you select a directory with helm, the file in that directory can be used with helm.

### Direct link to the package repository

https://github.com/masasam/emacs-helm-directory

### Your association with the package

I am author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
