### PR TITLE
Add mpmc-queue

### DIFF
--- a/recipes/mpmc-queue
+++ b/recipes/mpmc-queue
@@ -1,0 +1,3 @@
+(mpmc-queue
+ :repo "smizoe/mpmc-queue"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

mpmc-queue is an implementation of multiple-producer-multiple-fconsumer queue for emacs >= 26.
This wraps queue structure provided in [queue.el](https://elpa.gnu.org/packages/queue.html) and offers operations useful in multi-threaded programming.

### Direct link to the package repository

https://github.com/smizoe/mpmc-queue

### Your association with the package

I'm the author/maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Regarding the last item, I got an error with message `package-version-join: Wrong type argument: arrayp, nil`, but it seems to be harmless according to https://github.com/melpa/melpa/pull/5205 and several others.