### PR TITLE
Point deleted recipe files from Emacswiki to ahungry rehost

### DIFF
--- a/recipes/ac-dabbrev
+++ b/recipes/ac-dabbrev
@@ -1,0 +1,4 @@
+(ac-dabbrev
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("ac-dabbrev.el"))

--- a/recipes/anchored-transpose
+++ b/recipes/anchored-transpose
@@ -1,0 +1,4 @@
+(anchored-transpose
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("anchored-transpose.el"))

--- a/recipes/aok
+++ b/recipes/aok
@@ -1,0 +1,4 @@
+(aok
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("aok.el"))

--- a/recipes/apropos-fn+var
+++ b/recipes/apropos-fn+var
@@ -1,0 +1,4 @@
+(apropos-fn+var
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("apropos-fn+var.el"))

--- a/recipes/apu
+++ b/recipes/apu
@@ -1,0 +1,4 @@
+(apu
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("apu.el"))

--- a/recipes/ascii
+++ b/recipes/ascii
@@ -1,0 +1,4 @@
+(ascii
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("ascii.el"))

--- a/recipes/auto-capitalize
+++ b/recipes/auto-capitalize
@@ -1,0 +1,4 @@
+(auto-capitalize
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("auto-capitalize.el"))

--- a/recipes/auto-install
+++ b/recipes/auto-install
@@ -1,0 +1,4 @@
+(auto-install
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("auto-install.el"))

--- a/recipes/autofit-frame
+++ b/recipes/autofit-frame
@@ -1,0 +1,4 @@
+(autofit-frame
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("autofit-frame.el"))

--- a/recipes/awk-it
+++ b/recipes/awk-it
@@ -1,0 +1,4 @@
+(awk-it
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("awk-it.el"))

--- a/recipes/backup-each-save
+++ b/recipes/backup-each-save
@@ -1,0 +1,4 @@
+(backup-each-save
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("backup-each-save.el"))

--- a/recipes/batch-mode
+++ b/recipes/batch-mode
@@ -1,0 +1,4 @@
+(batch-mode
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("batch-mode.el"))

--- a/recipes/better-registers
+++ b/recipes/better-registers
@@ -1,0 +1,4 @@
+(better-registers
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("better-registers.el"))

--- a/recipes/blank-mode
+++ b/recipes/blank-mode
@@ -1,0 +1,4 @@
+(blank-mode
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("blank-mode.el"))

--- a/recipes/bookmark+
+++ b/recipes/bookmark+
@@ -1,0 +1,4 @@
+(bookmark+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("bookmark+.el"))

--- a/recipes/browse-kill-ring+
+++ b/recipes/browse-kill-ring+
@@ -1,0 +1,4 @@
+(browse-kill-ring+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("browse-kill-ring+.el"))

--- a/recipes/bs-ext
+++ b/recipes/bs-ext
@@ -1,0 +1,4 @@
+(bs-ext
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("bs-ext.el"))

--- a/recipes/buffer-stack
+++ b/recipes/buffer-stack
@@ -1,0 +1,4 @@
+(buffer-stack
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("buffer-stack.el"))

--- a/recipes/chm-view
+++ b/recipes/chm-view
@@ -1,0 +1,4 @@
+(chm-view
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("chm-view.el"))

--- a/recipes/cmds-menu
+++ b/recipes/cmds-menu
@@ -1,0 +1,4 @@
+(cmds-menu
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("cmds-menu.el"))

--- a/recipes/col-highlight
+++ b/recipes/col-highlight
@@ -1,0 +1,4 @@
+(col-highlight
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("col-highlight.el"))

--- a/recipes/column-marker
+++ b/recipes/column-marker
@@ -1,0 +1,4 @@
+(column-marker
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("column-marker.el"))

--- a/recipes/crosshairs
+++ b/recipes/crosshairs
@@ -1,0 +1,4 @@
+(crosshairs
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("crosshairs.el"))

--- a/recipes/csv-nav
+++ b/recipes/csv-nav
@@ -1,0 +1,4 @@
+(csv-nav
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("csv-nav.el"))

--- a/recipes/cursor-chg
+++ b/recipes/cursor-chg
@@ -1,0 +1,4 @@
+(cursor-chg
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("cursor-chg.el"))

--- a/recipes/cursor-in-brackets
+++ b/recipes/cursor-in-brackets
@@ -1,0 +1,4 @@
+(cursor-in-brackets
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("cursor-in-brackets.el"))

--- a/recipes/cus-edit+
+++ b/recipes/cus-edit+
@@ -1,0 +1,4 @@
+(cus-edit+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("cus-edit+.el"))

