### PR TITLE
Add esxml-query to esxml

### DIFF
--- a/recipes/esxml
+++ b/recipes/esxml
@@ -1,1 +1,1 @@
-(esxml :fetcher github :repo "tali713/esxml" :files ("esxml.el"))
+(esxml :fetcher github :repo "tali713/esxml" :files ("esxml.el" "esxml-query.el"))


### PR DESCRIPTION
### Brief summary of what the package does

esxml is a package for taking apart XML, manipulating it and generating XML.  esxml-query is a new addition to it that allows extracting contents in a jQuery-like fashion with CSS selectors.  I'd like to add its file to the recipe so that other packages can make use of this feature. 

### Direct link to the package repository

https://github.com/tali713/esxml

### Your association with the package

I'm a contributor with commit access to esxml and wrote esxml-query.  Previously I've only contributed bugfixes.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

`M-x checkdoc` hangs here.  I'm not sure whether the remaining points are relevant, considering this PR is about adding a file to an existing package, but I'll address them if needed.