### PR TITLE
Add recipe for auto-semicolon.

### DIFF
--- a/recipes/auto-semicolon
+++ b/recipes/auto-semicolon
@@ -1,0 +1,1 @@
+(auto-semicolon :repo "jcs090218/auto-semicolon" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a simple package that will automatically add semicolon
at the end of the line.  This package is only helpful if you
code programming language that need semicolon at the end of
each operation.

### Direct link to the package repository

https://github.com/jcs090218/auto-semicolon

### Your association with the package

I am both creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