--- a/recipes/cygwin-mount
+++ b/recipes/cygwin-mount
@@ -1,0 +1,4 @@
+(cygwin-mount
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("cygwin-mount.el"))

--- a/recipes/dired+
+++ b/recipes/dired+
@@ -1,0 +1,4 @@
+(dired+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("dired+.el"))

--- a/recipes/dired-details
+++ b/recipes/dired-details
@@ -1,0 +1,4 @@
+(dired-details
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("dired-details.el"))

--- a/recipes/dired-details+
+++ b/recipes/dired-details+
@@ -1,0 +1,4 @@
+(dired-details+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("dired-details+.el"))

--- a/recipes/dired-sort
+++ b/recipes/dired-sort
@@ -1,0 +1,4 @@
+(dired-sort
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("dired-sort.el"))

--- a/recipes/dired-sort-menu
+++ b/recipes/dired-sort-menu
@@ -1,0 +1,4 @@
+(dired-sort-menu
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("dired-sort-menu.el"))

--- a/recipes/dired-sort-menu+
+++ b/recipes/dired-sort-menu+
@@ -1,0 +1,4 @@
+(dired-sort-menu+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("dired-sort-menu+.el"))

--- a/recipes/doremi
+++ b/recipes/doremi
@@ -1,0 +1,4 @@
+(doremi
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("doremi.el"))

--- a/recipes/doremi-cmd
+++ b/recipes/doremi-cmd
@@ -1,0 +1,4 @@
+(doremi-cmd
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("doremi-cmd.el"))

--- a/recipes/doremi-frm
+++ b/recipes/doremi-frm
@@ -1,0 +1,4 @@
+(doremi-frm
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("doremi-frm.el"))

--- a/recipes/doremi-mac
+++ b/recipes/doremi-mac
@@ -1,0 +1,4 @@
+(doremi-mac
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("doremi-mac.el"))

--- a/recipes/dropdown-list
+++ b/recipes/dropdown-list
@@ -1,0 +1,4 @@
+(dropdown-list
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("dropdown-list.el"))

--- a/recipes/dummy-h-mode
+++ b/recipes/dummy-h-mode
@@ -1,0 +1,4 @@
+(dummy-h-mode
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("dummy-h-mode.el"))

--- a/recipes/echo-bell
+++ b/recipes/echo-bell
@@ -1,0 +1,4 @@
+(echo-bell
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("echo-bell.el"))

--- a/recipes/el-swank-fuzzy
+++ b/recipes/el-swank-fuzzy
@@ -1,0 +1,4 @@
+(el-swank-fuzzy
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("el-swank-fuzzy.el"))

--- a/recipes/eldoc-extension
+++ b/recipes/eldoc-extension
@@ -1,0 +1,4 @@
+(eldoc-extension
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("eldoc-extension.el"))

--- a/recipes/etags-select
+++ b/recipes/etags-select
@@ -1,0 +1,4 @@
+(etags-select
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("etags-select.el"))

--- a/recipes/etags-table
+++ b/recipes/etags-table
@@ -1,0 +1,4 @@
+(etags-table
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("etags-table.el"))

--- a/recipes/face-remap+
+++ b/recipes/face-remap+
@@ -1,0 +1,4 @@
+(face-remap+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("face-remap+.el"))

--- a/recipes/facemenu+
+++ b/recipes/facemenu+
@@ -1,0 +1,4 @@
+(facemenu+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("facemenu+.el"))

--- a/recipes/faces+
+++ b/recipes/faces+
@@ -1,0 +1,4 @@
+(faces+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("faces+.el"))

--- a/recipes/files+
+++ b/recipes/files+
@@ -1,0 +1,4 @@
+(files+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("files+.el"))

--- a/recipes/filesets+
+++ b/recipes/filesets+
@@ -1,0 +1,4 @@
+(filesets+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("filesets+.el"))

--- a/recipes/find-dired+
+++ b/recipes/find-dired+
@@ -1,0 +1,4 @@
+(find-dired+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("find-dired+.el"))

--- a/recipes/finder+
+++ b/recipes/finder+
@@ -1,0 +1,4 @@
+(finder+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("finder+.el"))

--- a/recipes/fit-frame
+++ b/recipes/fit-frame
@@ -1,0 +1,4 @@
+(fit-frame
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("fit-frame.el"))

--- a/recipes/font-lock+
+++ b/recipes/font-lock+
@@ -1,0 +1,4 @@
+(font-lock+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("font-lock+.el"))

