### PR TITLE
Add banner-comment

### DIFF
--- a/recipes/banner-comment
+++ b/recipes/banner-comment
@@ -1,0 +1,1 @@
+(banner-comment :repo "WJCFerguson/banner-comment" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Trivial Emacs package to format a comment as a banner.  Will reformat an existing banner.

### Direct link to the package repository

https://github.com/WJCFerguson/banner-comment

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
