### PR TITLE
Add sqlite3-api recipe

### DIFF
--- a/recipes/sqlite3-api
+++ b/recipes/sqlite3-api
@@ -1,0 +1,1 @@
+(sqlite3-api :fetcher github :repo "pekingduck/emacs-sqlite3-api")


### PR DESCRIPTION
### Brief summary of what the package does

This package does two things:
1. Provides a function `sqlite3-api-install-dynamic-module` to users to install a dynamic module (from same repo below) that wraps around the SQLite3 C API.
2. Defines two error symbols used by the dynamic module.

### Direct link to the package repository

https://github.com/pekingduck/emacs-sqlite3-api

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)