### PR TITLE
Add recipe for js-auto-format-mode

### DIFF
--- a/recipes/js-auto-format-mode
+++ b/recipes/js-auto-format-mode
@@ -1,0 +1,1 @@
+(js-auto-format-mode :fetcher github :repo "ybiquitous/js-auto-format-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs minor mode for auto-formatting JavaScript code. After saving JavaScript file, its' code will be formatted automatically.

By default, this package uses [ESLint](https://eslint.org/), but it can customize any formatters such as [Prettier](https://github.com/prettier/prettier).

### Direct link to the package repository

https://github.com/ybiquitous/js-auto-format-mode

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
