### PR TITLE
Add a recipe for deadgrep

### DIFF
--- a/recipes/deadgrep
+++ b/recipes/deadgrep
@@ -1,0 +1,1 @@
+(deadgrep :repo "Wilfred/deadgrep" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Deadgrep is an Emacs package for performing ripgrep searches. Unlike `M-x grep` and ag/rg equivalents, it does not use `compilation-mode`. Instead, it is tailor-made for displaying, navigating
and filtering ripgrep results.

![deadgrep_screenshot](https://user-images.githubusercontent.com/70800/41689857-ac210714-74ea-11e8-9b05-894dfff4e843.png)

### Direct link to the package repository

https://github.com/Wilfred/deadgrep

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
