### PR TITLE
migrated those packages to Org-mode contrib/ now

### DIFF
--- a/recipes/ob-php
+++ b/recipes/ob-php
@@ -1,1 +1,0 @@
-(ob-php :fetcher github :repo "stardiviner/ob-php")

--- a/recipes/ob-redis
+++ b/recipes/ob-redis
@@ -1,1 +1,0 @@
-(ob-redis :fetcher github :repo "stardiviner/ob-redis")

--- a/recipes/ob-smiles
+++ b/recipes/ob-smiles
@@ -1,3 +1,0 @@
-(ob-smiles
- :fetcher github
- :repo "stardiviner/ob-smiles")

--- a/recipes/ob-spice
+++ b/recipes/ob-spice
@@ -1,3 +1,0 @@
-(ob-spice
- :fetcher github
- :repo "stardiviner/ob-spice")


### PR DESCRIPTION
Because they are low development activity. And publish with Org-mode is better.
So I migrated them to Org-mode/contrib/ now. Original repo on GitHub is
"Archived".

- https://github.com/stardiviner/ob-php
- https://github.com/stardiviner/ob-redis
- https://github.com/stardiviner/ob-spice
- https://github.com/stardiviner/ob-smiles

### Your association with the package

I'm maintainer

### Relevant communications with the upstream package maintainer

**None needed**