### PR TITLE
Add commit-msg-prefix

### DIFF
--- a/recipes/commit-msg-prefix
+++ b/recipes/commit-msg-prefix
@@ -1,1 +1,0 @@
-(commit-msg-prefix :repo "kidd/commit-msg-prefix" :fetcher github)

--- a/recipes/commit-msg-prefix
+++ b/recipes/commit-msg-prefix
@@ -1,0 +1,1 @@
+(commit-msg-prefix :repo "kidd/commit-msg-prefix" :fetcher github)

--- a/recipes/git-msg-prefix
+++ b/recipes/git-msg-prefix
@@ -1,0 +1,1 @@
+(git-msg-prefix :repo "kidd/git-msg-prefix" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Helper functions to hook onto git-commit-mode and provide a list of past commits where you can pick one from the list (different completion options (ivy/helm/ido)) and it inserts part of the text of the selected one. 

More info in:
http://puntoblogspot.blogspot.com.es/2017/07/announcing-commit-msg-prefix.html

### Direct link to the package repository

https://github.com/kidd/commit-msg-prefix

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

It's the first time uploading the package

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
