### PR TITLE
Update srcery-theme repo location

### DIFF
--- a/recipes/srcery-theme
+++ b/recipes/srcery-theme
@@ -1,1 +1,1 @@
-(srcery-theme :fetcher github :repo "roosta/emacs-srcery")
+(srcery-theme :fetcher github :repo "srcery-colors/srcery-emacs")


### PR DESCRIPTION
Moved the theme to an organization, so updating repository location to match.

https://github.com/srcery-colors/srcery-emacs

the package content is unchanged