### PR TITLE
Fix nix-mode

### DIFF
--- a/recipes/nix-mode
+++ b/recipes/nix-mode
@@ -1,2 +1,1 @@
-(nix-mode :repo "NixOS/nix-mode" :fetcher github
-          :files ("nix-mode.el"))
+(nix-mode :repo "NixOS/nix-mode" :fetcher github)

--- a/recipes/nix-mode
+++ b/recipes/nix-mode
@@ -1,1 +1,3 @@
-(nix-mode :repo "NixOS/nix-mode" :fetcher github)
+(nix-mode :repo "NixOS/nix-mode" :fetcher github
+          :files (:defaults
+           (:exclude "nix-company.el" "nix-mode-mmm.el")))


### PR DESCRIPTION
Only nix-mode.el was included. But nix-mode relies also on other files such as nix-format.el which are all part of the repository.
