### PR TITLE
Add recipe for benchstat.el

### DIFF
--- a/recipes/benchstat
+++ b/recipes/benchstat
@@ -1,0 +1,1 @@
+(benchstat :repo "Quasilyte/benchstat.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Convenient wrapper around `benchmark-run-compiled` which makes it
very easy to analyze the benchmarking results.

Internally uses [benchstat](https://godoc.org/golang.org/x/perf/cmd/benchstat) program to calculate deltas and other statistics.

Useful for Emacs Lisp hackers that already know that min/max/avg is not a proper metric for
relative performance measurement.

### Direct link to the package repository

https://github.com/Quasilyte/benchstat.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
