### PR TITLE
Rename repos for some recipes

### DIFF
--- a/recipes/ido-completing-read+
+++ b/recipes/ido-completing-read+
@@ -1,2 +1,2 @@
-(ido-completing-read+ :repo "DarwinAwardWinner/ido-ubiquitous" :fetcher github
+(ido-completing-read+ :repo "DarwinAwardWinner/ido-completing-read-plus" :fetcher github
                       :files ("ido-completing-read+.el"))

--- a/recipes/ido-ubiquitous
+++ b/recipes/ido-ubiquitous
@@ -1,2 +1,2 @@
-(ido-ubiquitous :repo "DarwinAwardWinner/ido-ubiquitous" :fetcher github
+(ido-ubiquitous :repo "DarwinAwardWinner/ido-completing-read-plus" :fetcher github
                 :files ("ido-ubiquitous.el"))

--- a/recipes/mac-pseudo-daemon
+++ b/recipes/mac-pseudo-daemon
@@ -1,2 +1,2 @@
-(mac-pseudo-daemon :repo "DarwinAwardWinner/osx-pseudo-daemon" :fetcher github
+(mac-pseudo-daemon :repo "DarwinAwardWinner/mac-pseudo-daemon" :fetcher github
                    :files ("mac-pseudo-daemon.el"))

--- a/recipes/osx-pseudo-daemon
+++ b/recipes/osx-pseudo-daemon
@@ -1,2 +1,2 @@
-(osx-pseudo-daemon :repo "DarwinAwardWinner/osx-pseudo-daemon" :fetcher github
+(osx-pseudo-daemon :repo "DarwinAwardWinner/mac-pseudo-daemon" :fetcher github
                    :files ("osx-pseudo-daemon.el"))


### PR DESCRIPTION
The ido-ubiquitous and osx-pseudo-daemon Github repos have been
renamed to ido-completing-readplus and mac-pseudo-daemon,
respectively.

All packages from these repos build cleanly with the new recipes on my system.