### PR TITLE
Add blacken recipe.

### DIFF
--- a/recipes/blacken
+++ b/recipes/blacken
@@ -1,0 +1,1 @@
+(blacken :fetcher github :repo "proofit404/blacken")


### PR DESCRIPTION
### Brief summary of what the package does

Integration with python black tool

### Direct link to the package repository

https://github.com/proofit404/blackify

### Your association with the package

author

### Relevant communications with the upstream package maintainer

back-mode does not start with the package prefix. The same way as yapfify and isortify packages do.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
