### PR TITLE
org-rich-yank

### DIFF
--- a/recipes/org-rich-yank
+++ b/recipes/org-rich-yank
@@ -1,0 +1,2 @@
+(org-rich-yank :fetcher github
+               :repo "unhammer/org-rich-yank")


### PR DESCRIPTION
### Brief summary of what the package does

Rich text clipboard for org-mode. Adds a function to yank the
top of the kill-ring into a BEGIN_SRC block of the correct mode, along
with a link to where it came from.

### Direct link to the package repository

https://github.com/unhammer/org-rich-yank

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
