### PR TITLE
add recipe for sql-clickhouse

### DIFF
--- a/recipes/sql-clickhouse
+++ b/recipes/sql-clickhouse
@@ -1,0 +1,1 @@
+(sql-clickhouse :fetcher github :repo "leethargo/sql-clickhouse")


### PR DESCRIPTION
### Brief summary of what the package does

Adds product type `ClickHouse` for builtin SQL mode.

### Direct link to the package repository

https://github.com/leethargo/sql-clickhouse

### Your association with the package

I'm author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
