### PR TITLE
Add numbers.el

### DIFF
--- a/recipes/numbers
+++ b/recipes/numbers
@@ -1,0 +1,1 @@
+(numbers :fetcher github :repo "davep/numbers.el")


### PR DESCRIPTION
### Brief summary of what the package does

`numbers.el` is a little wrapper around http://numbersapi.com/ that can be used to display maths information and trivia about numbers.

### Direct link to the package repository

https://github.com/davep/numbers.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
