### PR TITLE
Add recipe for zoom

### DIFF
--- a/recipes/zoom
+++ b/recipes/zoom
@@ -1,0 +1,1 @@
+(zoom :repo "cyrus-and/zoom" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This minor mode takes care of managing the window sizes by enforcing a fixed and automatic balanced layout where the currently selected window is resized according to `zoom-size` which can be an absolute value in lines/columns, a ratio between the selected window and frame size or even a custom callback.

### Direct link to the package repository

https://github.com/cyrus-and/zoom

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

See [this notice](https://github.com/cyrus-and/zoom/blob/b425fafe5960bdb34a62c85d611fda5f96f4df79/README.md#what-about-golden-ratioel), it is maybe important.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
