### PR TITLE
Transfer emacs-php packages

### DIFF
--- a/recipes/apache-mode
+++ b/recipes/apache-mode
@@ -1,1 +1,1 @@
-(apache-mode :fetcher github :repo "zonuexe/apache-mode")
+(apache-mode :fetcher github :repo "emacs-php/apache-mode")

--- a/recipes/composer
+++ b/recipes/composer
@@ -1,1 +1,1 @@
-(composer :fetcher github :repo "zonuexe/composer.el")
+(composer :fetcher github :repo "emacs-php/composer.el")

--- a/recipes/copy-file-on-save
+++ b/recipes/copy-file-on-save
@@ -1,1 +1,1 @@
-(copy-file-on-save :fetcher github :repo "zonuexe/emacs-auto-deployment")
+(copy-file-on-save :fetcher github :repo "emacs-php/emacs-auto-deployment")

--- a/recipes/datetime-format
+++ b/recipes/datetime-format
@@ -1,4 +1,4 @@
 (datetime-format
- :repo "zonuexe/emacs-datetime"
+ :repo "emacs-php/emacs-datetime"
  :fetcher github
  :files ("datetime-format.el"))

--- a/recipes/magic-filetype
+++ b/recipes/magic-filetype
@@ -1,1 +1,1 @@
-(magic-filetype :fetcher github :repo "zonuexe/magic-filetype.el")
+(magic-filetype :fetcher github :repo "emacs-php/magic-filetype.el")

--- a/recipes/phan
+++ b/recipes/phan
@@ -1,1 +1,1 @@
-(phan :fetcher github :repo "zonuexe/phan.el")
+(phan :fetcher github :repo "emacs-php/phan.el")

--- a/recipes/projectile-variable
+++ b/recipes/projectile-variable
@@ -1,1 +1,1 @@
-(projectile-variable :fetcher github :repo "zonuexe/projectile-variable")
+(projectile-variable :fetcher github :repo "emacs-php/projectile-variable")

--- a/recipes/psysh
+++ b/recipes/psysh
@@ -1,1 +1,1 @@
-(psysh :fetcher github :repo "zonuexe/psysh.el")
+(psysh :fetcher github :repo "emacs-php/psysh.el")

--- a/recipes/robots-txt-mode
+++ b/recipes/robots-txt-mode
@@ -1,1 +1,1 @@
-(robots-txt-mode :fetcher github :repo "zonuexe/robots-txt-mode")
+(robots-txt-mode :fetcher github :repo "emacs-php/robots-txt-mode")

--- a/recipes/timecop
+++ b/recipes/timecop
@@ -1,4 +1,4 @@
 (timecop
- :repo "zonuexe/emacs-datetime"
+ :repo "emacs-php/emacs-datetime"
  :fetcher github
  :files ("timecop.el"))


### PR DESCRIPTION
I transferred my PHP/Web development related packages to [emacs-php](https://github.com/emacs-php).

- https://melpa.org/#/apache-mode
- https://melpa.org/#/composer
- https://melpa.org/#/copy-file-on-save
- https://melpa.org/#/datetime-format
- https://melpa.org/#/magic-filetype
- https://melpa.org/#/phan
- https://melpa.org/#/projectile-variable
- https://melpa.org/#/psysh
- https://melpa.org/#/robots-txt-mode
- https://melpa.org/#/timecop
