### PR TITLE
Add lsp-html

### DIFF
--- a/recipes/lsp-html
+++ b/recipes/lsp-html
@@ -1,4 +1,3 @@
 (lsp-html
  :fetcher github
- :repo "emacs-lsp/lsp-html"
- :files ("lsp-html.el"))
+ :repo "emacs-lsp/lsp-html")

--- a/recipes/lsp-html
+++ b/recipes/lsp-html
@@ -1,0 +1,4 @@
+(lsp-html
+ :fetcher github
+ :repo "emacs-lsp/lsp-html"
+ :files ("lsp-html.el"))


### PR DESCRIPTION
### Brief summary of what the package does

HTML support for lsp-mode using [vscode-html-languageserver-bin](https://github.com/vscode-langservers/vscode-html-languageserver-bin)

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-html

### Your association with the package

Maintainer

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
