### PR TITLE
Remove obsolete company-solidity package

### DIFF
--- a/recipes/company-solidity
+++ b/recipes/company-solidity
@@ -1,3 +1,0 @@
-(company-solidity
- :repo "ssmolkin1/company-solidity"
- :fetcher github)


### PR DESCRIPTION
@ssmolkin1 integrated it as part of emacs-solidity:

https://github.com/ethereum/emacs-solidity/pull/26

prevents recursive load errors when users install this obsolete package:
```
Debugger entered--Lisp error: (error "Recursive load" "/home/juergen/.emacs.d/elpa/solidity-mode-20180429.1111/solidity-mode.elc" "/home/juergen/.emacs.d/elpa/company-solidity-20180407.1344/company-solidity.el" "/home/juergen/.emacs.d/elpa/solidity-mode-20180429.1111/solidity-mode.elc" "/home/juergen/.emacs.d/elpa/company-solidity-20180407.1344/company-solidity.el" "/home/juergen/.emacs.d/elpa/solidity-mode-20180429.1111/solidity-mode.elc" "/home/juergen/.emacs.d/elpa/company-solidity-20180407.1344/company-solidity.el" "/home/juergen/.emacs.d/elpa/solidity-mode-20180429.1111/solidity-mode.elc" "/home/juergen/.emacs.d/elpa/company-solidity-20180407.1344/company-solidity.el" "/home/juergen/.emacs.d/elpa/solidity-mode-20180429.1111/solidity-mode.elc")
  require(solidity-mode)
  eval-buffer(#<buffer  *load*-854752> nil "/home/juergen/.emacs.d/elpa/company-solidity-20180407.1344/company-solidity.el" nil t)  ; Reading at buffer position 1249

```