--- a/recipes/frame-cmds
+++ b/recipes/frame-cmds
@@ -1,0 +1,4 @@
+(frame-cmds
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("frame-cmds.el"))

--- a/recipes/frame-fns
+++ b/recipes/frame-fns
@@ -1,0 +1,4 @@
+(frame-fns
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("frame-fns.el"))

--- a/recipes/framemove
+++ b/recipes/framemove
@@ -1,0 +1,4 @@
+(framemove
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("framemove.el"))

--- a/recipes/fuzzy-format
+++ b/recipes/fuzzy-format
@@ -1,0 +1,4 @@
+(fuzzy-format
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("fuzzy-format.el"))

--- a/recipes/fuzzy-match
+++ b/recipes/fuzzy-match
@@ -1,0 +1,4 @@
+(fuzzy-match
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("fuzzy-match.el"))

--- a/recipes/gnus-spotlight
+++ b/recipes/gnus-spotlight
@@ -1,0 +1,4 @@
+(gnus-spotlight
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("gnus-spotlight.el"))

--- a/recipes/gregorio-mode
+++ b/recipes/gregorio-mode
@@ -1,0 +1,4 @@
+(gregorio-mode
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("gregorio-mode.el"))

--- a/recipes/grep+
+++ b/recipes/grep+
@@ -1,0 +1,4 @@
+(grep+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("grep+.el"))

--- a/recipes/header2
+++ b/recipes/header2
@@ -1,0 +1,4 @@
+(header2
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("header2.el"))

--- a/recipes/help+
+++ b/recipes/help+
@@ -1,0 +1,4 @@
+(help+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("help+.el"))

--- a/recipes/help-fns+
+++ b/recipes/help-fns+
@@ -1,0 +1,4 @@
+(help-fns+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("help-fns+.el"))

--- a/recipes/help-mode+
+++ b/recipes/help-mode+
@@ -1,0 +1,4 @@
+(help-mode+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("help-mode+.el"))

--- a/recipes/hexrgb
+++ b/recipes/hexrgb
@@ -1,0 +1,4 @@
+(hexrgb
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("hexrgb.el"))

--- a/recipes/hide-comnt
+++ b/recipes/hide-comnt
@@ -1,0 +1,4 @@
+(hide-comnt
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("hide-comnt.el"))

--- a/recipes/hide-region
+++ b/recipes/hide-region
@@ -1,0 +1,4 @@
+(hide-region
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("hide-region.el"))

--- a/recipes/hideshowvis
+++ b/recipes/hideshowvis
@@ -1,0 +1,4 @@
+(hideshowvis
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("hideshowvis.el"))

--- a/recipes/highlight-chars
+++ b/recipes/highlight-chars
@@ -1,0 +1,4 @@
+(highlight-chars
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("highlight-chars.el"))

--- a/recipes/highlight-cl
+++ b/recipes/highlight-cl
@@ -1,0 +1,4 @@
+(highlight-cl
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("highlight-cl.el"))

--- a/recipes/highlight-tail
+++ b/recipes/highlight-tail
@@ -1,0 +1,4 @@
+(highlight-tail
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("highlight-tail.el"))

--- a/recipes/hl-defined
+++ b/recipes/hl-defined
@@ -1,0 +1,4 @@
+(hl-defined
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("hl-defined.el"))

--- a/recipes/hl-line+
+++ b/recipes/hl-line+
@@ -1,0 +1,4 @@
+(hl-line+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("hl-line+.el"))

--- a/recipes/hl-spotlight
+++ b/recipes/hl-spotlight
@@ -1,0 +1,4 @@
+(hl-spotlight
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("hl-spotlight.el"))

--- a/recipes/icicles
+++ b/recipes/icicles
@@ -1,0 +1,4 @@
+(icicles
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("icicles.el"))

--- a/recipes/icomplete+
+++ b/recipes/icomplete+
@@ -1,0 +1,4 @@
+(icomplete+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("icomplete+.el"))

--- a/recipes/igrep
+++ b/recipes/igrep
@@ -1,0 +1,4 @@
+(igrep
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("igrep.el"))

--- a/recipes/imenu+
+++ b/recipes/imenu+
@@ -1,0 +1,4 @@
+(imenu+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("imenu+.el"))

--- a/recipes/info+
+++ b/recipes/info+
@@ -1,0 +1,4 @@
+(info+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("info+.el"))

--- a/recipes/irfc
+++ b/recipes/irfc
@@ -1,0 +1,4 @@
+(irfc
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("irfc.el"))

--- a/recipes/isearch+
+++ b/recipes/isearch+
@@ -1,0 +1,4 @@
+(isearch+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("isearch+.el"))

