### PR TITLE
Move emacs-psci package

### DIFF
--- a/recipes/psci
+++ b/recipes/psci
@@ -1,1 +1,1 @@
-(psci :fetcher github :repo "ardumont/emacs-psci")
+(psci :fetcher github :repo "purescript-emacs/emacs-psci")


### PR DESCRIPTION
Fixes https://github.com/purescript-emacs/emacs-psci/issues/17.

We just moved the emacs-psci repository under the purescript-emacs organisation.
