### PR TITLE
Add some of my small packages

### DIFF
--- a/recipes/em-dired
+++ b/recipes/em-dired
@@ -1,1 +1,1 @@
-(nix-update :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/em-dired.el"))
+(em-dired :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/em-dired.el"))

--- a/recipes/em-dired
+++ b/recipes/em-dired
@@ -1,0 +1,1 @@
+(nix-update :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/em-dired.el"))

--- a/recipes/macho-mode
+++ b/recipes/macho-mode
@@ -1,1 +1,1 @@
-(nix-update :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/macho-mode.el"))
+(macho-mode :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/macho-mode.el"))

--- a/recipes/macho-mode
+++ b/recipes/macho-mode
@@ -1,0 +1,1 @@
+(nix-update :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/macho-mode.el"))

--- a/recipes/nethack
+++ b/recipes/nethack
@@ -1,0 +1,1 @@
+(nix-update :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/nethack.el"))

--- a/recipes/nethack
+++ b/recipes/nethack
@@ -1,1 +1,1 @@
-(nix-update :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/nethack.el"))
+(nethack :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/nethack.el"))

--- a/recipes/set-defaults
+++ b/recipes/set-defaults
@@ -1,1 +1,1 @@
-(nix-update :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/set-defaults.el"))
+(set-defaults :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/set-defaults.el"))

--- a/recipes/set-defaults
+++ b/recipes/set-defaults
@@ -1,0 +1,1 @@
+(nix-update :repo "matthewbauer/bauer" :fetcher github :files ("site-lisp/set-defaults.el"))


### PR DESCRIPTION
### Brief summary of what the package does

- em-dired: treat Eshell buffers like Dired where each ```cd``` brings up a new buffer
- set-defaults: provides an alternative to ```custom-set-variables``` for Emacs distributions where ```standard-value``` is set to your new value
- nethack: provides a major mode for playing nethack in term buffers
- macho-mode: an equivalent to elf-mode for Mach-O executables (available on macOS)

### Direct link to the package repository

https://github.com/matthewbauer/bauer

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Notes

- ```set-defaults.el``` defines two functions unprefixed: ```set-envs``` and ```set-paths```. Not sure if that is a deal breaker. They are very useful in my config.
- ```set-defaults.el``` also has to add advice around ```custom-declare-variable``` so that it avoids overwriting config values when a package is loaded. I could make it run through a function but currently it's small enough to work for me.

Anyway, if ```set-defaults.el``` is a deal breaker, I can drop it for now and include it in another PR.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
