### PR TITLE
Switched URL for jabber from git.code.sf.net to github.com

### DIFF
--- a/recipes/jabber
+++ b/recipes/jabber
@@ -1,4 +1,4 @@
 (jabber
- :url "https://git.code.sf.net/p/emacs-jabber/git"
+ :url "https://github.com/legoscia/emacs-jabber.git"
  :fetcher git
  :files ("*.el" "*.texi" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))


### PR DESCRIPTION
### Brief summary of what the package does

I've just switched URL for jabber from git.code.sf.net to github.com because
last one looks like passed away.

At github.com I used @legoscia branch that looks like as official place.

I guess Magnus confirm it ;)

P.S. Magnus, hey, how are you? :)

### Direct link to the package repository

https://github.com/legoscia/emacs-jabber

### Your association with the package

Old time ago yes, now nope, but I feel that current maintainer can confirm that it should be changed.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)