### PR TITLE
Add 'pinyin' recipe

### DIFF
--- a/recipes/pinyin
+++ b/recipes/pinyin
@@ -1,0 +1,3 @@
+(pinyin :fetcher github
+        :repo "xuchunyang/pinyin.el"
+        :files (:defaults ("pinyin-data" "pinyin-data/pinyin.txt")))


### PR DESCRIPTION
### Brief summary of what the package does

Convert Hanzi to Pinyin, such as `汉字` to `hàn zì`.

### Direct link to the package repository

https://github.com/xuchunyang/pinyin.el

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
