### PR TITLE
Added outline-toc recipe.

### DIFF
--- a/recipes/outline-toc
+++ b/recipes/outline-toc
@@ -1,0 +1,2 @@
+(outline-toc :fetcher github
+             :repo "abingham/outline-toc.el")


### PR DESCRIPTION
### Brief summary of what the package does

Adds a table of contents sidebar for outline-mode compatible buffers.

### Direct link to the package repository

https://github.com/abingham/outline-toc.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
