### PR TITLE
Add missing treemacs file.

### DIFF
--- a/recipes/treemacs
+++ b/recipes/treemacs
@@ -1,4 +1,4 @@
 (treemacs
  :fetcher github
  :repo "Alexander-Miller/treemacs"
- :files (:defaults "icons" (:exclude "treemacs-evil.el" "treemacs-projectile.el")))
+ :files (:defaults "icons" "treemacs-dirs-to-collapse.py" (:exclude "treemacs-evil.el" "treemacs-projectile.el")))


### PR DESCRIPTION
Not a new package. This will simply add [a missing python script](https://github.com/Alexander-Miller/treemacs/blob/master/treemacs-dirs-to-collapse.py) to the package built that I didn't know is not caught by :defaults.
