### PR TITLE
Add see-mode recipe

### DIFF
--- a/recipes/see-mode
+++ b/recipes/see-mode
@@ -1,0 +1,1 @@
+(see-mode :repo "marcelino-m/see-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Edit literal string  in a separate buffer similar to org-src-mode

### Direct link to the package repository

https://github.com/marcelino-m/see-mode

### Your association with the package

Maintainer

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
