### PR TITLE
Recipe for projectile-trailblazer added

### DIFF
--- a/recipes/projectile-trailblazer
+++ b/recipes/projectile-trailblazer
@@ -1,0 +1,2 @@
+(projectile-trailblazer :repo "micdahl/projectile-trailblazer"
+                  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The package adds a minor mode for finding files in Rails projects which use Trailblazer.
It namely adds support for finding cells, contracts, operations and views. 

### Direct link to the package repository

https://github.com/micdahl/projectile-trailblazer

### Your association with the package

I am the maintainer, even if the package is heavy inspired by projectile-rails.

### Relevant communications with the upstream package maintainer

*none needed*

### Additional info

`package-lint` shows 

> 109:0: error: Global minor modes must `:require' their defining file (i.e. ":require 'projectile-trailblazer"), to support the customization variable of the same name.

 But I don't see, how to fix that. If I add `:require 'projectile-trailblazer`, I get errors when running my unit and integration tests. If I leave it as it is, everything works fine (as far as I see).

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
