### PR TITLE
Add gpastel

### DIFF
--- a/recipes/gpastel
+++ b/recipes/gpastel
@@ -1,0 +1,1 @@
+(gpastel :fetcher github :repo "DamienCassou/gpastel")


### PR DESCRIPTION
GPaste is a clipboard management system.  The Emacs package gpastel
makes sure that every copied text in GPaste is also in the Emacs
kill-ring.

Emacs has built-in support for synchronizing the system clipboard with
the kill-ring (see the variables interprogram-paste-function and
save-interprogram-paste-before-kill).  This support is not optimal
because it makes the kill-ring only contain the last text of
consecutive copied texts.  In other words, a user cannot copy multiple
pieces of text from an external application without going back to
Emacs in between.

On the contrary, gpastel supports this scenario by hooking into the
GPaste clipboard manager.  This means that the kill-ring will
always contain everything the user copies in external applications,
not just the last piece of text.

Additionally, when using EXWM (the Emacs X Window Manager), gpastel
makes it possible for the user to use the ~kill-ring~ from external
applications.

- URL: https://github.com/DamienCassou/desktop-environment

- Association: I'm the maintainer

- Communication: None needed
### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
