### PR TITLE
added recipe for catmacs

### DIFF
--- a/recipes/catmacs
+++ b/recipes/catmacs
@@ -1,3 +1,3 @@
-(catmacs :url "https://pymaximus@bitbucket.org/pymaximus/catmacs.git"
-         :fetcher git
-         :files ("catmacs.el"))
+(catmacs :url "https://bitbucket.org/pymaximus/catmacs"
+         :fetcher git )
+         

--- a/recipes/catmacs
+++ b/recipes/catmacs
@@ -1,0 +1,3 @@
+(catmacs :url "https://pymaximus@bitbucket.org/pymaximus/catmacs.git"
+         :fetcher git
+         :files ("catmacs.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Provides CAT client for Yaesu FT991A Transceiver

### Direct link to the package repository

https://bitbucket.org/pymaximus/catmacs

### Your association with the package

Author/Developer/Maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [ x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [ x] `M-x checkdoc` is happy with my docstrings
- [ x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
