### PR TITLE
Add recipe for pelican-mode.

### DIFF
--- a/recipes/pelican-mode
+++ b/recipes/pelican-mode
@@ -1,0 +1,2 @@
+(pelican-mode :fetcher git
+              :url "https://git.korewanetadesu.com/pelican-mode.git")


### PR DESCRIPTION
### Brief summary of what the package does

pelican-mode is an Emacs minor mode for editing pages and posts in
Pelican sites. Pelican is a static site generator which can process a
variety of text file formats. For more information, see URL
https://blog.getpelican.com/.

It's intended to be used alongside a major mode for the Pelican
document. Currently supported formats are Markdown, reStructuredText,
AsciiDoc, and Org.

### Direct link to the package repository

https://git.korewanetadesu.com/pelican-mode.git

### Your association with the package

Maintainer/author/user.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
