### PR TITLE
Add desktop-environment

### DIFF
--- a/recipes/desktop-environment
+++ b/recipes/desktop-environment
@@ -1,0 +1,1 @@
+(desktop-environment :fetcher github :repo "DamienCassou/desktop-environment")


### PR DESCRIPTION
### Brief summary of what the package does

This package helps you control your GNU/Linux desktop from Emacs.
With desktop-environment, you can control the brightness and volume
as well as take screenshots and lock your screen.  The package
depends on the availability of shell commands to do the hard work
for us.  These commands can be changed by customizing the
appropriate variables.

The global minor mode `desktop-environment-mode' binds standard
keys to provided commands: e.g., <XF86AudioRaiseVolume> to raise
the volume, <print> to take a screenshot, and <s-l> to lock the
screen.

### Direct link to the package repository

https://github.com/DamienCassou/desktop-environment

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
