### PR TITLE
specify "gh-pages" branch since "master" does not exist

### DIFF
--- a/recipes/google-c-style
+++ b/recipes/google-c-style
@@ -1,2 +1,3 @@
 (google-c-style :fetcher github
+                :branch "gh-pages"
                 :repo "google/styleguide")


### PR DESCRIPTION
Default branch is "master", but https://github.com/google/styleguide.git
git repo does not have such branch.
