### PR TITLE
Axiom-environment repository changed to git

### DIFF
--- a/recipes/axiom-environment
+++ b/recipes/axiom-environment
@@ -1,4 +1,5 @@
 (axiom-environment :fetcher bitbucket
                    :repo "pdo/axiom-environment"
                    :files ("*.el" ("data" "data/*.el") ("themes" "themes/*.el")
-                           (:exclude "axiom.el" "ob-axiom.el" "company-axiom.el")))
+                           (:exclude "axiom.el" "axiom-build-utils.el"
+                                     "ob-axiom.el" "company-axiom.el")))

--- a/recipes/axiom-environment
+++ b/recipes/axiom-environment
@@ -1,4 +1,4 @@
 (axiom-environment :fetcher bitbucket
                    :repo "pdo/axiom-environment"
                    :files ("*.el" ("data" "data/*.el") ("themes" "themes/*.el")
-                           (:exclude "axiom.el" "ob-axiom.el")))
+                           (:exclude "axiom.el" "ob-axiom.el" "company-axiom.el")))

--- a/recipes/axiom-environment
+++ b/recipes/axiom-environment
@@ -1,5 +1,5 @@
-(axiom-environment :fetcher bitbucket
-                   :repo "pdo/axiom-environment"
+(axiom-environment :fetcher git
+                   :url "https://bitbucket.org/pdo/axiom-environment.git"
                    :files ("*.el" ("data" "data/*.el") ("themes" "themes/*.el")
                            (:exclude "axiom.el" "axiom-build-utils.el"
                                      "ob-axiom.el" "company-axiom.el")))

--- a/recipes/company-axiom
+++ b/recipes/company-axiom
@@ -1,3 +1,3 @@
-(company-axiom :fetcher bitbucket
-               :repo "pdo/axiom-environment"
+(company-axiom :fetcher git
+               :url "https://bitbucket.org/pdo/axiom-environment.git"
                :files ("company-axiom.el"))

--- a/recipes/company-axiom
+++ b/recipes/company-axiom
@@ -1,0 +1,3 @@
+(company-axiom :fetcher bitbucket
+               :repo "pdo/axiom-environment"
+               :files ("company-axiom.el"))

--- a/recipes/ob-axiom
+++ b/recipes/ob-axiom
@@ -1,3 +1,3 @@
-(ob-axiom :fetcher bitbucket
-          :repo "pdo/axiom-environment"
+(ob-axiom :fetcher git
+          :url "https://bitbucket.org/pdo/axiom-environment.git"
           :files ("ob-axiom.el"))

--- a/recipes/vc-fossil
+++ b/recipes/vc-fossil
@@ -1,1 +1,1 @@
-(vc-fossil :fetcher github :repo "emacsorphanage/vc-fossil" :files ("vc/el/*.el" "doc/*"))
+(vc-fossil :fetcher github :repo "venks1/emacs-fossil" :files ("vc/el/*.el" "doc/*"))


### PR DESCRIPTION
The axiom-environment repository has changed from mercurial to git, but still uses the same account on bitbucket.  This affects packages: axiom-environment, ob-axiom & company-axiom.

Thanks,
Paul

