### PR TITLE
csound-mode fix: remove `:defaults` to fix build error

### DIFF
--- a/recipes/csound-mode
+++ b/recipes/csound-mode
@@ -1,4 +1,4 @@
 (csound-mode :fetcher github
 	     :repo "hlolli/csound-mode"
-	     :files (:defaults "*.el" "csoundAPI_emacsLisp"
+	     :files (:defaults "csoundAPI_emacsLisp"
 		     (:exclude ".dir-locals.el")))


### PR DESCRIPTION
https://github.com/melpa/melpa/pull/4797

Continuteing on what was discussed here, there's a build error popping up that is easily solved by removing the keyword `:defaults`.  In the end it will follow the pattern of cider https://github.com/melpa/melpa/blob/master/recipes/cider which does not use `:defaults` and works fine.