### PR TITLE
Create s12cpuv2-mode

### DIFF
--- a/recipes/s12cpuv2-mode
+++ b/recipes/s12cpuv2-mode
@@ -1,0 +1,1 @@
+(s12cpuv2-mode :fetcher github :repo "AdamNiederer/s12cpuv2-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for the assembly language of the S12CPUV2 found on some Freescale microcontrollers

### Direct link to the package repository

https://github.com/AdamNiederer/s12cpuv2-mode

### Your association with the package

Wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
