### PR TITLE
Add fill-function-arguments

### DIFF
--- a/recipes/fill-function-arguments
+++ b/recipes/fill-function-arguments
@@ -1,0 +1,1 @@
+(fill-function-arguments :repo "davidshepherd7/fill-function-arguments" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
 Add/remove line breaks between function arguments and similar constructs 

### Direct link to the package repository

https://github.com/davidshepherd7/fill-function-arguments

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
