### PR TITLE
add zpl-mode

### DIFF
--- a/recipes/zpl-mode
+++ b/recipes/zpl-mode
@@ -1,0 +1,1 @@
+(zpl-mode :repo "ax487/zpl-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

ZIMPL major mode for Emacs

### Direct link to the package repository

https://github.com/ax487/zpl-mode.git

### Your association with the package

Maintainer of the package

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
