### PR TITLE
Add recipe for ipython-shell-send

### DIFF
--- a/recipes/ipython-shell-send
+++ b/recipes/ipython-shell-send
@@ -1,0 +1,1 @@
+(ipython-shell-send :fetcher github :repo "jackkamm/ipython-shell-send-el")


### PR DESCRIPTION
### Brief summary of what the package does

This is a small package for sending code regions to the IPython interpreter. It properly handles code containing IPython magic, unlike the built-in python.el.

### Direct link to the package repository

https://github.com/jackkamm/ipython-shell-send-el

### Your association with the package

I am the maintainer.

### Checklist

Please confirm with `x`:

- [x ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
