### PR TITLE
Add snoopy-mode package

### DIFF
--- a/recipes/snoopy
+++ b/recipes/snoopy
@@ -1,0 +1,2 @@
+(snoopy :fetcher github
+        :repo "anmonteiro/snoopy-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Snoopy Mode is a minor mode for number row unshifted character insertion in Emacs.

### Direct link to the package repository

https://github.com/anmonteiro/snoopy-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
