### PR TITLE
Adding ja-network to elpa repository

### DIFF
--- a/recipes/ja-network
+++ b/recipes/ja-network
@@ -1,0 +1,1 @@
+(ja-network :repo "jamiguet/ja-network" :fetcher github)


### PR DESCRIPTION
### Provides hooks for handling intermittent network connectivity

Defines network-up-hook and network-down-hook which get invoked when no specified interfaces are add up on the host. It also provides a have-network-p which returns nil if none of the listed interfaces are up. 

The package uses customised variables to enable the same configuration to run on several machines.

### Direct link to the package repository

https://github.com/jamiguet/ja-network

### Your association with the package

I am the creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
