### PR TITLE
Add multi-run

### DIFF
--- a/recipes/multi-run
+++ b/recipes/multi-run
@@ -1,0 +1,1 @@
+(multi-run :repo "sagarjha/multi-run" :fetcher github)


### PR DESCRIPTION
multi-run 
### Brief summary of what the package does

A minor mode for managing multiple emacs eshell terminals and running commands on them

### Direct link to the package repository

https://github.com/sagarjha/multi-run

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

** None needed **

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
