### PR TITLE
remove baidu-life

### DIFF
--- a/recipes/baidu-life
+++ b/recipes/baidu-life
@@ -1,1 +1,0 @@
-(baidu-life :fetcher github :repo "lujun9972/el-baidu-life")


### PR DESCRIPTION
Baidu has changed api urls, so this package is no longer valid.