### PR TITLE
Rename kaolin-theme to kaolin-themes

### DIFF
--- a/recipes/kaolin-theme
+++ b/recipes/kaolin-theme
@@ -1,1 +1,0 @@
-(kaolin-theme :fetcher github :repo "ogdenwebb/kaolin-theme")

--- a/recipes/kaolin-themes
+++ b/recipes/kaolin-themes
@@ -1,0 +1,1 @@
+(kaolin-themes :fetcher github :repo "ogdenwebb/emacs-kaolin-themes" :old-names (kaolin-theme) :files (:defaults "themes/*.el"))


### PR DESCRIPTION
I rework my single theme to theme pack and change the repository  structure.   