### PR TITLE
Update docker-compose-mode's recipe to exclude test and helper files

### DIFF
--- a/recipes/docker-compose-mode
+++ b/recipes/docker-compose-mode
@@ -1,4 +1,4 @@
 (docker-compose-mode
  :repo "meqif/docker-compose-mode"
  :fetcher github
- :files (:defaults (:exclude "docker-compose-mode-helpers.el" "tests/*.el")))
+ :files (:defaults (:exclude "docker-compose-mode-helpers.el")))

--- a/recipes/docker-compose-mode
+++ b/recipes/docker-compose-mode
@@ -1,1 +1,4 @@
-(docker-compose-mode :repo "meqif/docker-compose-mode" :fetcher github)
+(docker-compose-mode
+ :repo "meqif/docker-compose-mode"
+ :fetcher github
+ :files (:defaults (:exclude "docker-compose-mode-helpers.el" "tests/*.el")))


### PR DESCRIPTION
This change will prevent the file `docker-compose-mode-helpers.el` and tests from being included in the `docker-compose-mode` package.

### Brief summary of what the package does

Major mode for editing docker-compose files

### Direct link to the package repository

https://github.com/meqif/docker-compose-mode

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
