### PR TITLE
Add org-outline-numbering

### DIFF
--- a/recipes/org-outline-numbering
+++ b/recipes/org-outline-numbering
@@ -1,0 +1,1 @@
+(org-outline-numbering :repo "andersjohansson/org-outline-numbering" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This package defines a minor mode that displays an outline numbering as overlays on Org mode headlines. The numbering matches how it would appear when exporting the org file.

### Direct link to the package repository

https://gitlab.com/andersjohansson/org-outline-numbering

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