--- a/recipes/isearch-prop
+++ b/recipes/isearch-prop
@@ -1,0 +1,4 @@
+(isearch-prop
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("isearch-prop.el"))

--- a/recipes/jira
+++ b/recipes/jira
@@ -1,0 +1,4 @@
+(jira
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("jira.el"))

--- a/recipes/judge-indent
+++ b/recipes/judge-indent
@@ -1,0 +1,4 @@
+(judge-indent
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("judge-indent.el"))

--- a/recipes/lacarte
+++ b/recipes/lacarte
@@ -1,0 +1,4 @@
+(lacarte
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("lacarte.el"))

--- a/recipes/lib-requires
+++ b/recipes/lib-requires
@@ -1,0 +1,4 @@
+(lib-requires
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("lib-requires.el"))

--- a/recipes/lispxmp
+++ b/recipes/lispxmp
@@ -1,0 +1,4 @@
+(lispxmp
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("lispxmp.el"))

--- a/recipes/list-processes+
+++ b/recipes/list-processes+
@@ -1,0 +1,4 @@
+(list-processes+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("list-processes+.el"))

--- a/recipes/macros+
+++ b/recipes/macros+
@@ -1,0 +1,4 @@
+(macros+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("macros+.el"))

--- a/recipes/main-line
+++ b/recipes/main-line
@@ -1,0 +1,4 @@
+(main-line
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("main-line.el"))

--- a/recipes/mb-depth+
+++ b/recipes/mb-depth+
@@ -1,0 +1,4 @@
+(mb-depth+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("mb-depth+.el"))

--- a/recipes/menu-bar+
+++ b/recipes/menu-bar+
@@ -1,0 +1,4 @@
+(menu-bar+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("menu-bar+.el"))

--- a/recipes/message-x
+++ b/recipes/message-x
@@ -1,0 +1,4 @@
+(message-x
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("message-x.el"))

--- a/recipes/minor-mode-hack
+++ b/recipes/minor-mode-hack
@@ -1,0 +1,4 @@
+(minor-mode-hack
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("minor-mode-hack.el"))

--- a/recipes/misc-cmds
+++ b/recipes/misc-cmds
@@ -1,0 +1,4 @@
+(misc-cmds
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("misc-cmds.el"))

--- a/recipes/misc-fns
+++ b/recipes/misc-fns
@@ -1,0 +1,4 @@
+(misc-fns
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("misc-fns.el"))

--- a/recipes/modeline-char
+++ b/recipes/modeline-char
@@ -1,0 +1,4 @@
+(modeline-char
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("modeline-char.el"))

--- a/recipes/modeline-posn
+++ b/recipes/modeline-posn
@@ -1,0 +1,4 @@
+(modeline-posn
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("modeline-posn.el"))

--- a/recipes/mouse+
+++ b/recipes/mouse+
@@ -1,0 +1,4 @@
+(mouse+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("mouse+.el"))

--- a/recipes/mouse3
+++ b/recipes/mouse3
@@ -1,0 +1,4 @@
+(mouse3
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("mouse3.el"))

--- a/recipes/multi-eshell
+++ b/recipes/multi-eshell
@@ -1,0 +1,4 @@
+(multi-eshell
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("multi-eshell.el"))

--- a/recipes/muttrc-mode
+++ b/recipes/muttrc-mode
@@ -1,0 +1,4 @@
+(muttrc-mode
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("muttrc-mode.el"))

--- a/recipes/mwe-log-commands
+++ b/recipes/mwe-log-commands
@@ -1,0 +1,4 @@
+(mwe-log-commands
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("mwe-log-commands.el"))

--- a/recipes/naked
+++ b/recipes/naked
@@ -1,0 +1,4 @@
+(naked
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("naked.el"))

--- a/recipes/narrow-indirect
+++ b/recipes/narrow-indirect
@@ -1,0 +1,4 @@
+(narrow-indirect
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("narrow-indirect.el"))

--- a/recipes/novice+
+++ b/recipes/novice+
@@ -1,0 +1,4 @@
+(novice+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("novice+.el"))

--- a/recipes/oneonone
+++ b/recipes/oneonone
@@ -1,0 +1,4 @@
+(oneonone
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("oneonone.el"))

--- a/recipes/palette
+++ b/recipes/palette
@@ -1,0 +1,4 @@
+(palette
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("palette.el"))

--- a/recipes/plsql
+++ b/recipes/plsql
@@ -1,0 +1,4 @@
+(plsql
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("plsql.el"))

--- a/recipes/point-undo
+++ b/recipes/point-undo
@@ -1,0 +1,4 @@
+(point-undo
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("point-undo.el"))

