### PR TITLE
add recipe for ninrod/evil-replace-with-char

### DIFF
--- a/recipes/evil-replace-with-char
+++ b/recipes/evil-replace-with-char
@@ -1,0 +1,1 @@
+(evil-replace-with-char :repo "ninrod/evil-replace-with-char" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides an evil operator, =zx= to replace all chars of a text object with a char.

### Direct link to the package repository

https://github.com/ninrod/evil-replace-with-char

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
