### PR TITLE
Add counsel-org-capture-string

### DIFF
--- a/recipes/counsel-org-capture-string
+++ b/recipes/counsel-org-capture-string
@@ -1,0 +1,1 @@
+(counsel-org-capture-string :fetcher github :repo "akirak/counsel-org-capture-string")


### PR DESCRIPTION
### Brief summary of what the package does

Quickly capture a line of text using counsel and org-capture-string

### Direct link to the package repository

https://github.com/akirak/counsel-org-capture-string

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
