### PR TITLE
add new adafruit-wisdom package

### DIFF
--- a/recipes/adafruit-wisdom
+++ b/recipes/adafruit-wisdom
@@ -1,0 +1,1 @@
+(adafruit-wisdom :fetcher github :repo "gonewest818/adafruit-wisdom.el")


### PR DESCRIPTION
### Brief summary of what the package does

In the spirit of dad-joke, pulls a quote at random from adafruit.com. This is a curated list of mostly engineering, math and science-related quotes from well known figures in those fields.

### Direct link to the package repository

https://github.com/gonewest818/adafruit-wisdom.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

none needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
