### PR TITLE
Add recipe for evil-test-helpers

### DIFF
--- a/recipes/evil-test-helpers
+++ b/recipes/evil-test-helpers
@@ -1,0 +1,3 @@
+(evil-test-helpers :repo "emacs-evil/evil"
+                   :fetcher github
+                   :files ("evil-test-helpers.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Provides a helper macro `evil-test-buffer` which is intended to be used for ERT testing evil plugin packages. In other words, allows tests for evil plugins to be written in the same manner as evil's own tests.

### Direct link to the package repository

https://github.com/emacs-evil/evil

### Your association with the package

A contributor

### Relevant communications with the upstream package maintainer

Evil maintainer wasamasa approved this here https://github.com/emacs-evil/evil/issues/846
Relevant PR https://github.com/emacs-evil/evil/pull/850

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

  package lint doesn't like the fact that definitions don't start with the prefix "evil-test-helpers".  It doesn't have any other objections.

- [X] My elisp byte-compiles cleanly

  ~~There's a warning about a macro being defined too late. I can submit a PR to evil's repo if this is an issue.~~ The warning is fixed.

- [ ] `M-x checkdoc` is happy with my docstrings

  checkdoc reports 8 issues. I can easily fix 3-4 of them, but not all of them.

- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
