### PR TITLE
Pointed codesearch recipe to new repo.

### DIFF
--- a/recipes/codesearch
+++ b/recipes/codesearch
@@ -1,3 +1,3 @@
 (codesearch :fetcher github
-            :repo "abingham/codesearch.el"
-            :files ("codesearch.el"))
+            :repo "abingham/emacs-codesearch"
+            :files ("codesearch.el" "listing-codesearch.el"))

--- a/recipes/codesearch
+++ b/recipes/codesearch
@@ -1,1 +1,3 @@
-(codesearch :fetcher github :repo "abingham/emacs-codesearch")
+(codesearch :fetcher github
+            :repo "abingham/emacs-codesearch"
+            :files ("codesearch.el" "listing-codesearch.el"))

--- a/recipes/codesearch
+++ b/recipes/codesearch
@@ -1,3 +1,1 @@
-(codesearch :fetcher github
-            :repo "abingham/emacs-codesearch"
-            :files ("codesearch.el" "listing-codesearch.el"))
+(codesearch :fetcher github :repo "abingham/emacs-codesearch")


### PR DESCRIPTION
The official repo for codsearch.el changed a while back, but I forgot to update
the melpa recipe.

### Brief summary of what the package does

Let's use use the codesearch code indexing system in emacs.

### Direct link to the package repository

https://github.com/abingham/emacs-codesearch

### Your association with the package

Maintainer, author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
