### PR TITLE
Remove markdown-edit-indirect

### DIFF
--- a/recipes/markdown-edit-indirect
+++ b/recipes/markdown-edit-indirect
@@ -1,1 +1,0 @@
-(markdown-edit-indirect :fetcher github :repo "emacs-pe/markdown-edit-indirect.el")


### PR DESCRIPTION
Markdown Mode includes `markdown-edit-code-block` since v2.3 (released August
31, 2017) which basically deprecates this package. I'll eventually remove this repository

### Brief summary of what the package does

[Please write a quick summary of the package.]

### Direct link to the package repository

https://github.com/emacs-pe/markdown-edit-indirect.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer


### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [ ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
