### PR TITLE
Geiser repository moved to Gitlab

### DIFF
--- a/recipes/geiser
+++ b/recipes/geiser
@@ -1,5 +1,5 @@
 (geiser
- :fetcher github
+ :fetcher gitlab
  :repo "jaor/geiser"
  :files ("elisp/*.el"
          "elisp/geiser-version.el.in"


### PR DESCRIPTION
This is an update of an existing recipe (geiser) with the only change of moving its repository fetcher from github to gitlab.  The reason is that I (geiser's maintainer) am going to discontinue Github hosting, making Gitlab the new home of the project's code.
