### PR TITLE
adding logpad.el

### DIFF
--- a/recipes/logpad
+++ b/recipes/logpad
@@ -1,0 +1,2 @@
+(logpad :fetcher bitbucket
+        :repo "tux_/logpad.el")


### PR DESCRIPTION
### Brief summary of what the package does

This minor mode transfers the logging mechanisms of Windows Notepad to GNU Emacs.

### Direct link to the package repository

https://bitbucket.org/tux_/logpad.el

### Your association with the package

I am the maintainer of both this one and its predecessor "logpad.vim".

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
