### PR TITLE
Add vyper-mode

### DIFF
--- a/recipes/vyper-mode
+++ b/recipes/vyper-mode
@@ -1,0 +1,3 @@
+(vyper-mode
+  :repo "ralexstokes/vyper-mode"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Adds a basic programming mode for the [Vyper language](https://github.com/ethereum/vyper). This mode currently offers support for syntax highlighting.

### Direct link to the package repository

https://github.com/ralexstokes/vyper-mode

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
