### PR TITLE
csound-mode small change

### DIFF
--- a/recipes/csound-mode
+++ b/recipes/csound-mode
@@ -1,4 +1,6 @@
 (csound-mode :fetcher github
 	     :repo "hlolli/csound-mode"
-	     :files (:defaults "csoundAPI_emacsLisp"
-		     (:exclude ".dir-locals.el")))
+	     :files (:defaults "csoundAPI_emacsLisp/emacscsnd.c"
+			       "csoundAPI_emacsLisp/Makefile"
+			       "csoundAPI_emacsLisp/float-version.h"
+			       (:exclude ".dir-locals.el")))


### PR DESCRIPTION
Sorry for the noise, but the build compilation of csound-mode is rightfully creating tons of warning messages that I'm working on limiting. One step I'm taking here is to cherry pick the files from the gitmodule so that all the *.el files in that gitmodule won't be compiled.