### PR TITLE
add python-pytest package

### DIFF
--- a/recipes/python-pytest
+++ b/recipes/python-pytest
@@ -1,0 +1,3 @@
+(python-pytest
+ :fetcher github
+ :repo "wbolster/emacs-python-pytest")


### PR DESCRIPTION
### Brief summary of what the package does

python pytest runner inside comint, with various "dwim" interactive commands.

more modern, more features, and more opinionated, and more ‘works out of the box’ than other python testing related emacs packages.

### Direct link to the package repository

https://github.com/wbolster/emacs-python-pytest

### Your association with the package

author/maintainer

### Relevant communications with the upstream package maintainer

none needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
