### PR TITLE
Various Makefile improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .#*
 /.cask
 /.ecukes-failing-scenarios
+/config.mk
 /download_log.db
 /download_log.json.gz
 /elpa

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 TOP := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
+-include ./config.mk
+
 SHELL         := bash
 EMACS_COMMAND ?= emacs
 

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ $(RCPDIR)/.dirstamp: .FORCE
 ## Recipe rules
 $(RCPDIR)/%: .FORCE
 	@echo " • Building package $(@F) ..."
-	- $(TIMEOUT) $(EVAL) "(let ((package-build-stable $(STABLE)) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"$(PKGDIR)\" package-build--melpa-base))) (package-build-archive \"$(@F)\"))"
-
-	@echo " ✓ Wrote $$(ls -lsh $(PKGDIR)/$(@F)-*) "
+	- $(TIMEOUT) $(EVAL) "(let ((package-build-stable $(STABLE)) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"$(PKGDIR)\" package-build--melpa-base))) (package-build-archive \"$(@F)\"))" \
+	&& echo " ✓ Success:" \
+	&& ls -lsh $(PKGDIR)/$(@F)-*
 	@test $(SLEEP) -gt 0 && echo " Sleeping $(SLEEP) seconds ..." && sleep $(SLEEP) || true
 	@echo
 

--- a/Makefile
+++ b/Makefile
@@ -63,16 +63,16 @@ packages/archive-contents: .FORCE
 	$(EVAL) '(package-build-dump-archive-contents)'
 
 cleanup:
-	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--melpa-base))) (package-build-cleanup))'
+	$(EVAL) '(let ((package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--melpa-base))) (package-build-cleanup))'
 
 ## Json rules
 html/archive.json: $(PKGDIR)/archive-contents
 	@echo " • Building $@ ..."
-	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--melpa-base))) (package-build-archive-alist-as-json "html/archive.json"))'
+	$(EVAL) '(let ((package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--melpa-base))) (package-build-archive-alist-as-json "html/archive.json"))'
 
 html/recipes.json: $(RCPDIR)/.dirstamp
 	@echo " • Building $@ ..."
-	$(EVAL) '(let ((package-build-stable $(STABLE)) (package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--melpa-base))) (package-build-recipe-alist-as-json "html/recipes.json"))'
+	$(EVAL) '(let ((package-build-archive-dir (expand-file-name "$(PKGDIR)/" package-build--melpa-base))) (package-build-recipe-alist-as-json "html/recipes.json"))'
 
 json: html/archive.json html/recipes.json
 

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,6 @@ SLEEP   ?= 0
 SANDBOX := ./sandbox
 STABLE ?= nil
 
-EVAL := $(EMACS_COMMAND)
-
-## Check for needing to initialize CL-LIB from ELPA
-NEED_CL-LIB := $(shell $(EMACS_COMMAND) --no-site-file --batch --eval '(prin1 (version< emacs-version "24.3"))')
-ifeq ($(NEED_CL-LIB), t)
-	EMACS_COMMAND := $(EMACS_COMMAND) --eval "(package-initialize)"
-endif
-
 EVAL := $(EMACS_COMMAND) --no-site-file --batch -L $(TOP)/package-build -l package-build.el --eval
 
 TIMEOUT := $(shell which timeout && echo "-k 60 600")

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@ SLEEP   ?= 0
 SANDBOX := sandbox
 STABLE  ?= nil
 
+LOAD_PATH ?= $(TOP)/package-build
+
 EVAL := $(EMACS_COMMAND) --no-site-file --batch \
--L $(TOP)/package-build \
+$(addprefix -L ,$(LOAD_PATH)) \
 --eval '(setq package-build-archive-dir "$(TOP)/$(PKGDIR)/")' \
 --load package-build.el \
 --eval

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,18 @@ SLEEP   ?= 0
 SANDBOX := sandbox
 STABLE  ?= nil
 
