### PR TITLE
Add recipe for git-attr

### DIFF
--- a/recipes/git-attr
+++ b/recipes/git-attr
@@ -1,0 +1,1 @@
+(git-attr :fetcher github :repo "arnested/emacs-git-attr")


### PR DESCRIPTION
### Brief summary of what the package does

Expose gitattributes to emacs buffers

I.e. putting files marked as `linguist-generated=true` into `read-only-mode` on visiting.

### Direct link to the package repository

https://github.com/arnested/emacs-git-attr

### Your association with the package

Author/maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
