### PR TITLE
Use encrypted transport (https) for eide (#3004)

### DIFF
--- a/recipes/eide
+++ b/recipes/eide
@@ -1,1 +1,1 @@
-(eide :fetcher git :url "git://git.tuxfamily.org/gitroot/eide/emacs-ide.git" :files ("src/*.el" "src/themes/*.el"))
+(eide :fetcher git :url "https://git.tuxfamily.org/eide/emacs-ide.git" :files ("src/*.el" "src/themes/*.el"))


### PR DESCRIPTION
### Direct link to the package repository

https://git.tuxfamily.org/eide/emacs-ide.git

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
