### PR TITLE
Recipe: Add magit-todos

### DIFF
--- a/recipes/magit-todos
+++ b/recipes/magit-todos
@@ -1,0 +1,1 @@
+(magit-todos :fetcher github :repo "alphapapa/magit-todos")


### PR DESCRIPTION
### Brief summary of what the package does

This package displays keyword entries from source code comments and Org files in the Magit status buffer. Activating an item jumps to it in its file. 

### Direct link to the package repository

https://github.com/alphapapa/magit-todos

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

Thanks.