### PR TITLE
Transfer elisp-lint to new maintainer

### DIFF
--- a/recipes/elisp-lint
+++ b/recipes/elisp-lint
@@ -1,2 +1,2 @@
-(elisp-lint :fetcher github :repo "nschum/elisp-lint")
+(elisp-lint :fetcher github :repo "gonewest818/elisp-lint")
 


### PR DESCRIPTION
Note: this package is already built and distributed via MELPA.  This pull request completes a change of project ownership / maintainer.


### Brief summary of what the package does

Basic elisp linting (indentation, checkdoc, trailing whitespace, etc).

### Direct link to the package repository

https://github.com/gonewest818/elisp-lint

### Your association with the package

I am the new maintainer... github repository was transferred from the original author this morning.

### Relevant communications with the upstream package maintainer

Please comment here if you need more evidence of cooperation with the original maintainer... He transferred the github repo over to me (if you go to nschum/elisp-lint it redirects to mine), and I have email documenting our agreement to hand over the reins.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
