### PR TITLE
Add srcery-theme recipe

### DIFF
--- a/recipes/srcery-theme
+++ b/recipes/srcery-theme
@@ -1,0 +1,1 @@
+(srcery-theme :fetcher github :repo "roosta/emacs-srcery")


### PR DESCRIPTION
### Brief summary of what the package does
A dark color theme ported from [vim-srcery](https://github.com/roosta/vim-srcery)

### Direct link to the package repository
https://github.com/roosta/emacs-srcery

### Your association with the package
Maintainer

### Relevant communications with the upstream package maintainer
Not applicable

### Checklist
- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
