### PR TITLE
Adds mw-thesaurus

### DIFF
--- a/recipes/mw-thesaurus
+++ b/recipes/mw-thesaurus
@@ -1,0 +1,3 @@
+(mw-thesaurus
+ :repo "agzam/mw-thesaurus.el"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Merriam-Webster Thesaurus

This package allows you to lookup a word and display its thesaurus definition in a nice Org-mode format using merriam-webster api.

### Direct link to the package repository

https://github.com/agzam/mw-thesaurus.el

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
