### PR TITLE
Update eide upstream Git URL

### DIFF
--- a/recipes/eide
+++ b/recipes/eide
@@ -1,1 +1,1 @@
-(eide :fetcher git :url "https://git.tuxfamily.org/eide/emacs-ide.git" :files ("src/*.el" "src/themes/*.el"))
+(eide :fetcher git :url "https://framagit.org/eide/eide.git" :files ("src/*.el" "src/themes/*.el"))


### PR DESCRIPTION
The project moved its Git repository from tuxfamily.org to framagit.org.
