### PR TITLE
Add recipe for total-lines-mode

### DIFF
--- a/recipes/total-lines
+++ b/recipes/total-lines
@@ -1,0 +1,1 @@
+(total-lines :repo "hinrik/total-lines" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides a minor mode that maintains a buffer-local `total-lines` variable, e.g. for use in a mode-line.

### Direct link to the package repository

https://github.com/hinrik/total-lines

### Your association with the package

I'm the creator.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
