### PR TITLE
Add emacs-google-java-format

### DIFF
--- a/recipes/emacs-google-java-format
+++ b/recipes/emacs-google-java-format
@@ -1,0 +1,3 @@
+(emacs-google-java-format
+ :fetcher github
+ :repo "sideshowcoder/emacs-google-java-format")


### PR DESCRIPTION
### Brief summary of what the package does

Use [google-java-format](https://github.com/google/google-java-format) to format java code inside emacs, and provide compatible emacs indention setting to add to `java-mode-hook`.

### Direct link to the package repository

https://github.com/sideshowcoder/emacs-google-java-format

### Your association with the package

Maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
