### PR TITLE
Add recipe for ‘gitlab-ci-mode’

### DIFF
--- a/recipes/gitlab-ci-mode
+++ b/recipes/gitlab-ci-mode
@@ -1,0 +1,3 @@
+(gitlab-ci-mode
+ :fetcher git
+ :url "https://gitlab.com/joewreschnig/gitlab-ci-mode.git")


### PR DESCRIPTION
### Brief summary of what the package does

gitlab-ci-mode is an Emacs major mode for editing GitLab CI files.
It provides syntax highlighting and completion for keywords and special
variables.

### Direct link to the package repository

https://gitlab.com/joewreschnig/gitlab-ci-mode.git

### Your association with the package

Author

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and *mostly* addressed its feedback (see below)
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

It's a multi-file package which I'm not 100% sure how to check with `package-lint` since it errors on files without version, etc. headers, and only the main file in the package has those. However, the lack of those is its only complaint.