### PR TITLE
Add package lsp-hack for hacklang

### DIFF
--- a/recipes/lsp-hack
+++ b/recipes/lsp-hack
@@ -1,0 +1,1 @@
+(lsp-hack :repo "jra3/lsp-hack" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A very simple lsp client definition for hooking up emacs to hack's hh_client to enable completion, jumping to definitions, type information, and more

See lsp-mode for more info on what lsp is

### Direct link to the package repository

https://github.com/jra3/lsp-hack

### Your association with the package

I am the author of this package

### Relevant communications with the upstream package maintainer

I am the author of this package

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
