### PR TITLE
Remove org-mac-iCal and org-mac-link recipes.

### DIFF
--- a/recipes/org-mac-iCal
+++ b/recipes/org-mac-iCal
@@ -1,4 +1,0 @@
-(org-mac-iCal
- :fetcher git
- :url "git://orgmode.org/org-mode.git"
- :files ("contrib/lisp/org-mac-iCal.el"))

--- a/recipes/org-mac-link
+++ b/recipes/org-mac-link
@@ -1,5 +1,0 @@
-(org-mac-link
- :fetcher git
- :url "git://orgmode.org/org-mode.git"
- :files ("contrib/lisp/org-mac-link.el")
- :old-names (org-mac-link-grabber))


### PR DESCRIPTION
These recipes use an insecure plain “git://” protocol (issue #3004).
They are also available in the “org-plus-contrib” package in
org-mode’s own ELPA, for users who want to explicitly add an insecure
archive or verify orgmode.org’s self-signed certificate themselves.