### PR TITLE
Update nordless-theme upstream

### DIFF
--- a/recipes/nordless-theme
+++ b/recipes/nordless-theme
@@ -1,4 +1,4 @@
 (nordless-theme
-  :repo "lethom/nordless-theme.el"
+  :repo "lthms/nordless-theme.el"
   :files ("nordless-theme.el")
   :fetcher github)


### PR DESCRIPTION
I have changed my github nickname recently, and created some kind of “parking account” to prevent someone to create a “rogue” repository lethom/nordless-theme.el. That being said, I am pretty sure updating the upstream of nordless-theme (my only package on Melpa) is a good idea :).

I want to apologise for the inconvenience. This will not happen again!

Have a great week-end.