### PR TITLE
added: recentf-remove-sudo-tramp-prefix

### DIFF
--- a/recipes/recentf-remove-sudo-tramp-prefix
+++ b/recipes/recentf-remove-sudo-tramp-prefix
@@ -1,0 +1,1 @@
+(recentf-remove-sudo-tramp-prefix :fetcher github :repo "ncaq/recentf-remove-sudo-tramp-prefix")


### PR DESCRIPTION
### Brief summary of what the package does

recentf save duplicate history, for instance.
"/sudo:root@akaza:/usr/share/emacs/24.5/lisp/net/tramp.el"
"/usr/share/emacs/24.5/lisp/net/tramp.el"
This Package normalise to after.

### Direct link to the package repository

<https://github.com/ncaq/recentf-remove-sudo-tramp-prefix>

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
