### PR TITLE
Add evil-fringe-mark

### DIFF
--- a/recipes/evil-fringe-mark
+++ b/recipes/evil-fringe-mark
@@ -1,0 +1,1 @@
+(evil-fringe-mark :fetcher github :repo "Andrew-William-Smith/evil-fringe-mark")


### PR DESCRIPTION
### Brief summary of what the package does

This package displays `evil-mode` marks as bitmap overlays in the Emacs fringe.

### Direct link to the package repository

https://github.com/Andrew-William-Smith/evil-fringe-mark

### Your association with the package

I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
