### PR TITLE
Add new file directories for treemacs.

### DIFF
--- a/recipes/treemacs
+++ b/recipes/treemacs
@@ -1,4 +1,12 @@
 (treemacs
  :fetcher github
  :repo "Alexander-Miller/treemacs"
- :files (:defaults "icons" "treemacs-dirs-to-collapse.py" (:exclude "treemacs-evil.el" "treemacs-projectile.el")))
+ :files (:defaults
+         "icons"
+         "treemacs-dirs-to-collapse.py"
+         "src/elisp/treemacs*.el"
+         "src/scripts/treemacs*.py"
+         (:exclude "src/elisp/treemacs-evil.el"
+                   "src/elisp/treemacs-projectile.el"
+                   "treemacs-evil.el"
+                   "treemacs-projectile.el")))

--- a/recipes/treemacs-evil
+++ b/recipes/treemacs-evil
@@ -1,4 +1,5 @@
 (treemacs-evil
  :fetcher github
  :repo "Alexander-Miller/treemacs"
- :files ("treemacs-evil.el"))
+ :files ("treemacs-evil.el"
+         "src/elisp/treemacs-evil.el"))

--- a/recipes/treemacs-projectile
+++ b/recipes/treemacs-projectile
@@ -1,4 +1,5 @@
 (treemacs-projectile
  :fetcher github
  :repo "Alexander-Miller/treemacs"
- :files ("treemacs-projectile.el"))
+ :files ("treemacs-projectile.el"
+         "src/elisp/treemacs-projectile.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This is just an update to the existing treemacs packages to prepare for some file structure refactoring. I like to separate my code into different files, and by now I've near 20 of them, with yet more to come. Time to (eventually) clean up a little. I want to put my elisp and python code into separate directories instead of stuffing everything into root. It's supposed to look [like this](https://github.com/Alexander-Miller/treemacs/tree/files/src).
Of course the package should still be built while the change isn't made yet, so all the old files and exclusions are kept in the recipes for now. I'll open a second PR to remove them once the refactoring is made.

### Direct link to the package repository

https://github.com/Alexander-Miller/treemacs

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
