### PR TITLE
add recipe 'overcast-theme'

### DIFF
--- a/recipes/overcast-theme
+++ b/recipes/overcast-theme
@@ -1,0 +1,1 @@
+(overcast-theme :fetcher github :repo "myTerminal/overcast-theme")


### PR DESCRIPTION
### Brief summary of what the package does

[overcast-theme](https://github.com/myTerminal/overcast-theme) is a dark theme for Emacs with almost everything except the code and the mode-line muted so that the focus is entirely on the code. The mode-line for the active window is highlighted (but in a less glaring manner) to make it more noticeable while moving back and forth between windows. The theme started from a template generated from [ThemeCreator](https://github.com/mswift42/themecreator) but I have added quite a few changes since then.

### Direct link to the package repository

https://github.com/myTerminal/overcast-theme

### Your association with the package

I am the author and maintainer of this project.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/melpa/melpa/5321)
<!-- Reviewable:end -->
