### PR TITLE
Add ‘flycheck-mmark’

### DIFF
--- a/recipes/flycheck-mmark
+++ b/recipes/flycheck-mmark
@@ -1,0 +1,1 @@
+(flycheck-mmark :repo "mmark-md/flycheck-mmark" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a [Flycheck](http://www.flycheck.org) checker for [MMark](https://github.com/mmark-md/mmark) markdown processor.

### Direct link to the package repository

https://github.com/mmark-md/flycheck-mmark

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

Not necessary.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
