### PR TITLE
Remove anything and all packages that depend on it (#3004)

### DIFF
--- a/recipes/ac-cake
+++ b/recipes/ac-cake
@@ -1,1 +1,0 @@
-(ac-cake :repo "k1LoW/emacs-ac-cake" :fetcher github)

--- a/recipes/ac-cake2
+++ b/recipes/ac-cake2
@@ -1,1 +1,0 @@
-(ac-cake2 :repo "k1LoW/emacs-ac-cake2" :fetcher github)

--- a/recipes/anything
+++ b/recipes/anything
@@ -1,4 +1,0 @@
-(anything
- :fetcher git
- :url "http://repo.or.cz/r/anything-config.git"
- :files ("*.el" "contrib/*" "extensions/*.el"))

--- a/recipes/anything-exuberant-ctags
+++ b/recipes/anything-exuberant-ctags
@@ -1,1 +1,0 @@
-(anything-exuberant-ctags :repo "k1LoW/anything-exuberant-ctags" :fetcher github)

--- a/recipes/anything-git-files
+++ b/recipes/anything-git-files
@@ -1,1 +1,0 @@
-(anything-git-files :fetcher github :repo "tarao/anything-git-files-el")

--- a/recipes/anything-git-grep
+++ b/recipes/anything-git-grep
@@ -1,1 +1,0 @@
-(anything-git-grep :fetcher github :repo "mechairoi/anything-git-grep")

--- a/recipes/anything-milkode
+++ b/recipes/anything-milkode
@@ -1,1 +1,0 @@
-(anything-milkode :fetcher github :repo "ongaeshi/anything-milkode")

--- a/recipes/anything-prosjekt
+++ b/recipes/anything-prosjekt
@@ -1,2 +1,0 @@
-(anything-prosjekt :fetcher github :repo "abingham/prosjekt"
-                   :files ("prosjekt/ext/anything/anything-prosjekt.el"))

--- a/recipes/anything-replace-string
+++ b/recipes/anything-replace-string
@@ -1,1 +1,0 @@
-(anything-replace-string :repo "k1LoW/anything-replace-string" :fetcher github)

--- a/recipes/anything-sage
+++ b/recipes/anything-sage
@@ -1,1 +1,0 @@
-(anything-sage :fetcher github :repo "stakemori/anything-sage")

--- a/recipes/anything-tramp
+++ b/recipes/anything-tramp
@@ -1,3 +1,0 @@
-(anything-tramp
- :repo "masasam/emacs-anything-tramp"
- :fetcher github)

--- a/recipes/cake
+++ b/recipes/cake
@@ -1,1 +1,0 @@
-(cake :fetcher github :repo "k1LoW/emacs-cake" :files ("*.el" "snippets"))

--- a/recipes/cake2
+++ b/recipes/cake2
@@ -1,1 +1,0 @@
-(cake2 :fetcher github :repo "k1LoW/emacs-cake2" :files ("*.el" "snippets"))

--- a/recipes/helm-anything
+++ b/recipes/helm-anything
@@ -1,1 +1,0 @@
-(helm-anything :repo "rubikitch/helm-anything" :fetcher github)

--- a/recipes/imgur
+++ b/recipes/imgur
@@ -1,1 +1,0 @@
-(imgur :fetcher github :repo "myuhe/imgur.el")


### PR DESCRIPTION
Follow up to https://github.com/melpa/melpa/issues/3004#issuecomment-375912059, https://github.com/melpa/melpa/issues/3004#issuecomment-375915794 (giving Steve a change to intervene).

Anything was long ago superseded by Helm, one of the most popular
packages of all time.  Remaining users of Anything should probably
move to Helm.

Anything is one of only two packages that Melpa still fetches over
an insecure connection.  And that, combined with a maintainer who
is hard to contact, is the reason why we finally pull the plug.