### PR TITLE
Add recipe for hjertnes/mb.el to MELPA

### DIFF
--- a/recipes/mp
+++ b/recipes/mp
@@ -1,0 +1,1 @@
+(mp :repo "hjertnes/mp.el" :fetcher github :files ("mp.el"))


### PR DESCRIPTION
### Brief summary of what the package does

My package adds four methods for posting content to micropub enpoints. 

### Direct link to the package repository

https://github.com/hjertnes/mp.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

No problem

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
