### PR TITLE
Add recipe for mu4e-query-fragments

### DIFF
--- a/recipes/mu4e-query-fragments
+++ b/recipes/mu4e-query-fragments
@@ -1,0 +1,2 @@
+(mu4e-query-fragments :repo "wavexx/mu4e-query-fragments.el"
+                      :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`mu4e-query-fragments` allows to define query snippets ("fragments") that
can be used in regular `mu4e` searches or bookmars. Fragments can be used to
define complex filters to apply in existing searches, or supplant bookmarks
entirely. Fragments compose properly with regular mu4e/xapian operators, and
can be arbitrarily nested.

### Direct link to the package repository

https://github.com/wavexx/mu4e-query-fragments.el

### Your association with the package

Author

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

package-lint complains that I use mu4e/qf as opposed to mu4e-query-fragments as the prefix, however I'm using mu4e/[suffix] to avoid namespace clashes with mu4e symbols, as well to keep it reasonably editable.

The same strategy is used with multiple-cursors (where mc/[ext] is used).