### PR TITLE
Add duplicate-region

### DIFF
--- a/recipes/duplicate-region
+++ b/recipes/duplicate-region
@@ -1,0 +1,1 @@
+(duplicate-region :repo "craiglyons/duplicate-region" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Duplicate an active region or the current line, above or below the current location, and activate it as a region.

### Direct link to the package repository

[craiglyons/duplicate-region](https://github.com/craiglyons/duplicate-region)

### Your association with the package

Author/maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
