### PR TITLE
Rename company-eshell-autosuggest to esh-autosuggest.

### DIFF
--- a/recipes/company-eshell-autosuggest
+++ b/recipes/company-eshell-autosuggest
@@ -1,1 +1,0 @@
-(company-eshell-autosuggest :fetcher github :repo "dieggsy/company-eshell-autosuggest")

--- a/recipes/esh-autosuggest
+++ b/recipes/esh-autosuggest
@@ -1,0 +1,4 @@
+(esh-autosuggest
+ :fetcher github
+ :repo "dieggsy/esh-autosuggest"
+ :old-names (company-eshell-autosuggest))


### PR DESCRIPTION
Rename in as discussed in #5182 

### Brief summary of what the package does

Fish-like autosuggestions for eshell

### Direct link to the package repository

https://github.com/dieggsy/esh-autosuggest

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
