### PR TITLE
use-package-el-get has moved to gitlab

### DIFF
--- a/recipes/use-package-el-get
+++ b/recipes/use-package-el-get
@@ -1,3 +1,3 @@
 (use-package-el-get
-    :fetcher github
+    :fetcher gitlab
     :repo "edvorg/use-package-el-get")


### PR DESCRIPTION
Hi. I'm the maintainer of of use-package-el-get (https://github.com/edvorg/use-package-el-get).
use-package-el-get repo has moved to gitlab and the one at github is no longer updated.
Please accept this pr to switch recipe to gitlab.