### PR TITLE
Split lv from hydra

### DIFF
--- a/recipes/lv
+++ b/recipes/lv
@@ -1,0 +1,3 @@
+(lv :repo "abo-abo/hydra"
+    :fetcher github
+    :files ("lv.el"))


### PR DESCRIPTION
> [`lv.el`] provides `lv-message` intended to be used in place of `message` when semi-permanent hints are needed, in order to not interfere with Echo Area.

This library is a dependency of `hydra` and maintained in [the same repository](https://github.com/abo-abo/hydra), but it can also be useful for packages that do not depend on `hydra`. Such as [`transient.el`](https://github.com/magit/transient), which only relates to `hydra` in that it is (or rather will grow to be) a *competitor*, it won't ever *depend* on `hydra`.

 @abo-abo are you okay with `lv` being defined as a package in its own right?

You'll also have to add `lv` to `hydra`'s Package-Requires.