### PR TITLE
Add recipe for smart-semicolon

### DIFF
--- a/recipes/smart-semicolon
+++ b/recipes/smart-semicolon
@@ -1,0 +1,1 @@
+(smart-semicolon :repo "iquiw/smart-semicolon" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Minor mode to insert semicolon smartly.
In short, insert `;` at eol if it is not there. Also there are some tweaks.
It is like what Eclipse does for Java.

### Direct link to the package repository

https://github.com/iquiw/smart-semicolon

### Your association with the package

Author.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
