### PR TITLE
Add nodemcu-mode recipe

### DIFF
--- a/recipes/nodemcu-mode
+++ b/recipes/nodemcu-mode
@@ -1,0 +1,2 @@
+(nodemcu-mode :repo "andrmuel/nodemcu-mode"
+              :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

nodemcu-mode is a minor mode that provides a wrapper for the popular nodemcu interaction tools nodemcu-tool and nodemcu-uploader. These are useful to upload Lua files to ESP8266 devices with NodeMCU firmware.

### Direct link to the package repository

https://github.com/andrmuel/nodemcu-mode

### Your association with the package

I am the author.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
