### PR TITLE
Add dynamic-spaces recipe

### DIFF
--- a/recipes/dynamic-spaces
+++ b/recipes/dynamic-spaces
@@ -1,0 +1,1 @@
+(dynamic-spaces :repo "Lindydancer/dynamic-spaces" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

When editing a text, and `dynamic-spaces-mode' is enabled, text separated by more than one space doesn't move, if possible. Concretely, end-of-line comments stay in place when you edit the code and you can edit a field in a table without affecting other fields.

### Direct link to the package repository

https://github.com/Lindydancer/dynamic-spaces

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
