### PR TITLE
Add nofrils-acme-theme

### DIFF
--- a/recipes/nofrils-acme-theme
+++ b/recipes/nofrils-acme-theme
@@ -1,0 +1,1 @@
+(nofrils-acme-theme :fetcher gitlab :repo "esessoms/nofrils-theme")


### PR DESCRIPTION
### Brief summary of what the package does

A color theme with minimal syntax highlighting, inspired by Plan 9's Acme.  Ported from the Vim theme https://github.com/robertmeta/nofrils

### Direct link to the package repository

https://gitlab.com/esessoms/nofrils-theme

### Your association with the package

I authored the Emacs port of this theme.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
