### PR TITLE
Add org-variable-pitch.

### DIFF
--- a/recipes/org-variable-pitch
+++ b/recipes/org-variable-pitch
@@ -1,0 +1,3 @@
+(org-variable-pitch
+ :fetcher github :repo "cadadr/elisp"
+ :files ("org-variable-pitch.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This is a package that helps facilitate using variable-pitch fonts
with Org Mode.

### Direct link to the package repository

https://github.com/cadadr/elisp

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
  - Except two negligible errors where the fix is not really useful.
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

P.S.  I have received enough criticism here on how I develop all my elisp programs in a single VCS repo, and I'm not inclined to change that.  The contribution guidelines do not forbid such use.  Still, if you do not approve such use of Melpa for publishing, I'd be fine with that and seek another way to publish my packages (probably putting up a personal ELPA repo of mine, I guess).