### PR TITLE
Add latexdiff.el package

### DIFF
--- a/recipes/latexdiff
+++ b/recipes/latexdiff
@@ -1,0 +1,3 @@
+(latexdiff
+ :fetcher github
+ :repo "galaunay/latexdiff.el")


### PR DESCRIPTION
### Brief summary of what the package does

Add the possibility to use [latexdiff](https://github.com/ftilmann/latexdiff) in Emacs.
This allows to make diff pdfs between several versions of one same tex file. 

### Direct link to the package repository

https://github.com/galaunay/latexdiff.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
