### PR TITLE
Update perl6-mode repo location

### DIFF
--- a/recipes/perl6-mode
+++ b/recipes/perl6-mode
@@ -1,1 +1,1 @@
-(perl6-mode :fetcher github :repo "hinrik/perl6-mode")
+(perl6-mode :fetcher github :repo "perl6/perl6-mode")

--- a/recipes/perl6-mode
+++ b/recipes/perl6-mode
@@ -1,1 +1,1 @@
-(perl6-mode :fetcher github :repo "perl6/perl6-mode")
+(perl6-mode :fetcher github :repo "perl6/perl6-mode" (:exclude "nqp-mode.el"))


### PR DESCRIPTION
Per https://github.com/perl6/perl6-mode/issues/11 and https://github.com/hinrik/perl6-mode/issues/20 perl6-mode will now be maintained by the Perl6 community, and so needs an update on MELPA to
use the new location.

Many thanks to @treyharris for initiating the move (https://github.com/perl6/perl6-mode/issues/9,) and to @hinrik for creating this major mode! :tada:
