### PR TITLE
add crystal-mode to recipes

### DIFF
--- a/recipes/emacs-crystal-mode
+++ b/recipes/emacs-crystal-mode
@@ -1,3 +1,3 @@
 (emacs-crystal-mode :repo "crystal-lang-tools/emacs-crystal-mode"
                :fetcher github
-               :files ("crystal-mode.el" "README.md"))
+               :files ("crystal-mode.el"))

--- a/recipes/emacs-crystal-mode
+++ b/recipes/emacs-crystal-mode
@@ -1,3 +1,3 @@
 (emacs-crystal-mode :repo "crystal-lang-tools/emacs-crystal-mode"
                :fetcher github
-               :files ("crystal-mode.el" "flycheck-crystal.el" "README.md"))
+               :files ("crystal-mode.el" "README.md"))

--- a/recipes/emacs-crystal-mode
+++ b/recipes/emacs-crystal-mode
@@ -1,0 +1,3 @@
+(emacs-crystal-mode :repo "crystal-lang-tools/emacs-crystal-mode"
+               :fetcher github
+               :files ("crystal-mode.el" "flycheck-crystal.el" "README.md"))


### PR DESCRIPTION
### Brief summary of what the package does

A minimal crystal mode for emacs, based on ruby-mode (of course)

### Direct link to the package repository

https://github.com/crystal-lang-tools/emacs-crystal-mode

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
