### PR TITLE
New Recipe: usql.el / Support U-SQL in sql-mode

### DIFF
--- a/recipes/usql
+++ b/recipes/usql
@@ -1,0 +1,1 @@
+(usql :fetcher github :repo "nickbarnwell/usql.el")


### PR DESCRIPTION
### Brief summary of what the package does

Add syntax highlighting for Microsoft's U-SQL language to sql-mode buffers.

### Direct link to the package repository

https://github.com/nickbarnwell/usql.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
