### PR TITLE
sqlite.el repository: fixed repository URL

### DIFF
--- a/recipes/sqlite
+++ b/recipes/sqlite
@@ -1,1 +1,1 @@
-(sqlite :fetcher github :repo "cnngimenez/sqlite.el")
+(sqlite :fetcher gitlab :repo "cnngimenez/sqlite.el")


### PR DESCRIPTION
I have fixed the sqlite.el fetcher to point to the gitlab. 

Refer to issue #5590.