### PR TITLE
Add move-2

### DIFF
--- a/recipes/move-2
+++ b/recipes/move-2
@@ -1,0 +1,1 @@
+(move-2 :fetcher github :repo "m-cat/move-2")


### PR DESCRIPTION
### Brief summary of what the package does

`move-2` provides more efficient movement commands like `move-2-move-left-twice`.

### Direct link to the package repository

https://github.com/m-cat/move-2

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)