### PR TITLE
req-package has moved to gitlab

### DIFF
--- a/recipes/req-package
+++ b/recipes/req-package
@@ -1,3 +1,3 @@
 (req-package
-    :fetcher github
+    :fetcher gitlab
     :repo "edvorg/req-package")


### PR DESCRIPTION
Hi. I'm the maintainer of of req-package (https://github.com/edvorg/req-package).
req-package repo has moved to gitlab and the one at github is no longer updated.
Please accept this pr to switch recipe to gitlab.