### PR TITLE
Update location of speechd upstream

### DIFF
--- a/recipes/speechd-el
+++ b/recipes/speechd-el
@@ -1,3 +1,3 @@
 (speechd-el
- :url "git://git.freebsoft.org/git/speechd-el"
- :fetcher git)
+ :fetcher github
+ :repo "brailcom/speechd-el")


### PR DESCRIPTION
(#3004)

### Direct link to the package repository

https://github.com/brailcom/speechd-el

### Relevant communications with the upstream package maintainer

See the announcement on the mailing list:

https://lists.freebsoft.org/pipermail/speechd/2018q1/004983.html

and the project page:

https://devel.freebsoft.org/speechd-el


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
