### PR TITLE
Add poly-ruby

### DIFF
--- a/recipes/poly-ruby
+++ b/recipes/poly-ruby
@@ -1,0 +1,3 @@
+(poly-ruby
+ :fetcher github
+ :repo "knu/poly-ruby.el")


### PR DESCRIPTION
### Brief summary of what the package does

poly-ruby introduces polymode for here-documents in a ruby script.

### Direct link to the package repository

https://github.com/knu/poly-ruby.el

### Your association with the package

I'm the author of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

I basically followed the naming conventions used in polymode, but I could change the names if it should be a must to satisfy package-lint.