### PR TITLE
Add play-crystal.el

### DIFF
--- a/recipes/play-crystal
+++ b/recipes/play-crystal
@@ -1,0 +1,1 @@
+(play-crystal :repo "veelenga/play-crystal.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs to [play.crystal-lang.org](https://play.crystal-lang.org/#/crystal) integration.

play.crystal-lang.org is a web resource to submit/run/share [Crystal](https://crystal-lang.org/) code.

This package allows you to use this resource without exiting your favorite Emacs.

Features:
* Allows to fetch code into Emacs buffers from play.crystal-lang.org
* Allows to submit code to play.crystal-lang.org directly from Emacs
* Allows to browse play.crystal-lang.org

Fixes https://github.com/veelenga/play-crystal.el/issues/2

/cc @brantou

### Direct link to the package repository

https://github.com/veelenga/play-crystal.el

### Your association with the package

Owner

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
