### PR TITLE
Update fetcher for centered-cursor-mode

### DIFF
--- a/recipes/centered-cursor-mode
+++ b/recipes/centered-cursor-mode
@@ -1,1 +1,1 @@
-(centered-cursor-mode :fetcher wiki)
+(centered-cursor-mode :fetcher github :repo "andre-r/centered-cursor-mode")


### PR DESCRIPTION
The author recently uploaded the mode to Github, and has added a bugfix that isn't in the EmacsWiki version.