### PR TITLE
Receipe: circadian - automatic theme-switching based on daytime

### DIFF
--- a/recipes/circadian
+++ b/recipes/circadian
@@ -1,0 +1,1 @@
+(circadian :fetcher github :repo "GuidoSchmidt/circadian.el")

--- a/recipes/hemera-theme
+++ b/recipes/hemera-theme
@@ -1,0 +1,1 @@
+(hemera-theme :fetcher github :repo "GuidoSchmidt/emacs-hemera-theme")

--- a/recipes/nyx-theme
+++ b/recipes/nyx-theme
@@ -1,0 +1,1 @@
+(nyx-theme :fetcher github :repo "GuidoSchmidt/emacs-nyx-theme")


### PR DESCRIPTION
### Brief summary of what the package does

Circadian provides a way to automatically switch themes for day and night and features two themes: hemera-theme and nyx-theme.

### Direct link to the package repository

https://github.com/GuidoSchmidt/circadian.el

### Your association with the package

Creater and maintainer 🙂 

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
