### PR TITLE
Add new package netease-music

### DIFF
--- a/recipes/netease-music
+++ b/recipes/netease-music
@@ -1,0 +1,1 @@
+(netease-music :repo "nicehiro/netease-music" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
You can listen to Netease Music(It's a Chinese music service provider) in Emacs.

### Direct link to the package repository
https://github.com/nicehiro/netease-music

### Your association with the package
I'm the maintainer and contributor.

### Relevant communications with the upstream package maintainer
None need.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
