### PR TITLE
Update mip-mode and draft-mode fetchers to gitlab

### DIFF
--- a/recipes/draft-mode
+++ b/recipes/draft-mode
@@ -1,1 +1,1 @@
-(draft-mode :fetcher github :repo "gaudecker/draft-mode")
+(draft-mode :fetcher gitlab :repo "gaudecker/draft-mode")

--- a/recipes/mip-mode
+++ b/recipes/mip-mode
@@ -1,1 +1,1 @@
-(mip-mode :fetcher github :repo "gaudecker/mip-mode")
+(mip-mode :fetcher gitlab :repo "gaudecker/mip-mode")


### PR DESCRIPTION
### Direct link to the package repositories

https://gitlab.com/gaudecker/mip-mode
https://gitlab.com/gaudecker/draft-mode

### Your association with the packages

Maintainer.

### Relevant communications with the upstream package maintainer

Repositories moved to GitLab.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [ ] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
