### PR TITLE
Add recipe for network-watch

### DIFF
--- a/recipes/ja-network
+++ b/recipes/ja-network
@@ -1,1 +1,0 @@
-(ja-network :repo "jamiguet/ja-network" :fetcher github)

--- a/recipes/ja-network
+++ b/recipes/ja-network
@@ -1,0 +1,1 @@
+(ja-network :repo "jamiguet/ja-network" :fetcher github)

--- a/recipes/network-watch
+++ b/recipes/network-watch
@@ -1,0 +1,1 @@
+(network-watch :repo "jamiguet/network-watch" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Package provides global minor mode for dealing with intermittent networking.

### Direct link to the package repository

https://github.com/jamiguet/network-watch

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
