### PR TITLE
Add elcord

### DIFF
--- a/recipes/elcord
+++ b/recipes/elcord
@@ -1,0 +1,6 @@
+(elcord
+ :fetcher github
+ :repo "Zulu-Inuoe/elcord"
+ :files
+ (:defaults
+  "stdpipe.ps1"))


### PR DESCRIPTION
### Brief summary of what the package does

Communicate with locally installed Discord to display Rich Presence information.

### Direct link to the package repository

https://github.com/Zulu-Inuoe/elcord

### Your association with the package

I've forked the original package [found here](https://github.com/Mstrodl/elcord) and heavily expanded on it to make it add Windows support, along with making the package more stable and robust.

I've found no way to contact the original author, but I've kept their authorship and copyright claims in the source and license.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
