### PR TITLE
Add lsp-ocaml recipe

### DIFF
--- a/recipes/lsp-ocaml
+++ b/recipes/lsp-ocaml
@@ -1,0 +1,1 @@
+(lsp-ocaml :repo "emacs-lsp/lsp-ocaml" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

OCaml/Reason support for lsp-mode using [ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server).

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-ocaml

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
