### PR TITLE
Add phpstan recipe

### DIFF
--- a/recipes/flycheck-phpstan
+++ b/recipes/flycheck-phpstan
@@ -1,0 +1,2 @@
+(flycheck-phpstan :fetcher github :repo "emacs-php/phpstan.el"
+                  :files ("flycheck-phpstan.el"))

--- a/recipes/phpstan
+++ b/recipes/phpstan
@@ -1,0 +1,1 @@
+(phpstan :fetcher github :repo "emacs-php/phpstan.el")

--- a/recipes/phpstan
+++ b/recipes/phpstan
@@ -1,1 +1,2 @@
-(phpstan :fetcher github :repo "emacs-php/phpstan.el")
+(phpstan :fetcher github :repo "emacs-php/phpstan.el"
+         :files ("phpstan.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Emacs interface to [PHPStan](https://github.com/phpstan/phpstan), includes checker for Flycheck.

### Direct link to the package repository

https://github.com/emacs-php/phpstan.el

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
