### PR TITLE
Added rebinder recipe

### DIFF
--- a/recipes/rebinder
+++ b/recipes/rebinder
@@ -1,0 +1,1 @@
+(rebinder :repo "darkstego/rebinder.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The package allows rebinding of prefix keys, and allows safe overriding of the prefixes.
So for example if anyone wants to safely move C-c to another key, this package allows
them to do it.

### Direct link to the package repository

https://github.com/darkstego/rebinder.el

### Your association with the package

I am the owner and maintainer of the package

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
