### PR TITLE
Add Redshank

### DIFF
--- a/recipes/redshank
+++ b/recipes/redshank
@@ -1,0 +1,1 @@
+(redshank :repo "emacsattic/redshank" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Redshank is a lisp refactoring package, primarily targeting Common Lisp.

### Direct link to the package repository

https://github.com/emacsattic/redshank

### Your association with the package

I maintain emacs-refactor, which depends on this (https://github.com/Wilfred/emacs-refactor/issues/36). I've used the package itself a little.

### Relevant communications with the upstream package maintainer

See #4622. This package was removed as part of #5010.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
