### PR TITLE
Add recipe for mu4e-jump-to-list

### DIFF
--- a/recipes/mu4e-jump-to-list
+++ b/recipes/mu4e-jump-to-list
@@ -1,0 +1,2 @@
+(mu4e-jump-to-list :repo "wavexx/mu4e-jump-to-list.el"
+                   :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

``mu4e-jump-to-list`` allows to select and view mailing lists automatically using existing ``List-ID`` headers in your mu database. Requires mu4e (http://www.djcbsoftware.nl/code/mu/).

### Direct link to the package repository

https://github.com/wavexx/mu4e-jump-to-list.el

### Your association with the package

Author.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
