### PR TITLE
Original repo for Leuven-theme doesn't provide release tags.

### DIFF
--- a/recipes/leuven-theme-stable
+++ b/recipes/leuven-theme-stable
@@ -1,0 +1,3 @@
+(leuven-theme-stable
+ :fetcher github
+ :repo "bzindovic/emacs-leuven-theme")


### PR DESCRIPTION
Original repo for Leuven-theme doesn't provide release tags so I've forked original repo and added a tag. I've added this recipe for a stable release of this excellent theme as a temporal solution, until original author adds them upstream. I've contacted original author and suggested adding tags upstream (see the issue: https://github.com/fniessen/emacs-leuven-theme/issues/50) but he hasn't responded yet.

### Brief summary of what the package does

This package installs tagged version of Leuven-theme, intended for MELPA Stable users.

### Direct link to the package repository

https://github.com/bzindovic/melpa

### Your association with the package

I am an enthusiast user and would like to add the Leuven-theme to MELPA Stable.

### Relevant communications with the upstream package maintainer

https://github.com/fniessen/emacs-leuven-theme/issues/50

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
