### PR TITLE
Remove packages fetched over insecure connections

### DIFF
--- a/recipes/escreen
+++ b/recipes/escreen
@@ -1,1 +1,0 @@
-(escreen :repo "emacsmirror/escreen" :fetcher github)

--- a/recipes/fm
+++ b/recipes/fm
@@ -1,1 +1,0 @@
-(fm :fetcher github :repo "emacsmirror/fm")

--- a/recipes/hl-sexp
+++ b/recipes/hl-sexp
@@ -1,1 +1,0 @@
-(hl-sexp :fetcher github :repo "emacsmirror/hl-sexp")

--- a/recipes/ldap-mode
+++ b/recipes/ldap-mode
@@ -1,1 +1,0 @@
-(ldap-mode :repo "emacsmirror/ldap-mode" :fetcher github)

--- a/recipes/list-register
+++ b/recipes/list-register
@@ -1,1 +1,0 @@
-(list-register :fetcher github :repo "emacsmirror/list-register")

--- a/recipes/osx-plist
+++ b/recipes/osx-plist
@@ -1,1 +1,0 @@
-(osx-plist :fetcher github :repo "emacsmirror/osx-plist")

--- a/recipes/psvn
+++ b/recipes/psvn
@@ -1,1 +1,0 @@
-(psvn :fetcher github :repo "emacsmirror/psvn")

--- a/recipes/quack
+++ b/recipes/quack
@@ -1,1 +1,0 @@
-(quack :repo "emacsmirror/quack" :fetcher github)

--- a/recipes/vkill
+++ b/recipes/vkill
@@ -1,1 +1,0 @@
-(vkill :fetcher github :repo "emacsmirror/vkill")

--- a/recipes/x-dict
+++ b/recipes/x-dict
@@ -1,1 +1,0 @@
-(x-dict :fetcher github :repo "emacsmirror/x-dict")

--- a/recipes/xterm-frobs
+++ b/recipes/xterm-frobs
@@ -1,1 +1,0 @@
-(xterm-frobs :fetcher github :repo "emacsmirror/xterm-frobs")

--- a/recipes/xterm-title
+++ b/recipes/xterm-title
@@ -1,1 +1,0 @@
-(xterm-title :fetcher github :repo "emacsmirror/xterm-title")


### PR DESCRIPTION
Melpa used to fetch these packages from the Emacsmirror, which in turn
imported these (and many more) packages by downloading individual
libraries over insecure connections.

The Emacsmirror no longer imports any packages over insecure
connections and because various attempts to get the maintainers to use
https have failed, these packages have been move to the Emacsattic.
Once a package is in the Emacsattic, it is no longer updated.

We have decided to remove insecure packages from Melpa too (#3004).

| Package       | Downloads |
| ------------- | --------- |
| escreen       |     1,616 |
| fm            |       981 |
| hl-sexp       |    25,452 |
| ldap-mode     |       877 |
| list-register |       827 |
| osx-plist     |     1,431 |
| psvn          |     4,116 |
| quack         |    10,675 |
| vkill         |    15,077 |
| x-dict        |       870 |
| xterm-frobs   |     1,067 |
| xterm-title   |       748 |