### PR TITLE
Add recipe for interactive-align

### DIFF
--- a/recipes/ialign
+++ b/recipes/ialign
@@ -1,0 +1,2 @@
+(ialign :fetcher github
+	:repo "mkcms/interactive-align")


### PR DESCRIPTION
### Brief summary of what the package does
Interactive version of align-regexp command.
This package provides `ia-interactive-align` command, which will align the selected
region automatically as the regexp characters are typed in the minibuffer.

### Direct link to the package repository

https://github.com/mkcms/interactive-align

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

Package-lint reports many "symbol doesn't start with package prefix" error - I use "ia-" prefix, and it wants "interactive-align-".

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
