### PR TITLE
Add mixed-pitch

### DIFF
--- a/recipes/mixed-pitch
+++ b/recipes/mixed-pitch
@@ -1,0 +1,1 @@
+(mixed-pitch :fetcher github :repo "jabranham/mixed-pitch")


### PR DESCRIPTION

### Brief summary of what the package does

A minor mode that enables easy mixing of fixed pitch and variable pitch fonts in
the same buffer.

### Direct link to the package repository

https://github.com/jabranham/mixed-pitch

### Your association with the package

Maintainer 

### Relevant communications with the upstream package maintainer

None nedeed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
