### PR TITLE
Add green is the new black theme recipe

### DIFF
--- a/recipes/green-is-the-new-black-theme
+++ b/recipes/green-is-the-new-black-theme
@@ -1,0 +1,1 @@
+(green-is-the-new-black-theme :repo "fredcamps/green-is-the-new-black-emacs" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A minimalist blackened green theme for emacs

### Direct link to the package repository

https://github.com/fredcamps/green-is-the-new-black-emacs

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
