### PR TITLE
Add a recipe for old-norse-input

### DIFF
--- a/recipes/old-norse-input
+++ b/recipes/old-norse-input
@@ -1,0 +1,1 @@
+(old-norse-input :repo "david-christiansen/emacs-old-norse-input" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a Quail input method specialized for writing Old Norse in Unicode on standard US or Scandinavian keyboards. Old Norse is the ancestor of modern Danish, Swedish, Norwegian, Icelandic, Faeroese, and Elfdalian. The common Roman-alphabet orthographies for Old Norse, however, make use of letters that are not present in any modern Scandinavian language and that are also difficult to access on a US International keyboard layout. This input method makes it much easier to type these characters.

### Direct link to the package repository

https://github.com/david-christiansen/emacs-old-norse-input

### Your association with the package

I wrote the package

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
