### PR TITLE
Add company-prescient recipe

### DIFF
--- a/recipes/company-prescient
+++ b/recipes/company-prescient
@@ -1,3 +1,3 @@
 (company-prescient :fetcher github
                    :repo "raxod502/prescient.el"
-                   :files ("company-prescient.el" "*.md"))
+                   :files ("company-prescient.el"))

--- a/recipes/company-prescient
+++ b/recipes/company-prescient
@@ -1,0 +1,3 @@
+(company-prescient :fetcher github
+                   :repo "raxod502/prescient.el"
+                   :files ("company-prescient.el" "*.md"))


### PR DESCRIPTION
### Brief summary of what the package does

`company-prescient.el` provides an interface for using `prescient.el` to sort Company completions. See https://github.com/melpa/melpa/pull/5504 which adds `prescient.el` to MELPA.

### Direct link to the package repository

https://github.com/raxod502/prescient.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
