### PR TITLE
WIP: Add missing files after use-package refactor

### DIFF
--- a/recipes/use-package
+++ b/recipes/use-package
@@ -1,9 +1,4 @@
 (use-package
     :fetcher github
     :repo "jwiegley/use-package"
-    :files ("up-core.el"
-            "up-delight.el"
-            "up-diminish.el"
-            "up-ensure.el"
-            "up-jump.el"
-            "use-package.el"))
+    :files (:defaults (:exclude "bind-key.el")))

--- a/recipes/use-package
+++ b/recipes/use-package
@@ -1,4 +1,9 @@
 (use-package
     :fetcher github
     :repo "jwiegley/use-package"
-    :files ("use-package.el"))
+    :files ("up-core.el"
+            "up-delight.el"
+            "up-diminish.el"
+            "up-ensure.el"
+            "up-jump.el"
+            "use-package.el"))


### PR DESCRIPTION
This is a work in progress. The current recipe for `use-package` is broken (except in MELPA Stable) because some of the package code has been extracted to other files that are not included yet. Installing the package with the new recipe no longer produces https://github.com/jwiegley/use-package/issues/533 but does display the following errors on load:

```
Warning (use-package): Unrecognized keyword: :ensure
Warning (use-package): Unrecognized keyword: :delight
Warning (use-package): Unrecognized keyword: :diminish
```

### Brief summary of what the package does

A use-package declaration for simplifying your .emacs

### Direct link to the package repository

https://github.com/jwiegley/use-package

### Your association with the package

Contributor

### Relevant communications with the upstream package maintainer

@jwiegley
https://github.com/jwiegley/use-package/issues/533#issuecomment-348852211

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
