### PR TITLE
Clarify use of version numbers for unstable MELPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ accepted by the `Makefile`.
 
 * `recipes/<NAME>` -- Build individual recipe `<NAME>`. Built packages
 are put in the `packages/` folder with version corresponding to the
-newest HEAD revision available; given according to the `%Y%m%d`
-format.
+date of the latest commit that modified at least one of the files
+specified by the recipe; given according to the `%Y%m%d` format.
 
 * `json` -- build all JSON files.
 


### PR DESCRIPTION
See #5005.

The version number for unstable MELPA packages, specified in  `README.md`, is slightly misleading. For example, for git, the version number is specified [here](https://github.com/melpa/melpa/blob/12cdbdf404fa859a48d1bb69f058321d7595d2a2/package-build/package-build.el#L606) — effectively `git log --first-parent -n1 --pretty=format:'\%ci' ${source-file-list}`, rather than being simply the date of the commit at HEAD.

### Checklist

Please confirm with `x`:

- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)



