### PR TITLE
Add recipe for ox-hugo

### DIFF
--- a/recipes/ox-hugo
+++ b/recipes/ox-hugo
@@ -1,0 +1,2 @@
+(ox-hugo :fetcher github
+         :repo "kaushalmodi/ox-hugo")


### PR DESCRIPTION
### Brief summary of what the package does

This library implements a Markdown back-end compatible with the
Hugo static site generator (https://gohugo.io/) for Org exporter.
This includes the generation of the Hugo post front-matter in TOML
or YAML.

### Direct link to the package repository

https://github.com/kaushalmodi/ox-hugo

### Your association with the package

Author

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)