### PR TITLE
Add recipe for flycheck-nimsuggest

### DIFF
--- a/recipes/flycheck-nimsuggest
+++ b/recipes/flycheck-nimsuggest
@@ -1,0 +1,1 @@
+(flycheck-nimsuggest :fetcher github :repo "yuutayamada/flycheck-nimsuggest")


### PR DESCRIPTION
### Brief summary of what the package does

This is a flycheck backend for Nim language. It uses nimsuggest (kinda IDE feature support tool) in 
backend. (there is a flycheck backend for Nim called flycheck-nim, but it uses nim's compiler command
`nim check`)

### Direct link to the package repository

https://github.com/yuutayamada/flycheck-nimsuggest

### Your association with the package

I'm this package's maintainer and also nim-mode's

### Relevant communications with the upstream package maintainer

currently flycheck-nimsuggest.el is included in nim-mode repository, but I will
change the dependencies as soon as I saw the MELPA's change.

The main reason of such change is that for less dependencies on the nim-mode repository and
from Emacs 26, somehow flymake is re-written, so I would include its backend instead of flycheck-nimsuggest. (FYI: https://lists.gnu.org/archive/html/emacs-devel/2017-09/msg00953.html)

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Thank you for reviewing!

EDIT: add a link for new flymake and correct wording