### PR TITLE
Add dired rsync

### DIFF
--- a/recipes/checkpatch-mode
+++ b/recipes/checkpatch-mode
@@ -1,0 +1,1 @@
+(checkpatch-mode :fetcher github :repo "stsquad/checkpatch-mode")

--- a/recipes/dired-rsync
+++ b/recipes/dired-rsync
@@ -1,0 +1,1 @@
+(dired-rsync :repo "stsquad/dired-rsync" :fetcher github)

--- a/recipes/flycheck-checkpatch
+++ b/recipes/flycheck-checkpatch
@@ -1,0 +1,1 @@
+(flycheck-checkpatch :fetcher github :repo "zpp0/flycheck-checkpatch")


### PR DESCRIPTION
### Brief summary of what the package does

Adds the command dired-rsync for copying files within dired buffers

### Direct link to the package repository

https://github.com/stsquad/dired-rsync

### Your association with the package

Maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [- 2 nit pick warnings] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
