### PR TITLE
Add org-wild-notifier

### DIFF
--- a/recipes/org-wild-notifier
+++ b/recipes/org-wild-notifier
@@ -1,0 +1,1 @@
+(org-wild-notifier :fetcher github :repo "akhramov/org-wild-notifier.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides iCal-style notifications for org-agenda, configurable via agenda properties.

### Direct link to the package repository

https://github.com/akhramov/org-wild-notifier.el

### Your association with the package

The author

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
