### PR TITLE
Add pyim-cangjie5dict recipe

### DIFF
--- a/recipes/pyim-cangjie5dict
+++ b/recipes/pyim-cangjie5dict
@@ -1,0 +1,3 @@
+(pyim-cangjie5dict :repo "erstern/pyim-cangjie5dict"
+                   :fetcher github
+                   :files (:defaults "*.pyim" "*.el"))

--- a/recipes/pyim-cangjie5dict
+++ b/recipes/pyim-cangjie5dict
@@ -1,3 +1,3 @@
 (pyim-cangjie5dict :repo "erstern/pyim-cangjie5dict"
                    :fetcher github
-                   :files (:defaults "*.pyim" "*.el"))
+                   :files (:defaults "*.pyim"))


### PR DESCRIPTION
### Brief summary of what the package does

This is a dict file for the input method engine [pyim](https://github.com/tumashu/pyim) (previously named chinese-pyim) using Chinese input scheme Cangjie v5, similar to [py-wbdict](https://github.com/tumashu/pyim-wbdict), it's another scheme to input Chinese characters. 

### Direct link to the package repository

https://github.com/erstern/pyim-cangjie5dict

### Your association with the package

As an enthusiastic user, I use Emacs and Chinese input schemes to typing.

### Relevant communications with the upstream package maintainer

Be the same to pyim-wbdict, cangjie5dict needed [pyim](https://github.com/tumashu/pyim) which formerly named chinese-pyim.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
