### PR TITLE
Add echange package recipe

### DIFF
--- a/recipes/echange
+++ b/recipes/echange
@@ -1,0 +1,6 @@
+(echange
+ :fetcher github
+ :repo "kirill-gerasimenko/echange"
+ :files ("bin/echange.el"
+         "bin/echange.bat"
+         "bin/echange.jar"))


### PR DESCRIPTION
### Brief summary of what the package does

Package provides 2 useful functions:

- opens email messages from MS Exchange in locally installed Outlook (or in default browser) by internet message id. Internet message id can be captured as a part of the link for org-mode
- fetches and saves calendar data from MS Exchange for 2 days to make it available as part of org-mode agenda.

### Direct link to the package repository

https://github.com/kirill-gerasimenko/echange

### Your association with the package

I'm creator and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
  I don't know how to check that, still new to Emacs and learning things. I'm willing to do that. Could you please point me to the way to do this? 
- [x] `M-x checkdoc` is happy with my docstrings
  Except of private methods which I don't see the reason to comment now (and manual https://www.gnu.org/software/emacs/manual/html_node/elisp/Documentation-Tips.html#Documentation-Tips says that only functions and variables inteded for users aka public should have docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
