### PR TITLE
Add recipe for webkit-color-picker

### DIFF
--- a/recipes/webkit-color-picker
+++ b/recipes/webkit-color-picker
@@ -1,0 +1,4 @@
+(webkit-color-picker
+ :fetcher github
+ :repo "osener/emacs-webkit-color-picker"
+ :files (:defaults "color-picker.html"))


### PR DESCRIPTION
### Brief summary of what the package does

Displays a Webkit color picker embedded in a child-frame (Emacs 26 only)

### Direct link to the package repository

https://github.com/osener/emacs-webkit-color-picker

### Your association with the package

Maintainer
### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
