### PR TITLE
Reintroducing `plantuml-mode` after the relicensing to GPLv3+

### DIFF
--- a/recipes/plantuml-mode
+++ b/recipes/plantuml-mode
@@ -1,0 +1,2 @@
+(plantuml-mode :fetcher github
+               :repo "skuro/plantuml-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`plantuml-mode` -- a major mode for editing PlantUML files

### Direct link to the package repository

https://github.com/skuro/plantuml/mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

Reintroducing the package after licensing has been moved to GPLv3+, making it Emacs compatible.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