+LISP_CONFIG ?= '(progn\
+  (setq package-build-working-dir "$(TOP)/$(WORKDIR)/")\
+  (setq package-build-archive-dir "$(TOP)/$(PKGDIR)/")\
+  (setq package-build-recipes-dir "$(TOP)/$(RCPDIR)/")\
+  (setq package-build-stable $(STABLE))\
+  (setq package-build-write-melpa-badge-images t))'
+
 LOAD_PATH ?= $(TOP)/package-build
 
 EVAL := $(EMACS_COMMAND) --no-site-file --batch \
 $(addprefix -L ,$(LOAD_PATH)) \
---eval '(setq package-build-archive-dir "$(TOP)/$(PKGDIR)/")' \
+--eval $(LISP_CONFIG) \
 --load package-build.el \
 --eval
 
@@ -92,7 +99,7 @@ $(RCPDIR)/.dirstamp: .FORCE
 ## Recipe rules
 $(RCPDIR)/%: .FORCE
 	@echo " • Building package $(@F) ..."
-	- $(TIMEOUT) $(EVAL) "(let ((package-build-stable $(STABLE)) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"$(PKGDIR)\" package-build--melpa-base))) (package-build-archive \"$(@F)\"))" \
+	- $(TIMEOUT) $(EVAL) "(package-build-archive \"$(@F)\")" \
 	&& echo " ✓ Success:" \
 	&& ls -lsh $(PKGDIR)/$(@F)-*
 	@test $(SLEEP) -gt 0 && echo " Sleeping $(SLEEP) seconds ..." && sleep $(SLEEP) || true

--- a/Makefile
+++ b/Makefile
@@ -43,27 +43,28 @@ index: json
 ## Cleanup rules
 clean-working:
 	@echo " • Removing package sources ..."
-	git clean -dffX $(WORKDIR)/.
+	@git clean -dffX $(WORKDIR)/.
 
 clean-packages:
 	@echo " • Removing packages ..."
-	git clean -dffX $(PKGDIR)/.
+	@git clean -dffX $(PKGDIR)/.
 
 clean-json:
 	@echo " • Removing json files ..."
-	-rm -vf html/archive.json html/recipes.json
+	@-rm -vf html/archive.json html/recipes.json
 
 clean-sandbox:
 	@echo " • Removing sandbox files ..."
-	if [ -d '$(SANDBOX)' ]; then \
+	@if [ -d '$(SANDBOX)' ]; then \
 		rm -rfv '$(SANDBOX)/elpa'; \
 		rmdir '$(SANDBOX)'; \
 	fi
 
 sync:
