### PR TITLE
Move wavexx's repositories to GitLab

### DIFF
--- a/recipes/gnus-desktop-notify
+++ b/recipes/gnus-desktop-notify
@@ -1,2 +1,2 @@
 (gnus-desktop-notify :repo "wavexx/gnus-desktop-notify.el"
-                     :fetcher github)
+                     :fetcher gitlab)

--- a/recipes/mu4e-jump-to-list
+++ b/recipes/mu4e-jump-to-list
@@ -1,2 +1,2 @@
 (mu4e-jump-to-list :repo "wavexx/mu4e-jump-to-list.el"
-                   :fetcher github)
+                   :fetcher gitlab)

--- a/recipes/mu4e-query-fragments
+++ b/recipes/mu4e-query-fragments
@@ -1,2 +1,2 @@
 (mu4e-query-fragments :repo "wavexx/mu4e-query-fragments.el"
-                      :fetcher github)
+                      :fetcher gitlab)

--- a/recipes/python-x
+++ b/recipes/python-x
@@ -1,2 +1,2 @@
 (python-x :repo "wavexx/python-x.el"
-          :fetcher github)
+          :fetcher gitlab)

--- a/recipes/rigid-tabs
+++ b/recipes/rigid-tabs
@@ -1,2 +1,2 @@
 (rigid-tabs :repo "wavexx/rigid-tabs.el"
-            :fetcher github)
+            :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This commit moves my own repositories from github to gitlab.
The package contents were mirrored, so they are effectively the same.
