### PR TITLE
Add eshell-bookmark

### DIFF
--- a/recipes/eshell-bookmark
+++ b/recipes/eshell-bookmark
@@ -1,0 +1,1 @@
+(eshell-bookmark :fetcher github :repo "Fuco1/eshell-bookmark")


### PR DESCRIPTION
### Brief summary of what the package does

Allows you to store bookmarks to eshell buffers

### Direct link to the package repository

https://github.com/Fuco1/eshell-bookmark

### Your association with the package

maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
