### PR TITLE
Update location of ocaml repository for caml recipe

### DIFF
--- a/recipes/caml
+++ b/recipes/caml
@@ -1,1 +1,3 @@
-(caml :fetcher svn :url "https://caml.inria.fr/svn/ocaml/trunk/emacs/")
+(caml :fetcher github
+ :repo "ocaml/ocaml"
+ :files ("emacs/*.el"))


### PR DESCRIPTION
### Direct link to the package repository

https://github.com/ocaml/ocaml/tree/trunk/emacs

### Relevant communications with the upstream package maintainer

See #5002.

It seems that OCaml is now mainly using github, rather than their own svn repository, and an upstream contributor thinks that fetching from github is better.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
