### PR TITLE
Add zen-mode

### DIFF
--- a/recipes/zen-mode
+++ b/recipes/zen-mode
@@ -1,0 +1,1 @@
+(zen-mode :repo "aki237/zen-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

zen-mode is simple emacs minor mode for distraction free editing

### Direct link to the package repository

https://github.com/aki237/zen-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
