### PR TITLE
Add org-section-numbers recipe

### DIFF
--- a/recipes/org-section-numbers
+++ b/recipes/org-section-numbers
@@ -1,0 +1,1 @@
+(org-section-numbers :repo "marcowahl/org-section-numbers" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Display natural section numbers for orgees [=Org subtrees].

This PR is due to one user who proposed this package could  be added to melpa.

### Direct link to the package repository

https://github.com/marcowahl/org-section-numbers

### Your association with the package

 maintainer,contributor,user

### Relevant communications with the upstream package maintainer

 **None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
