### PR TITLE
Fix ascending/descending sorting. Refs #5026

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -252,7 +252,7 @@
     var queryParams = {
       q: m.route.param('q') || defaultQueryParams.q,
       sort: m.route.param('sort') || defaultQueryParams.sort,
-      asc: m.route.param('asc') == 'true' || defaultQueryParams.asc
+      asc: m.route.param('asc') && m.route.param('asc') == 'false' ? false : defaultQueryParams.asc
     };
     var resetPagination = function() { this.paginatorCtrl.pageNumber(1); }.bind(this);
     var updateRoute = function() {


### PR DESCRIPTION
This PR tries to fix the following issue: the `asc` URL parameter is ignored, all these URLs work the same:
- https://melpa.org/#/?q=light%20theme%20ap&sort=downloads
- https://melpa.org/#/?q=light%20theme%20ap&sort=downloads&asc=true
- https://melpa.org/#/?q=light%20theme%20ap&sort=downloads&asc=false

Here's another way to reproduce the issue:
- open melpa.org
- search for `light theme ap`
- click `DLs` twice to get the theme with most downloads at the top, in this case it should be apropospriate-theme
- refresh the page
- the ordering is lost, apropospriate-theme is not on the top of the list, but on the bottom.

Refs #5026

Please let me know if the PR can be improved.