### PR TITLE
Change stardiviner/flycheck-inline to flycheck/flycheck-inline

### DIFF
--- a/recipes/flycheck-inline
+++ b/recipes/flycheck-inline
@@ -1,1 +1,1 @@
-(flycheck-inline :repo "stardiviner/flycheck-inline" :fetcher github)
+(flycheck-inline :repo "flycheck/flycheck-inline" :fetcher github)


### PR DESCRIPTION
These two packages were created independently around the same time and
serve the same purpose: to display Flycheck errors in the buffer directly using overlays.

Both parties [have agreed](https://github.com/stardiviner/flycheck-inline/issues/4) to merge into a single extension hosted at https://github.com/flycheck/flycheck-inline.

This PR just updates the recipe URL.

### Brief summary of what the package does

This is a Flycheck extension which display errors directly in the buffer using overlays.

### Direct link to the package repository

https://github.com/flycheck/flycheck-inline

### Your association with the package

I am the author and maintainer.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
