### PR TITLE
Pull goto-chg from GitHub

### DIFF
--- a/recipes/goto-chg
+++ b/recipes/goto-chg
@@ -1,1 +1,1 @@
-(goto-chg :fetcher wiki)
+(goto-chg :repo "emacs-evil/goto-chg" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

goto-chg allows you to jump to your last changes.

### Direct link to the package repository

https://github.com/emacs-evil/goto-chg

### Your association with the package

I'm maintaining this package from now on as it's been previously hosted on EmacsWiki.

### Relevant communications with the upstream package maintainer

I've reached out to the original author and got the impression that they were indifferent to the question of whether maintainership should be handed over or not.  For this reason I'm taking over maintainership as I want Evil to be installable from MELPA (Stable) and for it to work correctly with this package and the undo-tree package.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

### Other

See https://github.com/melpa/melpa/pull/5008 for more context.