### PR TITLE
Update source of fold-dwim (moved from emacsmirror to emacsattic)

### DIFF
--- a/recipes/fold-dwim
+++ b/recipes/fold-dwim
@@ -1,1 +1,1 @@
-(fold-dwim :fetcher github :repo "emacsmirror/fold-dwim")
+(fold-dwim :fetcher github :repo "emacsattic/fold-dwim")


### PR DESCRIPTION
### Direct link to the package repository

https://github.com/emacsattic/fold-dwim/

old, no longer existent:

https://github.com/emacsmirror/fold-dwim

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)


The fact that `fold-dwim` has been moved to the emacsattic could also be an argument in favour of its complete removal. Unfortunately, `fold-dwim-org` depends on it. (See: https://stable.melpa.org/#/fold-dwim ).


Edit: also note that there are `package-lint` issues (there are no explicitly labelled `Commentary:` or `Code:` sections).