### PR TITLE
Add recipe for 'iter2' package.

### DIFF
--- a/recipes/iter2
+++ b/recipes/iter2
@@ -1,0 +1,2 @@
+(iter2 :repo "doublep/iter2"
+       :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`iter2` is a fully compatible reimplementation of built-in `generator`
package.  It provides `iter2-defun` and `iter2-lambda` forms that can
be used instead of `iter-defun` and `iter-lambda`.  All other
functions and macros (e.g. `iter-yield`, `iter-next`) are
intentionally not duplicated: just use the ones from the original
package.

The main reasons for writing this was that 1) built-in can be extremely slow to convert long functions (~10 seconds for one 900 line megafunction) and 2) Emacs upstream is unresponsive to bug reports.

### Direct link to the package repository

https://github.com/doublep/iter2

### Your association with the package

I'm the only author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed.**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
