### PR TITLE
Add nerdtab package

### DIFF
--- a/recipes/nerdtab
+++ b/recipes/nerdtab
@@ -1,0 +1,1 @@
+(nerdtab :repo "casouri/nerdtab" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides keyboard-oriented tabs for Emacs.

Kind of like [winum](https://github.com/deb0ch/emacs-winum), but for buffers.

### Direct link to the package repository

https://github.com/casouri/nerdtab

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)