### PR TITLE
futhark-mode.el was moved to a subdirectory.

### DIFF
--- a/recipes/futhark-mode
+++ b/recipes/futhark-mode
@@ -1,2 +1,2 @@
-(futhark-mode :repo "HIPERFIT/futhark" :fetcher github
-              :files ("tools/futhark-mode.el"))
+(futhark-mode :repo "diku-dk/futhark-mode" :fetcher github
+              :files ("futhark-mode.el"))

--- a/recipes/futhark-mode
+++ b/recipes/futhark-mode
@@ -1,2 +1,1 @@
-(futhark-mode :repo "diku-dk/futhark-mode" :fetcher github
-              :files ("futhark-mode.el"))
+(futhark-mode :repo "diku-dk/futhark-mode" :fetcher github)


### PR DESCRIPTION
This recipe is already in MELPA, but upstream moved around.

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
