### PR TITLE
Use encrypted transport (https) for notmuch

### DIFF
--- a/recipes/notmuch
+++ b/recipes/notmuch
@@ -1,3 +1,3 @@
-(notmuch :url "git://git.notmuchmail.org/git/notmuch"
+(notmuch :url "https://git.notmuchmail.org/git/notmuch"
          :fetcher git
          :files ("emacs/*.el" "emacs/*.png"))


### PR DESCRIPTION
(#3004)

### Direct link to the package repository

https://git.notmuchmail.org/git/notmuch

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
