### PR TITLE
Add new package counsel-recentp

### DIFF
--- a/recipes/counsel-recentp
+++ b/recipes/counsel-recentp
@@ -1,0 +1,5 @@
+(counsel-recentp :fetcher github
+                 :repo "pepone/counsel-recentp"
+                 :files ("counsel-recentp.el"
+                         "README.md"
+                         "LICENSE"))

--- a/recipes/counsel-recentp
+++ b/recipes/counsel-recentp
@@ -1,5 +1,2 @@
 (counsel-recentp :fetcher github
-                 :repo "pepone/counsel-recentp"
-                 :files ("counsel-recentp.el"
-                         "README.md"
-                         "LICENSE"))
+                 :repo "pepone/counsel-recentp")


### PR DESCRIPTION
### Brief summary of what the package does

The package filters the recent files list created by `recentf-mode` and display the recently used git repositories using ivy, then allow to jump to magit status buffer for the selected repository

### Direct link to the package repository

https://github.com/pepone/counsel-recentp

### Your association with the package

I'm the author

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
