### PR TITLE
Re-add rubikitch's packages moved to GitHub

### DIFF
--- a/recipes/lispxmp
+++ b/recipes/lispxmp
@@ -1,0 +1,1 @@
+(lispxmp :fetcher github :repo "rubikitch/lispxmp")

--- a/recipes/minor-mode-hack
+++ b/recipes/minor-mode-hack
@@ -1,0 +1,1 @@
+(minor-mode-hack :fetcher github :repo "rubikitch/minor-mode-hack")

--- a/recipes/recentf-ext
+++ b/recipes/recentf-ext
@@ -1,0 +1,1 @@
+(recentf-ext :fetcher github :repo "rubikitch/recentf-ext")

--- a/recipes/sequential-command
+++ b/recipes/sequential-command
@@ -1,0 +1,1 @@
+(sequential-command :fetcher github :repo "rubikitch/sequential-command")

--- a/recipes/sticky
+++ b/recipes/sticky
@@ -1,0 +1,1 @@
+(sticky :fetcher github :repo "rubikitch/sticky")

--- a/recipes/usage-memo
+++ b/recipes/usage-memo
@@ -1,0 +1,2 @@
+(usage-memo :fetcher github :repo "rubikitch/usage-memo"
+    	    :files (:defaults (:exclude "test-usage-memo.el")))


### PR DESCRIPTION
except screenshot which still is only on the Wiki

(#5020)


### Direct link to the package repository

https://github.com/rubikitch/lispxmp

https://github.com/rubikitch/minor-mode-hack

https://github.com/rubikitch/recentf-ext

https://github.com/rubikitch/sequential-command

https://github.com/rubikitch/sticky

https://github.com/rubikitch/usage-memo


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
