### PR TITLE
Add a recipe for smalltalk-mode

### DIFF
--- a/recipes/smalltalk-mode
+++ b/recipes/smalltalk-mode
@@ -1,0 +1,3 @@
+(smalltalk-mode
+ :url "git://git.sv.gnu.org/smalltalk.git" :fetcher git
+ :files ("smalltalk-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

smalltalk-mode is part of GNU Smalltalk, and it provides basic syntax
highlighting for Smalltalk programs.

### Direct link to the package repository

http://smalltalk.gnu.org/

### Your association with the package

I'm an enthusiastic user.

### Relevant communications with the upstream package maintainer

All done.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
