### PR TITLE
Add himp recipe

### DIFF
--- a/recipes/himp
+++ b/recipes/himp
@@ -1,0 +1,2 @@
+(himp :fetcher github
+      :repo "mkcms/himp")


### PR DESCRIPTION
### Brief summary of what the package does

Hides imports/comments/documentation at beginning of buffer automatically.
Uses `vimish-fold` to hide those regions.
Currently, python and java is supported, but it can be easily extended.

### Direct link to the package repository

https://github.com/mkcms/himp

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
