### PR TITLE
Add lsp-javacomp recipe

### DIFF
--- a/recipes/lsp-javacomp
+++ b/recipes/lsp-javacomp
@@ -1,0 +1,1 @@
+(lsp-javacomp :repo "tigersoldier/lsp-javacomp" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A lsp-mode client that provides Java code-completion and other IDE
features. It's backed by JavaComp.

### Direct link to the package repository

https://github.com/tigersoldier/lsp-javacomp

### Your association with the package

I'm the author of the package

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
