### PR TITLE
Add back sicp recipe after license fix

### DIFF
--- a/recipes/sicp
+++ b/recipes/sicp
@@ -1,0 +1,2 @@
+(sicp :repo "webframp/sicp-info"
+      :fetcher github)


### PR DESCRIPTION
SICP package licensing has been resolved in:
- https://github.com/webframp/sicp-info/issues/6
- https://github.com/webframp/sicp-info/issues/7

### Brief summary of what the package does

Restoring package for SICP in info mode

### Your association with the package

Just the package maintainer, original content source is noted in package readme.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
