### PR TITLE
Add prog-fill recipe

### DIFF
--- a/recipes/prog-fill
+++ b/recipes/prog-fill
@@ -1,0 +1,3 @@
+(prog-fill
+ :repo "ahungry/prog-fill"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Breaks long line calls (chained methods or huge arg lists) into multi-line somewhat intelligently.

### Direct link to the package repository

https://github.com/ahungry/prog-fill

### Your association with the package

Owner

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