--- a/recipes/pp+
+++ b/recipes/pp+
@@ -1,0 +1,4 @@
+(pp+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("pp+.el"))

--- a/recipes/pp-c-l
+++ b/recipes/pp-c-l
@@ -1,0 +1,4 @@
+(pp-c-l
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("pp-c-l.el"))

--- a/recipes/pretty-lambdada
+++ b/recipes/pretty-lambdada
@@ -1,0 +1,4 @@
+(pretty-lambdada
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("pretty-lambdada.el"))

--- a/recipes/project-local-variables
+++ b/recipes/project-local-variables
@@ -1,0 +1,4 @@
+(project-local-variables
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("project-local-variables.el"))

--- a/recipes/recentf-ext
+++ b/recipes/recentf-ext
@@ -1,0 +1,4 @@
+(recentf-ext
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("recentf-ext.el"))

--- a/recipes/redo+
+++ b/recipes/redo+
@@ -1,0 +1,4 @@
+(redo+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("redo+.el"))

--- a/recipes/replace+
+++ b/recipes/replace+
@@ -1,0 +1,4 @@
+(replace+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("replace+.el"))

--- a/recipes/reveal-next
+++ b/recipes/reveal-next
@@ -1,0 +1,4 @@
+(reveal-next
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("reveal-next.el"))

--- a/recipes/rfringe
+++ b/recipes/rfringe
@@ -1,0 +1,4 @@
+(rfringe
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("rfringe.el"))

--- a/recipes/ruby-block
+++ b/recipes/ruby-block
@@ -1,0 +1,4 @@
+(ruby-block
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("ruby-block.el"))

--- a/recipes/screenshot
+++ b/recipes/screenshot
@@ -1,0 +1,4 @@
+(screenshot
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("screenshot.el"))

--- a/recipes/second-sel
+++ b/recipes/second-sel
@@ -1,0 +1,4 @@
+(second-sel
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("second-sel.el"))

--- a/recipes/sequential-command
+++ b/recipes/sequential-command
@@ -1,0 +1,4 @@
+(sequential-command
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("sequential-command.el"))

--- a/recipes/showkey
+++ b/recipes/showkey
@@ -1,0 +1,4 @@
+(showkey
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("showkey.el"))

--- a/recipes/simple+
+++ b/recipes/simple+
@@ -1,0 +1,4 @@
+(simple+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("simple+.el"))

--- a/recipes/speck
+++ b/recipes/speck
@@ -1,0 +1,4 @@
+(speck
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("speck.el"))

--- a/recipes/sqlplus
+++ b/recipes/sqlplus
@@ -1,0 +1,4 @@
+(sqlplus
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("sqlplus.el"))

--- a/recipes/sticky
+++ b/recipes/sticky
@@ -1,0 +1,4 @@
+(sticky
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("sticky.el"))

--- a/recipes/strings
+++ b/recipes/strings
@@ -1,0 +1,4 @@
+(strings
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("strings.el"))

--- a/recipes/subr+
+++ b/recipes/subr+
@@ -1,0 +1,4 @@
+(subr+
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("subr+.el"))

--- a/recipes/summarye
+++ b/recipes/summarye
@@ -1,0 +1,4 @@
+(summarye
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("summarye.el"))

--- a/recipes/swbuff-x
+++ b/recipes/swbuff-x
@@ -1,0 +1,4 @@
+(swbuff-x
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("swbuff-x.el"))

--- a/recipes/synonyms
+++ b/recipes/synonyms
@@ -1,0 +1,4 @@
+(synonyms
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("synonyms.el"))

--- a/recipes/tfs
+++ b/recipes/tfs
@@ -1,0 +1,4 @@
+(tfs
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("tfs.el"))

--- a/recipes/thesaurus
+++ b/recipes/thesaurus
@@ -1,0 +1,4 @@
+(thesaurus
+ :fetcher github
+ :repo "ahungry/emacswiki-mirror"
+ :files ("thesaurus.el"))


### PR DESCRIPTION
I think you're going to give a lot of users a lot of grief by deleting almost 200 packages in a single PR.

Since MELPA has poor "within Emacs" communication mechanisms (maybe it should do something like magit did for their fundraiser for relaying important news), even someone like myself who is somewhat involved in the elisp content creation community/emacs develop/MELPA had no idea this was coming.

Since I use a few of these deleted packages, I'd like to see them *not* disappear from package-list. :)

This should allow them to be managed in a safe manner, since they're essentially all abandoned (and you've been trying to reach the authors for half a year+ I see).