### PR TITLE
added org-listcruncher

### DIFF
--- a/recipes/org-listcruncher
+++ b/recipes/org-listcruncher
@@ -1,0 +1,3 @@
+(org-listcruncher
+ :fetcher github
+ :repo "dfeich/org-listcruncher")


### PR DESCRIPTION
### Brief summary of what the package does
org-listcruncher is a planning tool that allows the conversion of an Org mode list to an Org table (a list of lists).  The table can be used by other Org tables or Org code blocks for further calculations

### Direct link to the package repository

https://github.com/dfeich/org-listcruncher

### Your association with the package

I am the author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
