### PR TITLE
Add sailfish scratchbox mb2 package

### DIFF
--- a/recipes/sailfish-scratchbox-mb2
+++ b/recipes/sailfish-scratchbox-mb2
@@ -1,0 +1,1 @@
+(sailfish-scratchbox-mb2 :repo "vityafx/mb2.el" :fetcher github)


### PR DESCRIPTION
The package provides an easy way to invoke `mb2` script inside the sailfish sdk. Useful for sailfish os developers.

### Direct link to the package repository

https://github.com/vityafx/mb2.el

### Your association with the package

I am the maintainer of this project.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)