### PR TITLE
Use HTTPS for more recipes.

### DIFF
--- a/recipes/clang-format
+++ b/recipes/clang-format
@@ -1,4 +1,4 @@
 (clang-format
  :fetcher svn
- :url "http://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format"
+ :url "https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format"
  :files ("clang-format.el"))

--- a/recipes/darcsum
+++ b/recipes/darcsum
@@ -1,2 +1,2 @@
-(darcsum :url "http://hub.darcs.net/simon/darcsum" :fetcher darcs)
+(darcsum :url "https://hub.darcs.net/simon/darcsum" :fetcher darcs)
 

--- a/recipes/deft
+++ b/recipes/deft
@@ -1,2 +1,2 @@
-(deft :url "git://jblevins.org/git/deft.git" :fetcher git)
+(deft :repo "jrblevin/deft" :fetcher github)
 

--- a/recipes/fuel
+++ b/recipes/fuel
@@ -1,1 +1,1 @@
-(fuel :fetcher git :url "git://factorcode.org/git/factor.git" :files ("misc/fuel/*.el"))
+(fuel :fetcher github :repo "factor/factor" :files ("misc/fuel/*.el"))

--- a/recipes/llvm-mode
+++ b/recipes/llvm-mode
@@ -1,5 +1,5 @@
 (llvm-mode
- :url "http://llvm.org/git/llvm"
+ :url "https://llvm.org/git/llvm"
  :files ("utils/emacs/llvm-mode.el"
          "utils/emacs/tablegen-mode.el")
  :fetcher git)

--- a/recipes/sml-modeline
+++ b/recipes/sml-modeline
@@ -1,3 +1,3 @@
 (sml-modeline :fetcher bzr
-              :url "lp:~nxhtml/nxhtml/main"
+              :url "https://code.launchpad.net/~nxhtml/nxhtml/main"
               :files ("util/sml-modeline.el"))

--- a/recipes/tex-smart-umlauts
+++ b/recipes/tex-smart-umlauts
@@ -1,3 +1,3 @@
 (tex-smart-umlauts
  :fetcher darcs
- :url "http://hub.darcs.net/lyro/tex-smart-umlauts")
+ :url "https://hub.darcs.net/lyro/tex-smart-umlauts")

--- a/recipes/zeitgeist
+++ b/recipes/zeitgeist
@@ -1,3 +1,3 @@
 (zeitgeist :fetcher git
-	   :url "git://anongit.freedesktop.org/zeitgeist/zeitgeist-datasources"
+	   :url "https://anongit.freedesktop.org/git/zeitgeist/zeitgeist-datasources.git"
 	   :files ("emacs/*.el"))


### PR DESCRIPTION
This enables authenticated access for more packages (#3004):
- clang-format
- darcsum
- deft
- fuel
- llvm-mode
- sml-modeline
- tex-smart-umlauts
- zeitgeist

(I have not been able to test the two packages using Darcs, but as hub.darcs.net performs an automatic HTTPS redirect, this shouldn't make them any more broken.)

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
