### PR TITLE
Relocated org-gcal source repo

### DIFF
--- a/recipes/org-gcal
+++ b/recipes/org-gcal
@@ -1,1 +1,1 @@
-(org-gcal :fetcher github :repo "myuhe/org-gcal.el")
+(org-gcal :fetcher github :repo "kidd/org-gcal.el")


### PR DESCRIPTION
Org gcal has been abandoned for long time and I took care of it and merged PRs. (https://github.com/myuhe/org-gcal.el/issues/115 )

If the author comes back to activity I'm glad to give the package back to him, but for now, using our updated version makes sense

Fixes #5622 . 

### Brief summary of what the package does

The package synchronizes google calendar with an org file via google calendar api

### Direct link to the package repository
https://github.com/myuhe/org-gcal.el -> https://github.com/kidd/org-gcal.el

### Your association with the package

I'm an enthusiastic user, that after seeing there were many PRs pending to be merged and that the official version (melpa, master branch) is nearly unusable due to some bugs that are fixed in PRs, I decided to adopt the package, and take care of PR's and docs (at least). The package is not passing checkdocs or anything, so I'm also fixing that.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
