### PR TITLE
Add recipe for ruby-extra-highlight

### DIFF
--- a/recipes/ruby-extra-highlight
+++ b/recipes/ruby-extra-highlight
@@ -1,0 +1,1 @@
+(ruby-extra-highlight :repo "Lindydancer/ruby-extra-highlight" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package highlights parameters of Ruby functions and blocks. This makes Ruby mode behave more like other modes, like the modes for C and C++.

### Direct link to the package repository

https://github.com/Lindydancer/ruby-extra-highlight

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
