### PR TITLE
Add speeddating recipe

### DIFF
--- a/recipes/speeddating
+++ b/recipes/speeddating
@@ -1,0 +1,1 @@
+(speeddating :fetcher github :repo "xuchunyang/emacs-speeddating")


### PR DESCRIPTION
### Brief summary of what the package does

Increase date and time at point. For example, there is a date `1999-12-31` and the point is on `31`, Increase it by one will change it into `2000-01-01`.

### Direct link to the package repository

https://github.com/xuchunyang/emacs-speeddating

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
