### PR TITLE
Add `snazzy-theme` recipe

### DIFF
--- a/recipes/snazzy-theme
+++ b/recipes/snazzy-theme
@@ -1,0 +1,1 @@
+(snazzy-theme :repo "weijiangan/emacs-snazzy" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A high-contrast base16 theme based on @sindresorhus's Snazzy color scheme.

### Direct link to the package repository

https://github.com/weijiangan/emacs-snazzy

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
