### PR TITLE
Update evil's recipe to not include test files.

### DIFF
--- a/recipes/evil
+++ b/recipes/evil
@@ -1,5 +1,4 @@
 (evil :repo "emacs-evil/evil"
       :fetcher github
-      :files ("evil*.el"
-              "doc/*.texi"
-              (:exclude "evil*test*.el")))
+      :files (:defaults
+              (:exclude "evil-test-helpers.el")))

--- a/recipes/evil
+++ b/recipes/evil
@@ -1,1 +1,5 @@
-(evil :repo "emacs-evil/evil" :fetcher github)
+(evil :repo "emacs-evil/evil"
+      :fetcher github
+      :files ("evil*.el"
+              "doc/*.texi"
+              (:exclude "evil*test*.el")))


### PR DESCRIPTION
This change will prevent the file `evil-test-helpers.el` from being
included in the evil package.

### Brief summary of what the package does

Vim emulation

### Direct link to the package repository

https://github.com/emacs-evil/evil

### Your association with the package

A contributor

### Relevant communications with the upstream package maintainer

https://github.com/emacs-evil/evil/issues/846 - we discussed here the recipes for the `evil` and `evil-test-helpers` packages

### Checklist

Please confirm with `x`:

- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
