### PR TITLE
Remove omniref.el

### DIFF
--- a/recipes/omniref
+++ b/recipes/omniref
@@ -1,1 +1,0 @@
-(omniref :fetcher github :repo "dotemacs/omniref.el")


### PR DESCRIPTION
The service, which this package depends on: https://omniref.com has
closed down. Which renders the package no longer relevant.

I've also been approached by GitHub user Imintmate about the issue
https://github.com/dotemacs/omniref.el/issues/7 so that I can do the
clean removal of the package.

### Brief summary of what the package does

The package used to look up documentation at https://omniref.com service.
Since the service is gone, the package is no longer useful.

By removing the package, it's one less package to build/worry about when building the whole release.

### Direct link to the package repository

https://github.com/dotemacs/omniref.el

### Your association with the package

Maintainer.

### Checklist

Issues on the checklist aren't applicable in this case as this is a request for package removal.