### PR TITLE
Comment tags recipe

### DIFF
--- a/recipes/comment-tags
+++ b/recipes/comment-tags
@@ -1,0 +1,3 @@
+(comment-tags
+ :fetcher github
+ :repo "vincekd/comment-tags")

--- a/recipes/comment-tags
+++ b/recipes/comment-tags
@@ -1,4 +1,3 @@
 (comment-tags
  :fetcher github
- :repo "vincekd/comment-tags"
- :files ("comment-tags.el"))
+ :repo "vincekd/comment-tags")

--- a/recipes/comment-tags
+++ b/recipes/comment-tags
@@ -1,3 +1,4 @@
 (comment-tags
  :fetcher github
- :repo "vincekd/comment-tags")
+ :repo "vincekd/comment-tags"
+ :files ("comment-tags.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Provides a minor mode for highlighting and jumping between comment tags like TODO, FIXME, etc.

The current packages are fairly outdated and don't allow easily jumping between tags/viewing them in all in one spot.

### Direct link to the package repository

https://github.com/vincekd/comment-tags

### Your association with the package

I'm the creator and maintainer of the package.

### Relevant communications with the upstream package maintainer

None

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
