### PR TITLE
Add recipe for 'extmap' package.

### DIFF
--- a/recipes/datetime
+++ b/recipes/datetime
@@ -1,2 +1,3 @@
 (datetime :repo "doublep/datetime"
-          :fetcher github)
+          :fetcher github
+          :files (:defaults "*.extmap"))

--- a/recipes/extmap
+++ b/recipes/extmap
@@ -1,0 +1,2 @@
+(extmap :repo "doublep/extmap"
+        :fetcher github)


### PR DESCRIPTION
This will be used by the next version of `datetime` package to store timezone and locale databases.

### Brief summary of what the package does

`extmap` is a very simple package that lets you build a *read-only*,
*constant* database that maps Elisp symbols to almost arbitrary Elisp
objects.  The idea is to avoid preloading all data to memory and only
retrieve it when needed.

This package doesn’t use any external programs, making it a suitable
dependency for smaller libraries.

### Direct link to the package repository

https://github.com/doublep/extmap

### Your association with the package

I'm the only author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
