### PR TITLE
Remove obsolete magit-rockstar

### DIFF
--- a/recipes/magit-rockstar
+++ b/recipes/magit-rockstar
@@ -1,1 +1,0 @@
-(magit-rockstar :fetcher github :repo "tarsius/magit-rockstar")


### PR DESCRIPTION
Hopefully some users of `magit-rockstar` will find this.

* I have added `magit-commit-reshelve` and `magit-reselve-since` to `magit` itself. These are improved replacements for `magit-reshelve` and `magit-rockstar`.

* `magit-debug-sections` was only intended for my own use and I never use it.

* If you want to use `magit-uncommit-extend`, then add the definition to your init file.

   ```lisp
   (defun magit-uncommit-extend (&rest args)
     "Reverse the change at point in `HEAD'."
     (interactive)
     (let ((inhibit-magit-refresh t))
       (magit-reverse-in-index args))
     (magit-commit-extend))
   ```

  But note that the doc-string should actually end with "... and also commit everything that happens to be already staged when this command is invoked".