### PR TITLE
Move nix-mode to separate repository

### DIFF
--- a/recipes/nix-mode
+++ b/recipes/nix-mode
@@ -1,2 +1,2 @@
-(nix-mode :repo "NixOS/nix" :fetcher github
-          :files ("misc/emacs/nix-mode.el"))
+(nix-mode :repo "NixOS/nix-mode" :fetcher github
+          :files ("nix-mode.el"))


### PR DESCRIPTION
This adds the updated nix-mode.el version to the MELPA repository. Not sure what Nix maintainers think of this, but this nix-mode has some notable improvements in syntax highlighting. It is based on the same code as the original but with some improvements.

### Brief summary of what the package does

Same as older nix-mode, just with better highlighting support. Should make it easier for people to make changes, etc.

Because this moves an old package, I want to make sure everyone is okay with it before merging. These Nix people should probably sign off in some way:

- @edolstra
- @shlevy

If it's preferred to keep it within the NixOS org, maybe it can be made a separate repository? This is already done with NixOS/nix-idea. The main problem currently is that Emacs+Nix PRs sit around for a long time without anyone reviewing them.

Other people that might have input:

- @mdorman
- @ttuegel 
- @peti

See related issues: NixOS/nix#1419, matthewbauer/nix-mode#30

### Direct link to the package repository

https://github.com/NixOS/nix-mode

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
