### PR TITLE
Adds rib-mode recipe

### DIFF
--- a/recipes/rib-mode
+++ b/recipes/rib-mode
@@ -1,0 +1,1 @@
+(rib-mode :fetcher github :repo "blezek/rib-mode")


### PR DESCRIPTION
Adds a rib-mode for editing Renderman RIB files.

### Brief summary of what the package does

Major mode for editing Renderman RIB files.

### Direct link to the package repository

https://github.com/blezek/rib-mode

### Your association with the package

Maintainer of an abandoned package [original](http://rib-mode.sourceforge.net/).

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
