### PR TITLE
emacs-faust-mode: set source to upstream

### DIFF
--- a/recipes/faust-mode
+++ b/recipes/faust-mode
@@ -1,1 +1,1 @@
-(faust-mode :repo "magnetophon/emacs-faust-mode" :fetcher github)
+(faust-mode :repo "rukano/emacs-faust-mode" :fetcher github)


### PR DESCRIPTION
Currently my fork is in melpa, but development has started in the main repo again, so now we'd like that to be in here.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [ ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
