### PR TITLE
add recipe for nopaste

### DIFF
--- a/recipes/nopaste
+++ b/recipes/nopaste
@@ -1,0 +1,1 @@
+(nopaste :fetcher github :repo "anarcat/nopaste")


### PR DESCRIPTION
### Brief summary of what the package does

nopaste is a helper to send various contents from emacs into online
"paste" services. This is useful to share long code snippets with
other users on IRC or other medium.

### Direct link to the package repository

https://github.com/anarcat/nopaste

### Your association with the package

I was briefly a contributor and an enthusiastic user but I was
delegated the maintainership of the package, see https://github.com/avar/nopaste/pull/2#issuecomment-401323781

### Relevant communications with the upstream package maintainer

**None needed**.


### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)