### PR TITLE
Add poet-theme to Melpa

### DIFF
--- a/recipes/poet-theme
+++ b/recipes/poet-theme
@@ -1,0 +1,1 @@
+(poet-theme :fetcher github :repo "kunalb/poet")


### PR DESCRIPTION
Adds a new theme that tries to make writing prose more elegant: https://github.com/kunalb/poet

Tested by running a sandbox and installing the theme locally based on the documentation.

### Brief summary of what the package does

It's a new theme that styles variable-pitch mode carefully; eg. normal text is in georgia while code will still be shown in a monospace font.

### Direct link to the package repository

https://github.com/kunalb/poet

### Your association with the package

I'm the creator/maintainer.

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).  (X11/MIT)
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
