### PR TITLE
Add package celestial-mode-line.

### DIFF
--- a/recipes/celestial-mode-line
+++ b/recipes/celestial-mode-line
@@ -1,0 +1,1 @@
+(celestial-mode-line :fetcher github :repo "ecraven/celestial-mode-line")


### PR DESCRIPTION
### Brief summary of what the package does

Show lunar phase and sunrise/-set time in modeline

### Direct link to the package repository

https://github.com/ecraven/celestial-mode-line

### Your association with the package

I am the author.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
