### PR TITLE
Add nordless-theme recipe

### DIFF
--- a/recipes/nordless-theme
+++ b/recipes/nordless-theme
@@ -1,0 +1,4 @@
+(nordless-theme
+  :repo "lethom/nordless-theme.el"
+  :files ("nordless-theme.el")
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`nordless` is a mostly colorless theme, with two main source of inspiration: [nofrils](https://github.com/robertmeta/nofrils), an extremely minimalist colorscheme for vim, and [nord](https://github.com/arcticicestudio/nord), a north-bluish color palette.

### Direct link to the package repository

https://github.com/lethom/nordless-theme.el

### Your association with the package

I am the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
