### PR TITLE
Add tickscript-mode

### DIFF
--- a/recipes/tickscript-mode
+++ b/recipes/tickscript-mode
@@ -1,0 +1,1 @@
+(tickscript-mode :fetcher github :repo "msherry/tickscript-mode")


### PR DESCRIPTION
Adds a major mode called tickscript-mode, for working with TICKscript
files (https://docs.influxdata.com/kapacitor/v1.3/tick/), which are used with
InfluxDB and Kapacitor.

### Direct link to the package repository

https://github.com/msherry/tickscript-mode

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