-	rsync -avz --delete $(PKGDIR)/ $(WEBROOT)/packages
-	rsync -avz --safe-links --delete $(HTMLDIR)/* $(WEBROOT)/
-	chmod -R go+rx $(WEBROOT)/packages/*
+	@echo " • Synchronizing files ..."
+	@rsync -avz --delete $(PKGDIR)/ $(WEBROOT)/packages
+	@rsync -avz --safe-links --delete $(HTMLDIR)/* $(WEBROOT)/
+	@chmod -R go+rx $(WEBROOT)/packages/*
 
 
 pull-package-build:
@@ -75,19 +76,19 @@ packages: $(RCPDIR)/*
 
 packages/archive-contents: .FORCE
 	@echo " • Updating $@ ..."
-	$(EVAL) '(package-build-dump-archive-contents)'
+	@$(EVAL) '(package-build-dump-archive-contents)'
 
 cleanup:
-	$(EVAL) '(package-build-cleanup)'
+	@$(EVAL) '(package-build-cleanup)'
 
 ## Json rules
 html/archive.json: $(PKGDIR)/archive-contents
 	@echo " • Building $@ ..."
-	$(EVAL) '(package-build-archive-alist-as-json "html/archive.json")'
+	@$(EVAL) '(package-build-archive-alist-as-json "html/archive.json")'
 
 html/recipes.json: $(RCPDIR)/.dirstamp
 	@echo " • Building $@ ..."
-	$(EVAL) '(package-build-recipe-alist-as-json "html/recipes.json")'
+	@$(EVAL) '(package-build-recipe-alist-as-json "html/recipes.json")'
 
 json: html/archive.json html/recipes.json
 
@@ -99,7 +100,7 @@ $(RCPDIR)/.dirstamp: .FORCE
 ## Recipe rules
 $(RCPDIR)/%: .FORCE
 	@echo " • Building package $(@F) ..."
-	- $(TIMEOUT) $(EVAL) "(package-build-archive \"$(@F)\")" \
+	@- $(TIMEOUT) $(EVAL) "(package-build-archive \"$(@F)\")" \
 	&& echo " ✓ Success:" \
 	&& ls -lsh $(PKGDIR)/$(@F)-*
 	@test $(SLEEP) -gt 0 && echo " Sleeping $(SLEEP) seconds ..." && sleep $(SLEEP) || true
@@ -109,8 +110,8 @@ $(RCPDIR)/%: .FORCE
 ## Sandbox
 sandbox: packages/archive-contents
 	@echo " • Building sandbox ..."
-	mkdir -p $(SANDBOX)
-	$(EMACS_COMMAND) -Q \
+	@mkdir -p $(SANDBOX)
+	@$(EMACS_COMMAND) -Q \
 		--eval '(setq user-emacs-directory (file-truename "$(SANDBOX)"))' \
 		-l package \
 		--eval "(add-to-list 'package-archives '(\"gnu\" . \"http://elpa.gnu.org/packages/\") t)" \

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ $(RCPDIR)/.dirstamp: .FORCE
 
 ## Recipe rules
 $(RCPDIR)/%: .FORCE
-	@echo " • Building recipe $(@F) ..."
-
+	@echo " • Building package $(@F) ..."
 	- $(TIMEOUT) $(EVAL) "(let ((package-build-stable $(STABLE)) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"$(PKGDIR)\" package-build--melpa-base))) (package-build-archive \"$(@F)\"))"
 
 	@echo " ✓ Wrote $$(ls -lsh $(PKGDIR)/$(@F)-*) "

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,7 @@ $(RCPDIR)/%: .FORCE
 	- $(TIMEOUT) $(EVAL) "(let ((package-build-stable $(STABLE)) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"$(PKGDIR)\" package-build--melpa-base))) (package-build-archive \"$(@F)\"))"
 
 	@echo " ✓ Wrote $$(ls -lsh $(PKGDIR)/$(@F)-*) "
-	@echo " Sleeping for $(SLEEP) ..."
-	sleep $(SLEEP)
+	@test $(SLEEP) -gt 0 && echo " Sleeping $(SLEEP) seconds ..." && sleep $(SLEEP) || true
 	@echo
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))
 
-SHELL   := bash
-PKGDIR  := ./packages
-RCPDIR  := ./recipes
-HTMLDIR := ./html
-WORKDIR := ./working
+SHELL         := bash
+EMACS_COMMAND ?= emacs
+
+PKGDIR  := packages
+RCPDIR  := recipes
+HTMLDIR := html
+WORKDIR := working
 WEBROOT := $$HOME/www
-EMACS_COMMAND   ?= emacs
 SLEEP   ?= 0
-SANDBOX := ./sandbox
-STABLE ?= nil
+SANDBOX := sandbox
+STABLE  ?= nil
 
 EVAL := $(EMACS_COMMAND) --no-site-file --batch -L $(TOP)/package-build -l package-build.el --eval
 


### PR DESCRIPTION
Most importantly make it possible to load a `package-build.el` that is not located inside the melpa repository, which is very useful when you are working on that library as I currently am.

This is done by adding a `LOAD_PATH` variable. Also add a `LISP_CONFIG` variable, which makes it possible to set the various path variables used by `package-build`. Finally load `config.mk` if that exists, which provides a convenient way to set the mentioned variables.

And to top if of also some more or less cosmetic changes.