### PR TITLE
Add rubocopfmt package

### DIFF
--- a/recipes/rubocopfmt
+++ b/recipes/rubocopfmt
@@ -1,0 +1,1 @@
+(rubocopfmt :fetcher github :repo "jimeh/rubocopfmt.el")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs minor-mode to format Ruby code with RuboCop on save.

### Direct link to the package repository

https://github.com/jimeh/rubocopfmt.el

### Your association with the package

I'm am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

### Notes

I built the package with `M-x package-build-current-recipe` instead of running `make recipes/rubocopfmt`. Via `make` I kept getting an error about `cl-lib`:

```
$ make recipes/rubocopfmt
 • Building package rubocopfmt ...
Cannot open load file: cl-lib
make: [recipes/rubocopfmt] Error 255 (ignored)
```

However, I got the same error when trying to build `go-mode`:

```
$ make recipes/go-mode
 • Building package go-mode ...
Cannot open load file: cl-lib
make: [recipes/go-mode] Error 255 (ignored)
```

So I assume the issue is not related to my `rubocopfmt` package. Specially since I managed to build and install the `rubocopfmt` package successfully with `M-x package-build-current-recipe`.