### PR TITLE
Add a recipe for elisp-def

### DIFF
--- a/recipes/elisp-def
+++ b/recipes/elisp-def
@@ -1,0 +1,1 @@
+(elisp-def :repo "Wilfred/elisp-def" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

elisp-def is a package for finding the definition of symbols. It's
similar to elisp-slime-nav or xref-find-definitions in
emacs-lisp-mode, but handles macros, namespaces and local variables
intelligently.

### Direct link to the package repository

https://github.com/Wilfred/elisp-def

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
