### PR TITLE
use local branch if remote repoo is not accessible

### DIFF
--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -311,8 +311,11 @@ Returns the package version as a string."
 
 (defun package-build--git-repo (dir)
   "Get the current git repo for DIR."
-  (package-build--run-process-match
-   "Fetch URL: \\(.*\\)" dir "git" "remote" "show" "-n" "origin"))
+  (or (ignore-errors
+        (package-build--run-process-match
+         "Fetch URL: \\(.*\\)" dir "git" "remote" "show" "-n" "origin"))
+      (package-build--run-process-match
+       "\\(.*\\)" dir "git" "config" "remote.origin.url")))
 
 (defun package-build--checkout-git (name config dir)
   "Check package NAME with config CONFIG out of git into DIR."

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -362,6 +362,8 @@ Returns the package version as a string."
   (or (ignore-errors
         (package-build--run-process-match
          "HEAD branch: \\(.*\\)" dir "git" "remote" "show" "origin"))
+      (ignore-errors
+        (package-build--run-process-match "^\\* \\(.*\\)" dir "git" "branch"))
       "master"))
 
 (defun package-build--git-head-sha (dir)


### PR DESCRIPTION
Without internet connection, "git remote show origin" cannot be used to determine the branch name.
In such cases use the default branch name of the local clone rather than using "master" which may 
not be correct branch name for some packages such as google-c-style.