### PR TITLE
Suggest using the latest version of package-lint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Please confirm with `x`:
 
 - [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
 - [ ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
-- [ ] I've used [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
+- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 - [ ] My elisp byte-compiles cleanly
 - [ ] `M-x checkdoc` is happy with my docstrings
 - [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
It seems like package PRs are often submitted with the package-lint box checked, but with problems that should have been detected by it.  Maybe they were on an old version of package-lint.  I don't upgrade my packages very often, so I'm probably guilty of this myself.