### PR TITLE
Added kubernetes-tramp

### DIFF
--- a/recipes/kubernetes-tramp
+++ b/recipes/kubernetes-tramp
@@ -1,0 +1,3 @@
+(kubernetes-tramp
+ :fetcher github
+ :repo "gruggiero/kubernetes-tramp")


### PR DESCRIPTION
### Brief summary of what the package does

Allows to use TRAMP on a Docker container deployed on a Kubernetes cluster

### Direct link to the package repository

https://github.com/gruggiero/kubernetes-tramp

### Your association with the package

I'm the creator and mantainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
