### PR TITLE
Initial commit of cftag-mode

### DIFF
--- a/recipes/cftag-mode
+++ b/recipes/cftag-mode
@@ -1,0 +1,5 @@
+(cftag-mode
+ :repo "am2605/cfml-mode"
+ :fetcher github
+ :files ("cftag-mode.el")
+ )


### PR DESCRIPTION
### Brief summary of what the package does

Redefines html-mode to support additional CFML (ColdFusion) tags.  This is used by cfml-mode.

### Direct link to the package repository

https://github.com/am2605/cfml-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
