### PR TITLE
Add firrtl-mode from ibm/firrtl-mode

### DIFF
--- a/recipes/firrtl-mode
+++ b/recipes/firrtl-mode
@@ -1,0 +1,4 @@
+(firrtl-mode
+  :repo "ibm/firrtl-mode"
+  :branch "master"
+  :fetcher github)

--- a/recipes/firrtl-mode
+++ b/recipes/firrtl-mode
@@ -1,4 +1,3 @@
 (firrtl-mode
   :repo "ibm/firrtl-mode"
-  :branch "master"
   :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides basic synatx highlighting for the [FIRRTL language](https://bar.eecs.berkeley.edu/projects/2015-firrtl.html).

### Direct link to the package repository

https://github.com/ibm/firrtl-mode

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
  - __Note: Package released under [Apache v2](https://github.com/IBM/firrtl-mode/blob/master/LICENSE).__
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
  - __Note: Tested via `M-x byte-compile-file` producing no errors.__
- [X] `M-x checkdoc` is happy with my docstrings
  - __Note: Everything says "OK".__
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md) 
  - __Note: I've tested using `M-x package-install-file`. `C-c C-c` in any recipe doesn't work for me, but that should be my end.__
