### PR TITLE
Add libgit

### DIFF
--- a/recipes/libgit
+++ b/recipes/libgit
@@ -1,0 +1,17 @@
+(libgit :fetcher github
+	:repo "magit/libegit2"
+	:files ("CMakeLists.txt"
+		("libgit2" "libgit2/cmake")
+		("libgit2" "libgit2/CMakeLists.txt")
+		("libgit2" "libgit2/COPYING")
+		("libgit2" "libgit2/deps")
+		("libgit2" "libgit2/.HEADER")
+		("libgit2" "libgit2/include")
+		("libgit2" "libgit2/libgit2_clar.supp")
+		("libgit2" "libgit2/libgit2.pc.in")
+		("libgit2" "libgit2/script")
+		("libgit2" "libgit2/src")
+		"libgit.el"
+		"Makefile"
+		"src"
+		"uthash"))


### PR DESCRIPTION
### Brief summary of what the package does

This is an experimental module for libgit2 bindings to Emacs, intended to boost the performance of magit.

### Direct link to the package repository

https://github.com/magit/libegit2

### Your association with the package

@TheBB is the author and the repository is part of the `magit` "organisation", whose maintainer I am.

### Relevant communications with the upstream package maintainer

https://github.com/magit/magit/issues/2959 covers most of the past discussions.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - I'll submit a pull-request.
- [ ] My elisp byte-compiles cleanly
  - I'll submit a pull-request.
- [ ] `M-x checkdoc` is **mostly** happy with my docstrings
  - I'll submit a pull-request
  - I think messages such as `"libgit: building failed with exit code %d"` are okay, or do we have to say `"Libgit: ..."`?
  - `libgit-load` needs a doc-string.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've loaded `libgit`, which triggers the module to be build, and that succeeded.
* [x] I fixed a bug in `package-build.el` in the process :wink: 

### Going forward

Lets use this pull-request to discuss what still needs to be done (packaging-wise) before we can start distributing this as a (M)ELPA package.

Installing this package using `package.el` does not complete the installation, the C module also has to be build. If the module isn't available yet, then loading `libgit` triggers the build.

I would like to add this package soon, as long as possible before Magit actually starts depending on it. Provided some users volunteer to try installing it, this should give us some time to iron out as many build issues as possible before many users are affected.

We should probably create a wiki page, which lists the libraries and tools necessary to build the modules and how to install them on various platforms. And encourage testers to help with that.

Some other notes/questions:

* I tried to remove unneeded files but we might be able to remove some more. The tarball is still 5M, down from 20M.
* I kept `gitlib2/{COPYING,.HEADER}` for legal reasons. 
* Why do we bundle `uthash`?

