### PR TITLE
Change maintainer of bbcode-mode

### DIFF
--- a/recipes/bbcode-mode
+++ b/recipes/bbcode-mode
@@ -1,1 +1,1 @@
-(bbcode-mode :fetcher github :repo "ejmr/bbcode-mode")
+(bbcode-mode :fetcher github :repo "lassik/bbcode-mode")


### PR DESCRIPTION
Due to circumstances explained at length at <https://github.com/ejmr/bbcode-mode/pull/10> the current maintainer @ejmr suggested that I (@lassik) take over maintainership of the `bbcode-mode` package.

`bbcode-mode` was originally added to MELPA by @ejmr in PR #463.

My fork is at <https://github.com/lassik/bbcode-mode>. It is ready for release but I would appreciate if an experienced elisp coder could skim the code (it's only 165 lines). In particular, I'm hoping the `defmacro` and `eval` trick could be replaced with something more ordinary but I couldn't come up with anything better myself.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)