### PR TITLE
add `fuo` recipe

### DIFF
--- a/recipes/fuo
+++ b/recipes/fuo
@@ -1,0 +1,1 @@
+(fuo :repo "cosven/emacs-fuo" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs client for [feeluown](github.com/cosven/feeluown-core) daemon.

### Direct link to the package repository

https://github.com/cosven/emacs-fuo

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

require emacs 24.4 or higher version

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
