### PR TITLE
Add carbon-now-sh.el

### DIFF
--- a/recipes/carbon-now-sh
+++ b/recipes/carbon-now-sh
@@ -1,0 +1,1 @@
+(carbon-now-sh :repo "veelenga/carbon-now-sh.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs to [carbon.now.sh](https://carbon.now.sh/) integration

### Direct link to the package repository

https://github.com/veelenga/carbon-now-sh.el

### Your association with the package

I'm a maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
