### PR TITLE
evil-python-movement: port Neovim's movement in Python to Emacs/Evil

### DIFF
--- a/recipes/evil-python-movement
+++ b/recipes/evil-python-movement
@@ -1,0 +1,1 @@
+(evil-python-movement :url "https://bitbucket.org/FelipeLema/evil-python-movement.el" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

Port of Python movement in Neovim to Evil+Emacs.

Inspired by https://stackoverflow.com/a/28284564

### Direct link to the package repository

https://bitbucket.org/FelipeLema/evil-python-movement.el/src/master/

### Your association with the package

Creator and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
