### PR TITLE
Add dotenv-mode

### DIFF
--- a/recipes/dotenv-mode
+++ b/recipes/dotenv-mode
@@ -1,0 +1,3 @@
+(dotenv-mode
+  :repo "preetpalS/emacs-dotenv-mode"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A (simple) major mode for *.env* files which are typically used for loading environment variables into an application. *.env* files are typically loaded automatically by an added library such as one of the following:
- [Ruby: bkeepers/dotenv](https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/parser.rb)
- [JavaScript: motdotla/dotenv](https://github.com/motdotla/dotenv)
- [PHP: vlucas/phpdotenv](https://github.com/vlucas/phpdotenv)
- [Golang: joho/godotenv](https://github.com/joho/godotenv)

### Direct link to the package repository

https://github.com/preetpalS/emacs-dotenv-mode

### Your association with the package

I am the original author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
