### PR TITLE
Add org2web recipes

### DIFF
--- a/recipes/org-webpage
+++ b/recipes/org-webpage
@@ -1,3 +1,3 @@
-(org-webpage :repo "tumashu/org-webpage"
+(org-webpage :repo "tumashu/org2web"
              :fetcher github
              :files (:defaults "documents" "themes" "uploaders"))

--- a/recipes/org2web
+++ b/recipes/org2web
@@ -1,0 +1,3 @@
+(org2web :repo "tumashu/org2web"
+         :fetcher github
+         :files ("org2web*.el" "documents" "themes" "uploaders"))


### PR DESCRIPTION
I will rename org-webpage to org2web, the reason is:
https://github.com/purcell/package-lint/issues/75

This is stage 1.

