### PR TITLE
Update recipes (#4967, #4968, #4969)

### DIFF
--- a/recipes/choice-program
+++ b/recipes/choice-program
@@ -1,1 +1,1 @@
-(choice-program :fetcher github :repo "plandes/choice-program" :files ("lisp/*.el"))
+(choice-program :fetcher github :repo "plandes/choice-program")

--- a/recipes/mo-git-blame
+++ b/recipes/mo-git-blame
@@ -1,1 +1,1 @@
-(mo-git-blame :repo "mbunkus/mo-git-blame" :fetcher github)
+(mo-git-blame :repo "mbunkus/mo-git-blame" :fetcher gitlab)

--- a/recipes/simple-rtm
+++ b/recipes/simple-rtm
@@ -1,1 +1,1 @@
-(simple-rtm :fetcher github :repo "mbunkus/simple-rtm" :files ("lisp/*.el"))
+(simple-rtm :fetcher gitlab :repo "mbunkus/simple-rtm" :files ("lisp/*.el"))


### PR DESCRIPTION
### Relevant communications with the upstream package maintainer

For simple-rtm and mo-git-blame, the upstream package maintainer has stated that he's moving to gitlab. (See [here](https://github.com/mbunkus/simple-rtm) and [here](https://github.com/mbunkus/mo-git-blame).) The actual content of these moved repos does not seem to have been changed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
