### PR TITLE
Add recipe for flycheck-yang

### DIFF
--- a/recipes/flycheck-yang
+++ b/recipes/flycheck-yang
@@ -1,0 +1,1 @@
+(flycheck-yang :repo "andaru/flycheck-yang" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a [flycheck](http://www.flycheck.org/en/latest/) syntax checker for YANG ([RFC6020](https://tools.ietf.org/html/rfc6020)/[RFC7950](https://tools.ietf.org/html/rfc7950)) files using [`pyang`](https://github.com/mbj4668/pyang).

### Direct link to the package repository

https://github.com/andaru/flycheck-yang

### Your association with the package

Maintainer of `flycheck-yang`.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
