### PR TITLE
Add reason-mode package

### DIFF
--- a/recipes/reason-mode
+++ b/recipes/reason-mode
@@ -1,0 +1,3 @@
+(reason-mode :fetcher github
+             :repo "reasonml-editor/reason-mode"
+             :files ("*.el"))

--- a/recipes/reason-mode
+++ b/recipes/reason-mode
@@ -1,3 +1,1 @@
-(reason-mode :fetcher github
-             :repo "reasonml-editor/reason-mode"
-             :files ("*.el"))
+(reason-mode :fetcher github :repo "reasonml-editor/reason-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for editing [ReasonML](https://reasonml.github.io/).

### Direct link to the package repository

https://github.com/reasonml-editor/reason-mode

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
