### PR TITLE
Add recipe for erc-status-sidebar

### DIFF
--- a/recipes/erc-status-sidebar
+++ b/recipes/erc-status-sidebar
@@ -1,0 +1,1 @@
+(erc-status-sidebar :repo "drewbarbs/erc-status-sidebar" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides a hexchat-like sidebar that shows connected servers in ERC along with the number of unread messages. 

### Direct link to the package repository

https://github.com/drewbarbs/erc-status-sidebar

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
