### PR TITLE
Add recipe for elfeed-protocol

### DIFF
--- a/recipes/elfeed-protocol
+++ b/recipes/elfeed-protocol
@@ -1,0 +1,3 @@
+(elfeed-protocol
+  :repo "fasheng/elfeed-protocol"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provide extra protocols to make like ownCloud News works with elfeed 

### Direct link to the package repository

https://github.com/fasheng/elfeed-protocol

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
