### PR TITLE
Exclude files from use-package recipe that are part of other recipes

### DIFF
--- a/recipes/use-package
+++ b/recipes/use-package
@@ -1,4 +1,7 @@
 (use-package
     :fetcher github
     :repo "jwiegley/use-package"
-    :files (:defaults (:exclude "bind-key.el")))
+    :files (:defaults (:exclude "bind-key.el"
+                                "bind-chord.el"
+                                "use-package-chords.el"
+                                "use-package-ensure-system-package.el")))


### PR DESCRIPTION
Removing the files in this recipe that are also installed by the following recipes:
- recipes/bind-chord
- recipes/use-package-chords
- recipes/use-package-ensure-system-package

Related: https://github.com/melpa/melpa/pull/5173

### Your association with the package

An enthusiastic user.

### Relevant communications with the upstream package maintainer

@jwiegley

- https://github.com/jwiegley/use-package/commit/042e7292e4c4b29be81f875c270bfaec40f75434#commitcomment-26045246
- https://github.com/jwiegley/use-package/issues/559

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (**N/A**)
- [ ] My elisp byte-compiles cleanly (**N/A**)
- [ ] `M-x checkdoc` is happy with my docstrings (**N/A**)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
  - Well, I tried `make recipes/use-package`.. but looks like the `:excludes` in the recipe don't work there.. is that right?