### PR TITLE
Add sailfish-scratchbox recipe

### DIFF
--- a/recipes/sailfish-scratchbox
+++ b/recipes/sailfish-scratchbox
@@ -1,0 +1,1 @@
+(sailfish-scratchbox :repo "vityafx/sailfish-scratchbox.el" :fetcher github)


### PR DESCRIPTION
This recipe provides an easy way to interact with the sailfish sdk from inside the emacs.

### Direct link to the package repository

https://github.com/vityafx/sailfish-scratchbox.el

### Your association with the package

I am the maintainer of this project.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)