### PR TITLE
Add recipe for TeXfrag

### DIFF
--- a/recipes/TeXfrag
+++ b/recipes/TeXfrag
@@ -1,0 +1,1 @@
+(TeXfrag :repo "TobiasZawada/TeXfrag" :fetcher github)


### PR DESCRIPTION
TeXfrag can be used for rendering equations in sx-question-mode buffers.
sx.el is on melpa therefore also TeXfrag should be on melpa.

### Brief summary of what the package does

Make AUCTeX preview available for non-LaTeX buffers.

### Direct link to the package repository

https://github.com/TobiasZawada/TeXfrag

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
