### PR TITLE
change unstable branch of ensime

### DIFF
--- a/recipes/ensime
+++ b/recipes/ensime
@@ -1,2 +1,3 @@
 (ensime :fetcher github
+    :branch "2.0"
 	:repo "ensime/ensime-emacs")


### PR DESCRIPTION
We have split out our "unstable" release branch (`2.0`) and our dev branch (`3.0`, will break all the things). So changing melpa to point to `2.0`.