### PR TITLE
Move plain-theme to GitLab

### DIFF
--- a/recipes/plain-theme
+++ b/recipes/plain-theme
@@ -1,1 +1,1 @@
-(plain-theme :fetcher github :repo "yegortimoshenko/plain-theme")
+(plain-theme :fetcher gitlab :repo "yegortimoshenko/plain-theme")


### PR DESCRIPTION
This pull request changes plain-theme fetcher to point to the new origin at https://gitlab.com/yegortimoshenko/plain-theme.