### PR TITLE
Add ivy-filthy-rich

### DIFF
--- a/recipes/ivy-filthy-rich
+++ b/recipes/ivy-filthy-rich
@@ -1,0 +1,1 @@
+(ivy-filthy-rich :repo "casouri/ivy-filthy-rich" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Similar to ivy-rich, this package adds more information to ivy. 
However, ivy-filthy-rich can be customized.

### Direct link to the package repository

https://github.com/casouri/ivy-filthy-rich

### Your association with the package

Maintainer & author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)

### Note

- ~~package-lint complains about prefix because I use `ifrich` instead of `ivy-filthy-rich`~~ ~~I'm fixing that.~~ It's fixed.
- checkdoc complains about the "80 columns" on two or three docstrings, they are not ridiculously long.