### PR TITLE
Add magit-org-todos

### DIFF
--- a/recipes/magit-org-todos
+++ b/recipes/magit-org-todos
@@ -1,0 +1,1 @@
+(magit-org-todos :repo "danielma/magit-org-todos.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Adds all TODO items from a todo.org file in the magit project's root to the magit status buffer

### Direct link to the package repository

https://github.com/danielma/magit-org-todos.el

### Your association with the package

I'm the creator

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
