### PR TITLE
Add powerthesaurus recipe.

### DIFF
--- a/recipes/powerthesaurus
+++ b/recipes/powerthesaurus
@@ -1,0 +1,3 @@
+(powerthesaurus
+ :repo "SavchenkoValeriy/emacs-powerthesaurus"
+ :fetcher github)


### PR DESCRIPTION
This is my first Emacs package, so any comments are highly appreciated.

### Brief summary of what the package does

This package is an integration with [powerthesaurus.org](https://www.powerthesaurus.org). It helps to look up a word in powerthesaurus and either replace or insert selected option in the buffer (depending on the current selection).

### Direct link to the package repository

https://github.com/SavchenkoValeriy/emacs-powerthesaurus

### Your association with the package

I am the author and maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is mostly happy with my docstrings, it has one false positive (mixes a noun with a verb)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
