### PR TITLE
Term sets

### DIFF
--- a/recipes/buffer-sets
+++ b/recipes/buffer-sets
@@ -1,1 +1,1 @@
-(buffer-sets :url "https://git.flintfam.org/swf-projects/buffer-sets.git" :fetcher git)
+(buffer-sets :url "https://git.flintfam.org/swf-projects/buffer-sets.git" :fetcher git :files ("buffer-sets.el"))

--- a/recipes/term-sets
+++ b/recipes/term-sets
@@ -1,0 +1,1 @@
+(term-sets :url "https://git.flintfam.org/swf-projects/buffer-sets.git" :fetcher git :files ("term-sets.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This builds upon my other buffer-sets package, providing functionality to automatically gather org-mode based notes files for a given term (year/{summer,fall,spring,etc}).

### Direct link to the package repository

https://git.flintfam.org/swf-projects/buffer-sets

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
