### PR TITLE
Rename auth-password-store to auth-source-pass

### DIFF
--- a/recipes/auth-password-store
+++ b/recipes/auth-password-store
@@ -1,1 +1,0 @@
-(auth-password-store :fetcher github :repo "DamienCassou/auth-password-store")

--- a/recipes/auth-source-pass
+++ b/recipes/auth-source-pass
@@ -1,0 +1,4 @@
+(auth-source-pass
+ :fetcher github
+ :repo "DamienCassou/auth-password-store"
+ :old-names (auth-password-store))


### PR DESCRIPTION
I'm the maintainer. The new name is the same as the name used in Emacs
26 where the code has been introduced.