### PR TITLE
Recipe: Add frame-purpose

### DIFF
--- a/recipes/frame-purpose
+++ b/recipes/frame-purpose
@@ -1,0 +1,1 @@
+(frame-purpose :fetcher github :repo "alphapapa/frame-purpose.el")


### PR DESCRIPTION
### Brief summary of what the package does

frame-purpose makes it easy to open purpose-specific frames that only show certain buffers, e.g. by buffers’ major mode, their filename or directory, etc, with custom frame/X-window titles, icons, and other frame parameters.

### Direct link to the package repository

https://github.com/alphapapa/frame-purpose.el

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Thanks for your work on MELPA.