### PR TITLE
Add recipe for svnwrapper

### DIFF
--- a/recipes/svnwrapper
+++ b/recipes/svnwrapper
@@ -1,0 +1,1 @@
+(svnwrapper :repo "Lindydancer/svnwrapper" :fetcher github :files (:defaults "bin"))


### PR DESCRIPTION
### Brief summary of what the package does

This package adds highlighting and paging to the "svn" shell command. It uses Emacs in batch mode to perform the highlighting of both administrative subcommands and source files. The Emacs package "e2ansi" is used to emit ANSI escape sequences that can be displayed in a terminal.

### Direct link to the package repository

https://github.com/Lindydancer/svnwrapper

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
