### PR TITLE
Fix vc-fossil recipe

### DIFF
--- a/recipes/vc-fossil
+++ b/recipes/vc-fossil
@@ -1,1 +1,1 @@
-(vc-fossil :fetcher github :repo "emacsorphanage/vc-fossil")
+(vc-fossil :fetcher github :repo "emacsorphanage/vc-fossil" :files ("vc/el/*.el" "doc/*"))


### PR DESCRIPTION
The emacs lisp files are at vc/el, not at the root of the repository. 

The doc files are included since they had been, before the move to the 
emacsorphanage.

See issue #4970.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
