### PR TITLE
Create feebleline

### DIFF
--- a/recipes/feebleline
+++ b/recipes/feebleline
@@ -1,1 +1,1 @@
-(feebleline :fetcher github :repo "tautologyclub/feebleline" :files ("feebleline.el"))  
+(feebleline :fetcher github :repo "tautologyclub/feebleline")  

--- a/recipes/feebleline
+++ b/recipes/feebleline
@@ -1,0 +1,1 @@
+(feebleline :fetcher github :repo "tautologyclub/feebleline" :files ("feebleline.el"))  


### PR DESCRIPTION
### Brief summary of what the package does

feebleline removes the modeline and replaces it with a slimmer proxy version that gets continuously written to *Minibuf-0* whenever no one else is using it. The modeline of course gets restored when feebleline-mode is toggled. 

### Direct link to the package repository

https://github.com/tautologyclub/feebleline

### Your association with the package

I am the author and maintainer of the package. There are two skilled contributors in total, plus myself makes it three contributors in total.

### Relevant communications with the upstream package maintainer

feebleline has a high probability of conflicting with fancy modeline customizing packages -- I haven't tested this. But then again, if feebleline appeals to you, then fancy modelines probably do not.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
