### PR TITLE
Add recipe for eterm-256color.

### DIFF
--- a/recipes/eterm-256color
+++ b/recipes/eterm-256color
@@ -1,0 +1,1 @@
+(eterm-256color :fetcher github :repo "dieggsy/eterm-256color" :files (:defaults "eterm-256color.ti"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds support for customizable 256 colors in ansi-term and term.

### Direct link to the package repository

https://github.com/dieggsy/eterm-256color

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
