### PR TITLE
Add evil-stateful

### DIFF
--- a/recipes/evil-stateful
+++ b/recipes/evil-stateful
@@ -1,0 +1,1 @@
+(evil-stateful :fetcher github :repo "terlar/evil-stateful")


### PR DESCRIPTION
An Emacs minor mode that is intended as an extension with convenience functions
for [evil-mode](https://github.com/emacs-evil/evil). It adds the ability to attach functions to major-mode state
changes. For example if you are using markdown-mode you might want to hide
markup on `evil-normal-state` entry, but show markup on `evil-insert-state`
entry.

### Direct link to the package repository

https://github.com/terlar/evil-stateful

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Not sure how to satisfy the disambiguate `evil-stateful-mode` warning as I am not sure what the mode counts as, e.g. function/command/variable/option/symbol.