### PR TITLE
add recipe proxy-mode

### DIFF
--- a/recipes/proxy-mode
+++ b/recipes/proxy-mode
@@ -1,0 +1,1 @@
+(proxy-mode :fetcher github :repo "stardiviner/proxy-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Toggle proxy (HTTP, Socks, URL.el) inside of Emacs.

### Direct link to the package repository

https://github.com/stardiviner/proxy-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
