### PR TITLE
Add recipe for org-emms

### DIFF
--- a/recipes/org-emms
+++ b/recipes/org-emms
@@ -1,0 +1,1 @@
+(org-emms :repo "jagrg/org-emms" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Adds `emms` links for org-mode

### Direct link to the package repository

https://github.com/jagrg/org-emms

### Your association with the package

I am a contributor

### Relevant communications with the upstream package maintainer

The author agrees to add this package to MELPA: https://github.com/jagrg/org-emms/pull/1#issuecomment-402544147

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback: https://github.com/jagrg/org-emms/pull/3
- [x] `M-x checkdoc` is addressed in the same PR
- [x] My elisp byte-compiles cleanly
  not yet, but will be soon: https://github.com/jagrg/org-emms/pull/1#issuecomment-402544147
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
