### PR TITLE
Add cubicle-mode for the model checker Cubicle

### DIFF
--- a/recipes/cubicle-mode
+++ b/recipes/cubicle-mode
@@ -1,0 +1,4 @@
+(cubicle-mode
+ :fetcher github
+ :repo "cubicle-model-checker/cubicle"
+ :files ("doc/emacs/cubicle-mode.el"))

--- a/recipes/cubicle-mode
+++ b/recipes/cubicle-mode
@@ -1,4 +1,4 @@
 (cubicle-mode
  :fetcher github
  :repo "cubicle-model-checker/cubicle"
- :files ("doc/emacs/cubicle-mode.el"))
+ :files ("emacs/cubicle-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a major mode for editing files for the [model checker Cubicle](https://github.com/cubicle-model-checker/cubicle).

### Direct link to the package repository

https://github.com/cubicle-model-checker/cubicle/blob/master/emacs/cubicle-mode.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
