### PR TITLE
Add recipe for flycheck-pycheckers

### DIFF
--- a/recipes/flycheck-pycheckers
+++ b/recipes/flycheck-pycheckers
@@ -1,0 +1,2 @@
+(flycheck-pycheckers :fetcher github :repo "msherry/flycheck-pycheckers"
+                     :files (:defaults ("bin" "bin/pycheckers.py")))


### PR DESCRIPTION
### Brief summary of what the package does

Adds a new flycheck syntax checker called `pycheckers`. It's based off of the old pycheckers script that has been floating around EmacsWiki forever, but cleaned up, modernized, and with support for newer checkers like `flake8` and `mypy`.

### Direct link to the package repository

https://github.com/msherry/flycheck-pycheckers

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
