### PR TITLE
Add ‘apt-sources-list’ recipe

### DIFF
--- a/recipes/apt-sources-list
+++ b/recipes/apt-sources-list
@@ -1,0 +1,2 @@
+(apt-sources-list :fetcher git
+                  :url "https://git.korewanetadesu.com/apt-sources-list.git")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for editing APT’s `.list` files.

The `/etc/apt/sources.list` file and other files in `/etc/apt/sources.list.d` tell APT, found on Debian-based systems and others, where to find packages for installation.

This mode is derived from `apt-sources-mode` distributed in the `debian-el` Debian package, but has many differences. Among them:
- The load hook has been removed. Use `with-eval-after-load`.
- What is properly called a “suite” is no longer called a “distribution.”
- Most keys have changed. This is for better mnemonics (`C-c C-s` to change the suite), or for better Emacs integration (`C-M-n` or your `forward-list` equivalent to move between source lines).
- Editing functions may be called more easily from Emacs Lisp.


### Direct link to the package repository

https://git.korewanetadesu.com/apt-sources-list.git

### Your association with the package

Maintainer of this, long-time user of the `debian-el` version.

I emailed the Debian maintainer of `apt-sources-mode` a while back but did not receive an answer. The "official" mode is increasingly bad for me without option support, and it's generally not maintained (for example, it was never updated to add the new Debian release).

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
