### PR TITLE
Recipe: Add org-make-toc

### DIFF
--- a/recipes/org-make-toc
+++ b/recipes/org-make-toc
@@ -1,0 +1,1 @@
+(org-make-toc :fetcher github :repo "alphapapa/org-make-toc")


### PR DESCRIPTION
### Brief summary of what the package does

This package makes it easy to have a customizable table of contents in Org files that can be updated manually, or automatically when the file is saved.  Links to headings are created compatible with GitHub's Org renderer.

### Direct link to the package repository

https://github.com/alphapapa/org-make-toc

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Thanks.