### PR TITLE
add counsel-css recipe

### DIFF
--- a/recipes/counsel-css
+++ b/recipes/counsel-css
@@ -1,0 +1,1 @@
+(counsel-css :repo "hlissner/emacs-counsel-css" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

counsel-css is an ivy-mode backend for css selectors (works for SCSS and LESS too). It also has a hook to integrate its parser into Imenu.

### Direct link to the package repository

https://github.com/hlissner/emacs-counsel-css

### Your association with the package

enthusiastic user

### Relevant communications with the upstream package maintainer

none needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
