### PR TITLE
Add recipe for js-codemod

### DIFF
--- a/recipes/js-codemod
+++ b/recipes/js-codemod
@@ -1,0 +1,1 @@
+(js-codemod :fetcher github :repo "torgeir/js-codemod.el" :files (:defaults "replace"))


### PR DESCRIPTION
### Brief summary of what the package does

Runs [jscodeshift](https://github.com/facebook/jscodeshift) codemods on the current line or the selected region

### Direct link to the package repository

https://github.com/torgeir/js-codemod.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

---

I could use some help debugging installing the package locally like described in CONTRIBUTING.md. I'm seeing `package-untar-buffer: Package does not untar cleanly into directory js-codemod-20171017.2247/` on running `EMACS_COMMAND=/usr/local/bin/emacs make sandbox INSTALL=js-codemod` and I cant seem to figure out why.

`make recipe/js-codemod` on the other hand seems happy

```sh
➜  melpa git:(add-js-codemod) ✗ make recipes/js-codemod
 • Building recipe js-codemod ...
/usr/local/opt/coreutils/libexec/gnubin/timeout -k 60 600 emacs --no-site-file --batch -l package-build/package-build.el --eval "(let ((package-build-stable nil) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"./packages\" package-build--melpa-base))) (package-build-archive 'js-codemod))"

;;; js-codemod

Fetcher: github
Source: torgeir/js-codemod.el

Updating /Users/torgeirthoresen/Code/melpa/working/js-codemod/
/Users/torgeirthoresen/Code/melpa/working/js-codemod/js-codemod.el -> /var/folders/dm/pdbcszrx5_n9hksgnjv1v7j5pksndl/T/js-codemod861043Tn/js-codemod-20171017.2311/js-codemod.el
/Users/torgeirthoresen/Code/melpa/working/js-codemod/replace -> /var/folders/dm/pdbcszrx5_n9hksgnjv1v7j5pksndl/T/js-codemod861043Tn/js-codemod-20171017.2311/replace
File: /Users/torgeirthoresen/Code/melpa/packages/js-codemod-20171017.2311.entry
Built js-codemod in 2.363s, finished at Tue Oct 17 23:24:09 2017
 ✓ Wrote  8 -rw-r--r--  1 torgeirthoresen  1333597109   299B 17 okt 22:57 ./packages/js-codemod-20171017.2247.entry
24 -rw-r--r--  1 torgeirthoresen  1333597109    10K 17 okt 23:02 ./packages/js-codemod-20171017.2247.tar
 8 -rw-r--r--  1 torgeirthoresen  1333597109   299B 17 okt 23:24 ./packages/js-codemod-20171017.2311.entry
24 -rw-r--r--  1 torgeirthoresen  1333597109    10K 17 okt 23:24 ./packages/js-codemod-20171017.2311.tar
 8 -rw-r--r--  1 torgeirthoresen  1333597109   810B 17 okt 23:24 ./packages/js-codemod-badge.svg
 8 -rw-r--r--  1 torgeirthoresen  1333597109    52B 17 okt 23:24 ./packages/js-codemod-readme.txt
 Sleeping for 0 ...
sleep 0

➜  melpa git:(add-js-codemod) ✗ tar xvfz packages/js-codemod-20171017.2311.tar
x js-codemod-20171017.2311/
x js-codemod-20171017.2311/js-codemod-pkg.el
x js-codemod-20171017.2311/js-codemod.el
x js-codemod-20171017.2311/replace
➜  melpa git:(add-js-codemod) ✗ ls js-codemod-20171017.2311
js-codemod-pkg.el js-codemod.el     replace
```