### PR TITLE
Remove ac-anaconda recipe.

### DIFF
--- a/recipes/ac-anaconda
+++ b/recipes/ac-anaconda
@@ -1,3 +1,0 @@
-(ac-anaconda
- :fetcher github
- :repo "proofit404/ac-anaconda")


### PR DESCRIPTION
I've removed `ac-anaconda` package.

* I was broken for at least last 2 years. 
* No significant community interest in it (no active discussions or PRs to change the situation).
* Anyone interested in the auto-complete support can use `jedi.el` package.