### PR TITLE
Add emacs-helm-ghs

### DIFF
--- a/recipes/helm-ghs
+++ b/recipes/helm-ghs
@@ -1,0 +1,1 @@
+(helm-ghs :repo "iory/emacs-helm-ghs" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Add helm-ghs which is emacs wrapper of ghs(https://github.com/sonatard/ghs).

### Direct link to the package repository

https://github.com/iory/emacs-helm-ghs

### Your association with the package

I am the author of the package.

### Relevant communications with the upstream package maintainer

The github issues.

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
