### PR TITLE
Add recipe for web-search

### DIFF
--- a/recipes/web-search
+++ b/recipes/web-search
@@ -1,0 +1,3 @@
+(web-search :fetcher github
+            :repo "xuchunyang/web-search.el"
+            :files (:defaults "web-search" "web-search-completion.bash"))


### PR DESCRIPTION
### Brief summary of what the package does

Open a web search on Google/Wikipedia/etc from Emacs or the terminal, e.g., `M-x web-search foo` or `$ web-search foo`to search for "foo" on Google.

### Direct link to the package repository

https://github.com/xuchunyang/web-search.el

### Your association with the package

[Are you the maintainer? A contributor? An enthusiastic user?]

I'm the maintainer

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
