### PR TITLE
Add recipe use-ttf.

### DIFF
--- a/recipes/use-ttf
+++ b/recipes/use-ttf
@@ -1,0 +1,1 @@
+(use-ttf :repo "jcs090218/use-ttf" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

use-ttf is an Emacs package for you to use your own .ttf file in Emacs.

### Direct link to the package repository

https://github.com/jcs090218/use-ttf

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
