### PR TITLE
Add recipe: rg-dired-icons

### DIFF
--- a/recipes/rg-dired-icons
+++ b/recipes/rg-dired-icons
@@ -1,0 +1,3 @@
+(rg-dired-icons
+ :repo "rgemulla/rg-dired-icons"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Dired minor mode that displays file and directory icons for Windows. Also
provides utility functions for extracting, displaying, and caching icons.

### Direct link to the package repository

https://github.com/rgemulla/rg-dired-icons

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
