### PR TITLE
Add bart-mode

### DIFF
--- a/recipes/bart-mode
+++ b/recipes/bart-mode
@@ -1,0 +1,3 @@
+(bart-mode :fetcher github
+           :repo "mschuldt/bart-mode")
+


### PR DESCRIPTION
### Brief summary of what the package does

   Display real-time departure information for the Bay Area Rapid Transit (BART) system.

### Direct link to the package repository

   https://github.com/mschuldt/bart-mode

### Your association with the package

  I am the author

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)


 