### PR TITLE
Add borg

### DIFF
--- a/recipes/borg
+++ b/recipes/borg
@@ -1,0 +1,4 @@
+(borg :fetcher github
+      :repo "emacscollective/borg"
+      :files (:defaults "borg.mk")
+      :branch "elpa")


### PR DESCRIPTION
Borg is an alternative package manager.  Previously it was only
intended as a replacement for Package.el, but now it can also be
used as a secondary package manager alongside Package.el.  When
used like this, it should be installed using Package.el.

* [repository](https://github.com/emacscollective/borg)
* [announcement](https://github.com/emacscollective/borg/issues/46) with setup instructions
* [original announcement](https://emacsair.me/2016/05/17/assimilate-emacs-packages-as-git-submodules/) (2016)

I am the author.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, thought about it, and then **ignored** it
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is **mostly** happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
