### PR TITLE
Update treemacs file structure.

### DIFF
--- a/recipes/treemacs
+++ b/recipes/treemacs
@@ -3,10 +3,7 @@
  :repo "Alexander-Miller/treemacs"
  :files (:defaults
          "icons"
-         "treemacs-dirs-to-collapse.py"
          "src/elisp/treemacs*.el"
          "src/scripts/treemacs*.py"
          (:exclude "src/elisp/treemacs-evil.el"
-                   "src/elisp/treemacs-projectile.el"
-                   "treemacs-evil.el"
-                   "treemacs-projectile.el")))
+                   "src/elisp/treemacs-projectile.el")))

--- a/recipes/treemacs-evil
+++ b/recipes/treemacs-evil
@@ -1,5 +1,4 @@
 (treemacs-evil
  :fetcher github
  :repo "Alexander-Miller/treemacs"
- :files ("treemacs-evil.el"
-         "src/elisp/treemacs-evil.el"))
+ :files ("src/elisp/treemacs-evil.el"))

--- a/recipes/treemacs-projectile
+++ b/recipes/treemacs-projectile
@@ -1,5 +1,4 @@
 (treemacs-projectile
  :fetcher github
  :repo "Alexander-Miller/treemacs"
- :files ("treemacs-projectile.el"
-         "src/elisp/treemacs-projectile.el"))
+ :files ("src/elisp/treemacs-projectile.el"))


### PR DESCRIPTION
### Brief summary of what the package does

You may remember my previous PR about putting all my source files into /src/elisp and /src/scripts instead of having them all at the package root. This PR completes that refactoring, removing the now unneeded file definitions and exclusions.

### Direct link to the package repository

https://github.com/Alexander-Miller/treemacs

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
