### PR TITLE
Add org-fancy-priorities

### DIFF
--- a/recipes/org-fancy-priorities
+++ b/recipes/org-fancy-priorities
@@ -1,0 +1,4 @@
+(org-fancy-priorities
+ :repo "harrybournis/org-fancy-priorities"
+ :fetcher github)
+


### PR DESCRIPTION
### Brief summary of what the package does

This package displays priorities in Org Mode as use-defined custom strings. It does not alter the user's files, it uses text properties to set the 'display' property of a priority string (e.g. [#A]) to a string of arbitrary length specified by the user. For an example, check the screenshots in the README file in the repository.

### Direct link to the package repository

https://github.com/harrybournis/org-fancy-priorities

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
