### PR TITLE
Add el-fly-indent-mode

### DIFF
--- a/recipes/el-fly-indent-mode
+++ b/recipes/el-fly-indent-mode
@@ -1,0 +1,1 @@
+(el-fly-indent-mode :repo "jiahaowork/el-fly-indent-mode.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Indent Emacs Lisp on the fly

### Direct link to the package repository

https://github.com/jiahaowork/el-fly-indent-mode.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
