### PR TITLE
Add flycheck-tcl recipe

### DIFF
--- a/recipes/flycheck-tcl
+++ b/recipes/flycheck-tcl
@@ -1,0 +1,1 @@
+(flycheck-tcl :fetcher github :repo "nwidger/flycheck-tcl")


### PR DESCRIPTION
### Brief summary of what the package does

Adds a recipe for the flycheck-tcl package which adds a Tcl syntax checker to flycheck using ActiveState's tclchecker.

### Direct link to the package repository

https://github.com/nwidger/flycheck-tcl

### Your association with the package

I am the maintainer of flycheck-tcl.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
