### PR TITLE
Add emacs-lsp/lsp-clangd.

### DIFF
--- a/recipes/lsp-clangd
+++ b/recipes/lsp-clangd
@@ -1,0 +1,3 @@
+(lsp-clangd
+ :fetcher github
+ :repo "emacs-lsp/lsp-clangd")


### PR DESCRIPTION
### Brief summary of what the package does

Support for the clangd language server for lsp-mode.

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-clangd

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)