### PR TITLE
Add debian-control-mode recipe

### DIFF
--- a/recipes/debian-control-mode
+++ b/recipes/debian-control-mode
@@ -1,0 +1,2 @@
+(debian-control-mode :fetcher git :url "https://salsa.debian.org/debian/emacs-goodies-el.git"
+                     :files ("elisp/dpkg-dev-el/debian-control-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

major mode for Debian control files

### Direct link to the package repository

https://salsa.debian.org/debian/emacs-goodies-el/

### Your association with the package

User

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Checkdoc has lots of complaints, but I don't know how interested they are in accepting doc fixes to a 15-year-old elisp file.