### PR TITLE
Add a recipe for dired-recent

### DIFF
--- a/recipes/dired-recent
+++ b/recipes/dired-recent
@@ -1,0 +1,3 @@
+(dired-recent
+ :fetcher github
+ :repo "vifon/dired-recent.el")


### PR DESCRIPTION
### Brief summary of what the package does

A history of paths visited with Emacs dired.

### Direct link to the package repository

https://github.com/vifon/dired-recent.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
