### PR TITLE
add the nosearch file to yasnippet-snippets

### DIFF
--- a/recipes/yasnippet-snippets
+++ b/recipes/yasnippet-snippets
@@ -1,4 +1,4 @@
 (yasnippet-snippets
  :repo "AndreaCrotti/yasnippet-snippets"
  :fetcher github
- :files ("*.el" "snippets"))
+ :files ("*.el" "snippets" ".nosearch"))


### PR DESCRIPTION
Small change to include the `.nosearch` file, which if not included it's a bit of an issue.

I'm not 100% sure this is the right thing to do, but definitively that file is stripped out, and in this way it would not being stripped out, see this issue for reference:
https://github.com/AndreaCrotti/yasnippet-snippets/issues/273