### PR TITLE
Add org2ctex recipe

### DIFF
--- a/recipes/org2ctex
+++ b/recipes/org2ctex
@@ -1,0 +1,1 @@
+(org2ctex :fetcher github :repo "tumashu/org2ctex")


### PR DESCRIPTION
### Brief summary of what the package does

Export org to ctex (A macro of Chinese latex)

### Direct link to the package repository

https://github.com/tumashu/org2ctex

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
