### PR TITLE
Added line-up-words

### DIFF
--- a/recipes/line-up-words
+++ b/recipes/line-up-words
@@ -1,0 +1,2 @@
+(line-up-words :fetcher github
+               :repo "janestreet/line-up-words")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides emacs integration for the `line-up-words` tool that aligns words in a region. For instance, selecting lines 2-10 in the following code and pressing `M-x line-up-words` align the code as shown below:

```ocaml
type package =
  { name : string
  ; dir : Path.t
  ; version : string
  ; description : string
  ; archives : Path.t list Mode.Dict.t
  ; plugins : Path.t list Mode.Dict.t
  ; jsoo_runtime : string list
  ; requires : t list
  ; ppx_runtime_deps : t list
  }
```

```ocaml
type package =
  { name             : string
  ; dir              : Path.t
  ; version          : string
  ; description      : string
  ; archives         : Path.t list Mode.Dict.t
  ; plugins          : Path.t list Mode.Dict.t
  ; jsoo_runtime     : string list
  ; requires         : t list
  ; ppx_runtime_deps : t list
  }
```

### Direct link to the package repository

https://github.com/janestreet/line-up-words

### Your association with the package

This package is developed by [Jane Street](https://www.janestreet.com/). I'm a developer at Jane Street and I'm a member the team that takes care of publishing our open source packages on github.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
