### PR TITLE
Add (or split off) evil-org-agenda

### DIFF
--- a/recipes/evil-org-agenda
+++ b/recipes/evil-org-agenda
@@ -1,0 +1,3 @@
+(evil-org :repo "Somelauw/evil-org-mode"
+          :fetcher github
+          :files ("evil-org-agenda.el"))


### PR DESCRIPTION
Thanks to the good work of @Ambrevar, evil bindings have been created for org-agenda.
It's currently on https://github.com/Somelauw/evil-org-mode, but can be used on its own.
The question is whether it should be put in a different recipe or can stay in evil-org.
This pull request puts evil-org-agenda in its own recipe, so it can be installed without evil-org.el
Personally, I'm fine with bundling the packages together, but from the README it seems they should be separated.

### Brief summary of what the package does
Integrate emacs-evil with org-agenda

### Direct link to the package repository

https://github.com/Somelauw/evil-org-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
