### PR TITLE
Add format-all recipe

### DIFF
--- a/recipes/format-all
+++ b/recipes/format-all
@@ -1,0 +1,1 @@
+(format-all :fetcher github :repo "lassik/emacs-format-all-the-code")


### PR DESCRIPTION
### Brief summary of what the package does

Lets you auto-format source code in any one of several languages using the same command for all languages, instead of learning a different elisp package and formatting command for each language.

Currently supported:

* C/C++ (clang-format)
* D (dfmt)
* Elm (elm-format)
* Emacs Lisp (native)
* Go (gofmt)
* Haskell (hindent)
* JavaScript (standard)
* OCaml (ocp-indent)
* Perl (perltidy)
* Python (autopep8)
* Ruby (rufo)
* Rust (rustfmt)
* Shell script (shfmt)
* Swift (swiftformat)

New formatters can be added fairly easily if they are external programs that can read code from stdin and format it to stdout.

### Direct link to the package repository

https://github.com/lassik/emacs-format-all-the-code

### Your association with the package

Just wrote it :p

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)