### PR TITLE
Add word-count

### DIFF
--- a/recipes/word-count
+++ b/recipes/word-count
@@ -1,0 +1,1 @@
+(word-count :repo "mhatta/word-count-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A minor mode which shows the number of characters/words/lines of the current buffer in the modeline.

### Direct link to the package repository

https://github.com/mhatta/word-count-mode

### Your association with the package

I assume I'm the current maintainer.

### Relevant communications with the upstream package maintainer

This elisp was originally written by Hiroyuki Komatsu years ago.  After a  long period of inactivity (and the upstream website has long gone), Tomasz Skutnik salvaged it from Wayback Machine and made it work with Emacs 24.  I made it work with Emacs 26.

I contacted with Tomasz via  e-mail, and with his blessing, I prepared for MELPA.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
