### PR TITLE
Add recipe for erc-scrolltoplace

### DIFF
--- a/recipes/erc-scrolltoplace
+++ b/recipes/erc-scrolltoplace
@@ -1,0 +1,1 @@
+(erc-scrolltoplace :fetcher github :repo "jgkamat/erc-scrolltoplace")


### PR DESCRIPTION
### Brief summary of what the package does

`recenter`'s erc buffers so you can read the latest messages when the default module `keep-place` is enabled.

### Direct link to the package repository

https://github.com/jgkamat/erc-scrolltoplace

### Your association with the package

Maintainer/Creator

### Relevant communications with the upstream package maintainer

**None Needed**

This is a very tiny package, but I wanted to package it in case anyone else is interested in the same recentering behavior.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
