### PR TITLE
Add kaleidoscope & kaleidoscope-evil-state-flash

### DIFF
--- a/recipes/kaleidoscope
+++ b/recipes/kaleidoscope
@@ -1,0 +1,3 @@
+(kaleidoscope :repo "algernon/kaleidoscope.el"
+              :fetcher github
+              :files ("kaleidoscope.el"))

--- a/recipes/kaleidoscope-evil-state-flash
+++ b/recipes/kaleidoscope-evil-state-flash
@@ -1,0 +1,3 @@
+(kaleidoscope-evil-state-flash :repo "algernon/kaleidoscope.el"
+                               :fetcher github
+                               :files ("kaleidoscope-evil-state-flash.el"))


### PR DESCRIPTION
### Brief summary of what the package does

The `kaleidoscope` package makes it easier to work with [Kaleidoscope](https://github.com/keyboardio/Kaleidoscope)-powered devices, such as the [Keyboardio Model 01 keyboard](https://shop.keyboard.io). The `kaleidoscope-evil-state-flash` package builds on top of this foundation to provide a way to flash the keyboard with an Evil state-specific color when changing states.

A terrible quality video demo is available [here](https://trunk.mad-scientist.club/system/media_attachments/files/000/196/368/original/4b8868ca21dec73f.webm).

### Direct link to the package repository

https://github.com/algernon/kaleidoscope.el

### Your association with the package

I am the maintainer of the package.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
