### PR TITLE
Add side-notes recipe

### DIFF
--- a/recipes/side-notes
+++ b/recipes/side-notes
@@ -1,0 +1,1 @@
+(side-notes :fetcher github :repo "rnkn/side-notes")


### PR DESCRIPTION
### Brief summary of what the package does

Display a buffer in side window slot containing a notes file (e.g. `notes.txt`) for the current directory. Notes filename is a custom option and become buffer local when set.

### Direct link to the package repository

https://github.com/rnkn/side-notes

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)