### PR TITLE
Update source of nv-delete-back (GitHub -> GitLab)

### DIFF
--- a/recipes/nv-delete-back
+++ b/recipes/nv-delete-back
@@ -1,1 +1,1 @@
-(nv-delete-back :fetcher github :repo "nivaca/nv-delete-back")
+(nv-delete-back :fetcher gitlab :repo "nivaca/nv-delete-back")


### PR DESCRIPTION
### Direct link to the package repository

https://gitlab.com/nivaca/nv-delete-back/

(old, non-existent: 

https://github.com/nivaca/nv-delete-back/ )

### Relevant communications with the upstream package maintainer

@nivaca 's [user page](https://github.com/nivaca/) now points towards their [user page on GitLab](https://gitlab.com/nivaca), so it seems that they have moved (almost) all their repositories to GitLab.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)


(Package-lint reports only a lack of a `URL:` header.) 