### PR TITLE
Add imake recipe

### DIFF
--- a/recipes/imake
+++ b/recipes/imake
@@ -1,0 +1,1 @@
+(imake :fetcher github :repo "tarsius/imake")


### PR DESCRIPTION
### Prelude

In the past I have sometimes just pushed recipes for my own packages instead of going through the usual review, but I am not doing that in this case because you might consider `imake` to be one that falls into the *overspecialized, just for personal use* category. But first...

### Brief summary of what the package does

This package provides the command `imake`, which prompts for
a `make` target and runs it in the current directory.

This is an opinionated command suitable for simple Makefiles
such as those that can be found in the repositories of some
Emacs packages.  The make targets to be offered as completion
candidates have to be documented like so:

```make
help:
        $(info make lisp   - generate byte-code and autoloads)
        $(info make clean  - remove generated files)
```

More precisely, a `help` target containing lines that match
the regexp `"^\t$(info make \\([^)]*\\))"` is expected.

### Interlude

So it is a bit opinionated, but not that much - having a `help` target makes sense, and using the `info` function too.

### Direct link to the package repository

https://github.com/tarsius/imake

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

:wine_glass: 

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  See https://github.com/purcell/package-lint/issues/93.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
  Well mostly. It wants me to add some typos to example configuration.
- [x] I've built ~~and installed~~ the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
  And it actually caught a stupid pasto.
