### PR TITLE
adding helm-lib-babel

### DIFF
--- a/recipes/helm-lib-babel
+++ b/recipes/helm-lib-babel
@@ -1,0 +1,3 @@
+(helm-lib-babel
+ :fetcher github
+ :repo "dfeich/helm-lib-babel")


### PR DESCRIPTION
### Brief summary of what the package does

Helm extension to insert a reference to an org-mode source block function based on the user's library of babel or named source blocks in the current org-mode file.

### Direct link to the package repository

https://github.com/dfeich/helm-lib-babel

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
