### PR TITLE
Update recipes for paper-theme and forecast.

### DIFF
--- a/recipes/forecast
+++ b/recipes/forecast
@@ -1,1 +1,1 @@
-(forecast :fetcher github :repo "cadadr/forecast.el")
+(forecast :fetcher github :repo "cadadr/elisp" :files ("forecast.el"))

--- a/recipes/paper-theme
+++ b/recipes/paper-theme
@@ -1,1 +1,1 @@
-(paper-theme :fetcher github :repo "cadadr/paper-theme")
+(paper-theme :fetcher github :repo "cadadr/elisp" :files ("paper-theme.el"))


### PR DESCRIPTION
I've moved my public Elisp stuff into a single repository for
convenience (a repo per project was too much as all of them are
kind-of small and it's tedious to maintain one for each).  This commit
updates my recipes to fetch relevant files from the new
github.com:cadadr/elisp repo.

### Brief summary of what the package does

These packages were already on Melpa.

### Direct link to the package repository

https://github.com/cadadr/elisp

### Your association with the package

I am the maintainer of both projects

### Relevant communications with the upstream package maintainer

I don't know if it poses a problem but I've removed the release tags in order to switch to using the master branch as the latest stable version of each script.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

(I'm unsure about the non-checked ones, but the actual elisp files themselves are unchanged, and they were on Melpa since some time already, so I guess there should not be any problems merging.  I'll be happy to fix anything wrong with my patch/packages otherwise.  Sorry for the inconvenience.)
