### PR TITLE
Add recipe for other-emacs-eval

### DIFF
--- a/recipes/other-emacs-eval
+++ b/recipes/other-emacs-eval
@@ -1,0 +1,1 @@
+(other-emacs-eval :fetcher github :repo "xuchunyang/other-emacs-eval")


### PR DESCRIPTION
### Brief summary of what the package does

Evaluate the Emacs Lisp expression in other Emacs.

```emacs-lisp
emacs-version
;; => "27.0.50"

(other-emacs-eval 'emacs-version "emacs-25.3.1")
;; => "25.3.1"
```

### Direct link to the package repository

https://github.com/xuchunyang/other-emacs-eval

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
