### PR TITLE
Add recipe for fish-completion

### DIFF
--- a/recipes/fish-completion
+++ b/recipes/fish-completion
@@ -1,0 +1,3 @@
+(fish-completion
+ :repo "Ambrevar/emacs-fish-completion"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Add fish-based completion to Emacs and allow Eshell to fall back on it.

### Direct link to the package repository

https://github.com/Ambrevar/emacs-fish-completion

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

I am not sure about what the best practice is when it comes to functions setting external global variables, in this case `eshell-default-completion-function`.
Have a look at `fish-completion-eshell-toggle`: I suspect there is a much more idiomatic / cleaner way to do this.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
