### PR TITLE
Add hide-mode-line recipe

### DIFF
--- a/recipes/hide-mode-line
+++ b/recipes/hide-mode-line
@@ -1,0 +1,1 @@
+(hide-mode-line :repo "hlissner/emacs-hide-mode-line" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides `hide-mode-line-mode`. A simple, convenience minor mode that hides (or masks) the mode-line in your current buffer.

### Direct link to the package repository

https://github.com/hlissner/emacs-hide-mode-line

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)