### PR TITLE
Add attrap

### DIFF
--- a/recipes/attrap
+++ b/recipes/attrap
@@ -1,0 +1,2 @@
+(attrap :repo "jyp/attrap"
+        :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Attrap provides a command to attempt to fix the flycheck error at point.
Attrap currently comes with builtin fixers for
`haskell-dante` and `emacs-lisp`. Support for other flycheck
checkers can be added dynamically (see `attrap.el`).

### Direct link to the package repository

https://github.com/jyp/attrap

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer
N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
