### PR TITLE
Add company-posframe recipe

### DIFF
--- a/recipes/company-posframe
+++ b/recipes/company-posframe
@@ -1,0 +1,1 @@
+(company-posframe :fetcher github :repo "tumashu/company-posframe")


### PR DESCRIPTION
This is the first step to rename company-childframe to company-posframe,

After I finish company-childframe, I think its child-frame code is useful for other package,
for example: pyim, ivy, flycheck ...

So I extract child-frame related code and create a new package: posframe

Now I think company-posframe is a better name :-) for company-childframe
