### PR TITLE
Transfer php-auto-yasnippets into emacs-php

### DIFF
--- a/recipes/php-auto-yasnippets
+++ b/recipes/php-auto-yasnippets
@@ -1,1 +1,1 @@
-(php-auto-yasnippets :fetcher github :repo "ejmr/php-auto-yasnippets" :files ("*.el" "*.php"))
+(php-auto-yasnippets :fetcher github :repo "emacs-php/php-auto-yasnippets" :files ("*.el" "*.php"))


### PR DESCRIPTION
[`php-auto-yasnippets`](https://github.com/emacs-php/php-auto-yasnippets) was transferred to [emacs-php](https://github.com/emacs-php).

refs https://github.com/emacs-php/php-suite/issues/1