### PR TITLE
company-box: Add images folder

### DIFF
--- a/recipes/company-box
+++ b/recipes/company-box
@@ -1,3 +1,4 @@
 (company-box
  :fetcher github
- :repo "sebastiencs/company-box")
+ :repo "sebastiencs/company-box"
+ :files (:defaults "images"))


### PR DESCRIPTION
### Brief summary of what the package does

This add the `images` folder in the list of files to be fetch

### Direct link to the package repository

https://github.com/sebastiencs/company-box

### Your association with the package

Author

