### PR TITLE
Removed the projectile-codesearch recipe.

### DIFF
--- a/recipes/projectile-codesearch
+++ b/recipes/projectile-codesearch
@@ -1,3 +1,0 @@
-(projectile-codesearch :fetcher github
-                       :repo "abingham/codesearch.el"
-                       :files ("projectile-codesearch.el"))


### PR DESCRIPTION
This was outdated; the project is no longer maintained or really relevant.

### Brief summary of what the package does

Rough integration between projectile and codesearch.

### Direct link to the package repository

n/a

### Your association with the package

ex-maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
