### PR TITLE
Remove an old file from emacsql-sqlite's recipe

### DIFF
--- a/recipes/emacsql-sqlite
+++ b/recipes/emacsql-sqlite
@@ -1,3 +1,3 @@
 (emacsql-sqlite :repo "skeeto/emacsql"
                 :fetcher github
-                :files ("emacsql-sqlite.el" "emacsql-system.el" "sqlite"))
+                :files ("emacsql-sqlite.el" "sqlite"))


### PR DESCRIPTION
The file emacsql-system.el was removed from the emacsql-sqlite.el package, so it is no longer needed in the recipe.

https://github.com/skeeto/emacsql/commit/62d39157370219a1680265fa593f90ccd51457da
