### PR TITLE
Add recipe for ‘gitlab-ci-mode-flycheck’

### DIFF
--- a/recipes/gitlab-ci-mode-flycheck
+++ b/recipes/gitlab-ci-mode-flycheck
@@ -1,0 +1,3 @@
+(gitlab-ci-mode-flycheck
+ :fetcher git
+ :url "https://gitlab.com/joewreschnig/gitlab-ci-mode-flycheck.git")


### PR DESCRIPTION
### Brief summary of what the package does

Flycheck integration for `gitlab-ci-mode`.

### Direct link to the package repository

https://gitlab.com/joewreschnig/gitlab-ci-mode-flycheck.git

### Your association with the package

Author

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
