### PR TITLE
Add org-category-capture and org-projectile-helm recipes

### DIFF
--- a/recipes/org-category-capture
+++ b/recipes/org-category-capture
@@ -1,0 +1,3 @@
+(org-category-capture :repo "IvanMalison/org-projectile"
+                      :fetcher github
+                      :files ("org-category-capture*.el"))

--- a/recipes/org-projectile
+++ b/recipes/org-projectile
@@ -1,2 +1,3 @@
 (org-projectile :repo "IvanMalison/org-projectile"
-		:fetcher github)
+                :fetcher github
+                :files ("org-projectile.el" "org-category-capture.el"))

--- a/recipes/org-projectile-helm
+++ b/recipes/org-projectile-helm
@@ -1,0 +1,3 @@
+(org-projectile-helm :repo "IvanMalison/org-projectile"
+                     :fetcher github
+                     :files ("org-projectile-helm*.el"))


### PR DESCRIPTION
I know that you generally encourage submitters to include only 1 recipe per PR, but since these are all sort of intertwined, and it's better if the building gets separated all in one go, I'd like to change them all together if that's okay. I'll actually need to submit another request after this goes through to exclude org-category-capture.el from the org-projectile.el build, but I think I need to include it in org-projectile.el for now, since I can't change the requirements to include org-category-capture until this goes out.

### Brief summary of what the package does

Repository todo management for org-mode

### Direct link to the package repository

https://github.com/IvanMalison/org-projectile

### Your association with the package

Maintainer/Author

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
Proof: https://gist.github.com/445a433bc747525b32a6929308d73246
