### PR TITLE
add GF major mode

### DIFF
--- a/recipes/gf
+++ b/recipes/gf
@@ -1,0 +1,1 @@
+(gf :fetcher github :repo "grammaticalframework/gf-emacs-mode")


### PR DESCRIPTION
### Brief summary of what the package does

this is the major mode for the [GF](http://grammaticalframework.org) programming language and its shell.

### Direct link to the package repository

https://github.com/grammaticalframework/gf-emacs-mode

### Your association with the package

I'm the new maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - pcomplete functions can't have the package prefix
- [x] My elisp byte-compiles cleanly
  - there's this obsolete variable that I can't seem to find a replacement for
  - it gives me a wrong code suggestion
- [x] `M-x checkdoc` is happy with my docstrings
  - except the missing ones (all the interactive ones and user-facing ones are documented)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
