### PR TITLE
handing over maintainance of impatient-mode

### DIFF
--- a/recipes/impatient-mode
+++ b/recipes/impatient-mode
@@ -1,4 +1,4 @@
-(impatient-mode :repo "netguy204/imp.el"
+(impatient-mode :repo "skeeto/impatient-mode"
                 :fetcher github
                 :files ("*.html" "*.js" "impatient-mode.el"))
 


### PR DESCRIPTION
netguy204 (the original author of impatient-mode)
hands over maintainance to skeeto

### Brief summary of what the package does

See your changes in the browser as you type

### Direct link to the package repository

https://github.com/skeeto/impatient-mode

### Your association with the package

PR created by original author and current maintainer. Updated link points to next maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [ x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [ x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
