### PR TITLE
Re-add gvol-mode and achievements since they now have licenses

### DIFF
--- a/recipes/achievements
+++ b/recipes/achievements
@@ -1,0 +1,1 @@
+(achievements :fetcher bitbucket :repo "gvol/emacs-achievements")

--- a/recipes/gap-mode
+++ b/recipes/gap-mode
@@ -1,0 +1,4 @@
+(gap-mode
+ :fetcher bitbucket
+ :repo "gvol/gap-mode"
+ :files ("*.el" "emacs.gaprc"))


### PR DESCRIPTION
It was brought to my attention that gap-mode and emacs-achievements had been removed from MELPA.  After some work I was able to track it down to this commit:

https://github.com/melpa/melpa/commit/cf92ce1a2bc92c73071d157e7e223982bbd3f818

which says they were removed because of lack of license.  I have now added a LICENSE.txt file, so I'm creating this pull request.

That said, it would have been *VERY* nice to have had some indication that they would be removed.  Nothing was done to notify me.  There _were_ bugs filed by @tarsius asking for a license, but *NO* indication that there were repercussions.  I understand not wanting to distribute unlicensed code and simple sentence to that effect would have effected a much prompt change on my part.  I suspect that many or all packages similarly removed would benefit from such verbiage. </rant>

That said, thanks for all the work maintaining MELPA and it's valuable contribution to the Emacs community.