### PR TITLE
Move use-package-chords to the use-package repo

### DIFF
--- a/recipes/use-package-chords
+++ b/recipes/use-package-chords
@@ -1,3 +1,4 @@
-(use-package-chords :repo "waymondo/use-package-chords"
-                    :fetcher github
-                    :files ("use-package-chords.el"))
+(use-package-chords
+    :fetcher github
+    :repo "jwiegley/use-package"
+    :files ("use-package-chords.el"))


### PR DESCRIPTION
See also #5176 and #5178.

### Brief summary of what the package does

key-chord keyword for use-package

### Direct link to the package repository

https://github.com/jwiegley/use-package (formerly https://github.com/waymondo/use-package-chords)

### Your association with the package

Contributor to use-package, which has adopted this package into its repository.

### Relevant communications with the upstream package maintainer

@jwiegley @waymondo 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
