### PR TITLE
use-package recipe improvements

### DIFF
--- a/recipes/use-package
+++ b/recipes/use-package
@@ -1,11 +1,11 @@
 (use-package
     :fetcher github
     :repo "jwiegley/use-package"
-    :files (:defaults
+    :files ("use-package*.el"
+            "use-package*.texi"
             "LICENSE"
             "*.md"
             (:exclude
-             "bind-key.el"
-             "bind-chord.el"
              "use-package-chords.el"
-             "use-package-ensure-system-package.el")))
+             "use-package-ensure-system-package.el"
+             "use-package-tests.el")))

--- a/recipes/use-package
+++ b/recipes/use-package
@@ -2,6 +2,8 @@
     :fetcher github
     :repo "jwiegley/use-package"
     :files ("use-package*.el"
+            "dir"
+            "use-package*.info"
             "use-package*.texi"
             "LICENSE"
             "*.md"

--- a/recipes/use-package
+++ b/recipes/use-package
@@ -5,8 +5,6 @@
             "dir"
             "use-package*.info"
             "use-package*.texi"
-            "LICENSE"
-            "*.md"
             (:exclude
              "use-package-chords.el"
              "use-package-ensure-system-package.el"

--- a/recipes/use-package
+++ b/recipes/use-package
@@ -1,7 +1,11 @@
 (use-package
     :fetcher github
     :repo "jwiegley/use-package"
-    :files (:defaults (:exclude "bind-key.el"
-                                "bind-chord.el"
-                                "use-package-chords.el"
-                                "use-package-ensure-system-package.el")))
+    :files (:defaults
+            "LICENSE"
+            "*.md"
+            (:exclude
+             "bind-key.el"
+             "bind-chord.el"
+             "use-package-chords.el"
+             "use-package-ensure-system-package.el")))


### PR DESCRIPTION
Building on #5167, #5173, and #5181, I wanted to make use-package's file list easier to maintain (since there are multiple packages in the same repository) while adding some missing documentation files.

### Brief summary of what the package does

A use-package declaration for simplifying your .emacs

### Direct link to the package repository

https://github.com/jwiegley/use-package

### Your association with the package

Contributor

### Relevant communications with the upstream package maintainer

Some discussion with @jwiegley in https://gitter.im/use-package/Lobby.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
