### PR TITLE
Add ob-coffeescript

### DIFF
--- a/recipes/ob-coffeescript
+++ b/recipes/ob-coffeescript
@@ -1,1 +1,3 @@
-(ob-coffeescript :repo "brantou/ob-coffee" :fetcher github :files ("ob-coffee.el"))
+(ob-coffeescript :repo "brantou/ob-coffeescript"
+                 :fetcher github
+                 :files ("ob-coffeescript.el"))

--- a/recipes/ob-coffeescript
+++ b/recipes/ob-coffeescript
@@ -1,0 +1,1 @@
+(ob-coffeescript :repo "brantou/ob-coffee" :fetcher github :files ("ob-coffee.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Org-Babel support for evaluating coffee-script code.

### Direct link to the package repository

https://github.com/brantou/ob-coffeescript

### Your association with the package

I'm the creator of the package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
