### PR TITLE
use-package extensions now reside in use-package distribution

### DIFF
--- a/recipes/bind-chord
+++ b/recipes/bind-chord
@@ -1,3 +1,3 @@
-(bind-chord :repo "waymondo/use-package-chords"
+(bind-chord :repo "jwiegley/use-package"
             :fetcher github
             :files ("bind-chord.el"))

--- a/recipes/use-package-chords
+++ b/recipes/use-package-chords
@@ -1,3 +1,3 @@
-(use-package-chords :repo "waymondo/use-package-chords"
+(use-package-chords :repo "jwiegley/use-package"
                     :fetcher github
                     :files ("use-package-chords.el"))

--- a/recipes/use-package-ensure-system-package
+++ b/recipes/use-package-ensure-system-package
@@ -1,3 +1,3 @@
-(use-package-ensure-system-package :repo "waymondo/use-package-ensure-system-package"
+(use-package-ensure-system-package :repo "jwiegley/use-package"
                                    :fetcher github
                                    :files ("use-package-ensure-system-package.el"))


### PR DESCRIPTION
### Direct link to the package repository

https://github.com/jwiegley/use-package

### Your association with the package

Maintainer & contributor

### Relevant communications with the upstream package maintainer

These extensions have now been included in the `use-package` distribution.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
