### PR TITLE
Add recipe for evil-expat

### DIFF
--- a/recipes/evil-expat
+++ b/recipes/evil-expat
@@ -1,0 +1,1 @@
+(evil-expat :repo "edkolev/evil-expat" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Adds evil ex commands, ones that a vim user might be accustomed to.

### Direct link to the package repository

https://github.com/edkolev/evil-expat

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
