### PR TITLE
Add recipe for the Plaster emacs extension.

### DIFF
--- a/recipes/plaster
+++ b/recipes/plaster
@@ -1,0 +1,3 @@
+(plaster :repo "shirakumo/plaster"
+         :fetcher github
+         :files ("plaster.el"))

--- a/recipes/plaster
+++ b/recipes/plaster
@@ -1,3 +1,2 @@
 (plaster :repo "shirakumo/plaster"
-         :fetcher github
-         :files ("plaster.el"))
+         :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package allows convenient managing of pastes on a remote Plaster paste service instance.

### Direct link to the package repository

https://github.com/shirakumo/plaster

### Your association with the package

I'm the maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
