### PR TITLE
Add defkey

### DIFF
--- a/recipes/defkey
+++ b/recipes/defkey
@@ -1,0 +1,1 @@
+(defkey :repo "nickdrozd/defkey" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides a novel API for defining key bindings

### Direct link to the package repository

https://github.com/nickdrozd/defkey

### Your association with the package

Author, maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
#### `package-lint` objects to having a macro called `defkeys` in the package `defkey`.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
