### PR TITLE
Open source links in new tab

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -330,7 +330,7 @@
               m("td.recipe",
                 m("a", {href: p.recipeURL}, glyphicon('cutlery'))),
               m("td.source",
-                p.sourceURL ? m("a", {href: p.sourceURL}, p.source) : p.source),
+                p.sourceURL ? m("a", {href: p.sourceURL, target: "_blank"}, p.source) : p.source),
               m("td", [p.downloads.toLocaleString()])
             ]);
           }))


### PR DESCRIPTION
This PR adds `target="_blank"` to Source links. This is more intuitive in my opinion since Source links are external to melpa.org.

Thanks