### PR TITLE
added: symbolword-mode

### DIFF
--- a/recipes/symbolword-mode
+++ b/recipes/symbolword-mode
@@ -1,0 +1,1 @@
+(symbolword-mode :repo "ncaq/symbolword-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

modify word split.
symbolword-mode determine word split for symbol.
for instance hyphen.

### Direct link to the package repository

<https://github.com/ncaq/symbolword-mode>

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
