### PR TITLE
Add recipe for password-store-otp

### DIFF
--- a/recipes/password-store-otp
+++ b/recipes/password-store-otp
@@ -1,0 +1,2 @@
+(password-store-otp :repo "volrath/password-store-otp.el"
+                    :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs functions to interact with the [`pass-otp`](https://github.com/tadfisher/pass-otp) extension for [`pass`](https://www.passwordstore.org/).

### Direct link to the package repository

https://github.com/volrath/password-store-otp.el

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
