### PR TITLE
Add mgmtconfig-mode.

### DIFF
--- a/recipes/mgmtconfig-mode
+++ b/recipes/mgmtconfig-mode
@@ -1,0 +1,4 @@
+(mgmtconfig-mode
+ :fetcher github
+ :repo "purpleidea/mgmt"
+ :files ("misc/emacs/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for editing the mgmt config language.  Mgmt is a distributed, event-driven, parallel configuration management tool.

### Direct link to the package repository

https://github.com/purpleidea/mgmt/tree/master/misc/emacs

### Your association with the package

I am the author.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
