### PR TITLE
Add recipe for gif-screencast

### DIFF
--- a/recipes/gif-screencast
+++ b/recipes/gif-screencast
@@ -1,0 +1,3 @@
+(gif-screencast
+ :repo "Ambrevar/emacs-gif-screencast"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

One-frame-per-action GIF recording for optimal quality/size ratio.

### Direct link to the package repository

https://github.com/Ambrevar/emacs-gif-screencast

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

I've used reserved key-bindings (`f8` and `f9`) but those are only in effect during the recording.  Can you think of anything better?

- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
