### PR TITLE
Add recipe for digitalocean api

### DIFF
--- a/recipes/digitalocean
+++ b/recipes/digitalocean
@@ -1,0 +1,3 @@
+(digitalocean
+ :repo "olymk2/emacs-digitalocean"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
Commands to interact with digitalocean api v2 in particular starting stoping and creating droplets from with in emacs.

### Direct link to the package repository

https://github.com/olymk2/emacs-digitalocean

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)


The code byte compiles cleanly with one exception, an unused lexical binding this is given to me from the widgets library but I do not use is there a way to silence that ? 