### PR TITLE
Adds recipe for ob-erd

### DIFF
--- a/recipes/ob-erd
+++ b/recipes/ob-erd
@@ -1,0 +1,1 @@
+(ob-erd :fetcher github :repo "orimh/ob-erd")


### PR DESCRIPTION
### Brief summary of what the package does

This package integrates org-mode with [erd](https://github.com/BurntSushi/erd/), allowing to generate and inline diagrams in an org file.

### Direct link to the package repository

https://github.com/orimh/ob-erd

### Your association with the package

I made this package.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
