### PR TITLE
Add :version-regexp for several packages

### DIFF
--- a/recipes/chee
+++ b/recipes/chee
@@ -1,1 +1,4 @@
-(chee :repo "eikek/chee" :fetcher github :files ("emacs/*.el"))
+(chee :repo "eikek/chee"
+      :fetcher github
+      :files ("emacs/*.el")
+      :version-regexp "release/\\(.*\\)")

--- a/recipes/tdd-status-mode-line
+++ b/recipes/tdd-status-mode-line
@@ -1,1 +1,3 @@
-(tdd-status-mode-line :fetcher github :repo "algernon/tdd-status-mode-line")
+(tdd-status-mode-line :fetcher github
+		      :repo "algernon/tdd-status-mode-line"
+		      :version-regexp "tdd-status-mode-line-\\(.*\\)")

--- a/recipes/zel
+++ b/recipes/zel
@@ -1,1 +1,3 @@
-(zel :repo "rudolfochrist/zel" :fetcher github)
+(zel :repo "rudolfochrist/zel"
+     :fetcher github
+     :version-regexp "zel-\\(.*\\)")


### PR DESCRIPTION
Format of the tags for:

zel:
https://github.com/rudolfochrist/zel/tags

tdd-status-line:
https://github.com/algernon/tdd-status-mode-line/tags

chee:
https://github.com/eikek/chee/tags

### Direct link to the package repository

https://github.com/rudolfochrist/zel/
https://github.com/algernon/tdd-status-mode-line/
https://github.com/eikek/chee/

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

(Building and installing the packages with `STABLE=t make [...]` now also works.)

Minor issues:

### Chee

`chee-helm.el` depends on `helm-mode.el` but the dependency on `helm` is not declared in `chee.el` (issue both with stable and unstable package).