### PR TITLE
Add company-terraform recipe

### DIFF
--- a/recipes/company-terraform
+++ b/recipes/company-terraform
@@ -1,0 +1,1 @@
+(company-terraform :fetcher github :repo "rafalcieslak/emacs-company-terraform")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a `company` backend for Terraform files, enabling auto-completion in Terraform sources.

### Direct link to the package repository

https://github.com/rafalcieslak/emacs-company-terraform

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

I have also tested dependencies with `make sandbox`.