### PR TITLE
add rust-mode-reloaded

### DIFF
--- a/recipes/rust-mode-reloaded
+++ b/recipes/rust-mode-reloaded
@@ -1,0 +1,3 @@
+(rust-mode-reloaded
+    :repo "brotzeit/rust-mode-reloaded"
+    :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

It's a fork of https://github.com/rust-lang/rust-mode

### Direct link to the package repository

https://github.com/brotzeit/rust-mode-reloaded

### Your association with the package

Unfortunately the original package is unmaintained. I have made several changes and tried to improve the situation.

### Relevant communications with the upstream package maintainer

I guess none needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
