### PR TITLE
Add eg.el

### DIFF
--- a/recipes/eg
+++ b/recipes/eg
@@ -1,0 +1,1 @@
+(eg :fetcher github :repo "davep/eg.el")


### PR DESCRIPTION
### Brief summary of what the package does

`eg.el` is a [Norton Guide](http://www.davep.org/norton-guides/file-format/) [reader](http://www.davep.org/norton-guides/) for GNU Emacs. The package provides functions for decoding Norton Guide database files as well as a working Norton Guide reader. 

### Direct link to the package repository

https://github.com/davep/eg.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
