### PR TITLE
Recipe: Add highlight-function-calls

### DIFF
--- a/recipes/highlight-function-calls
+++ b/recipes/highlight-function-calls
@@ -1,0 +1,1 @@
+(highlight-function-calls :fetcher github :repo "alphapapa/highlight-function-calls")


### PR DESCRIPTION
### Brief summary of what the package does
This package highlights function symbols in function calls.  This makes them stand out from other symbols, which makes it easy to see where calls to other functions are.  Optionally, macros and special forms can be highlighted as well.  Also, a list of symbols can be excluded from highlighting; by default, ones like `+` / `-`, `<` / `>`, `error`, `require`, etc. are excluded.  Finally, the `not` function can be highlighted specially.

### Direct link to the package repository

https://github.com/alphapapa/highlight-function-calls

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Thanks.