### PR TITLE
Rename osx-pseudo-daemon to mac-pseudo-daemon

### DIFF
--- a/recipes/mac-pseudo-daemon
+++ b/recipes/mac-pseudo-daemon
@@ -1,0 +1,2 @@
+(mac-pseudo-daemon :repo "DarwinAwardWinner/osx-pseudo-daemon" :fetcher github
+                   :files ("mac-pseudo-daemon.el"))

--- a/recipes/osx-pseudo-daemon
+++ b/recipes/osx-pseudo-daemon
@@ -1,1 +1,2 @@
-(osx-pseudo-daemon :repo "DarwinAwardWinner/osx-pseudo-daemon" :fetcher github)
+(osx-pseudo-daemon :repo "DarwinAwardWinner/osx-pseudo-daemon" :fetcher github
+                   :files ("osx-pseudo-daemon.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This adds a new recipe mac-pseudo-daemon which is equivalent to the
old osx-pseudo-daemon. The new osx-pseudo-daemon package is just a
stub with obsolete alias definitions for backward comparibility.

(After a suitable period for everyone to switch over, I will rename
the repo and delete osx-pseudo-daemon.el entirely, and submit another 
update to the recipe.)

### Direct link to the package repository

https://github.com/DarwinAwardWinner/osx-pseudo-daemon

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Notes: `package-lint` complains aboud my decision to use an abbreviated prefix of `macpd-` for package functions rather than the full but quite unwieldly prefix of `mac-pseudo-daemon-`.