### PR TITLE
new recipe for magit-rbr package

### DIFF
--- a/recipes/magit-rbr
+++ b/recipes/magit-rbr
@@ -1,0 +1,1 @@
+(magit-rbr :fetcher github :repo "fanatoly/magit-rbr" :files ("magit-rbr.el"))

--- a/recipes/magit-rbr
+++ b/recipes/magit-rbr
@@ -1,1 +1,1 @@
-(magit-rbr :fetcher github :repo "fanatoly/magit-rbr" :files ("magit-rbr.el"))
+(magit-rbr :fetcher github :repo "fanatoly/magit-rbr")


### PR DESCRIPTION
### Brief summary of what the package does

This package tweaks magit to recognize `git rbr` rebases and use corresponding commands during the magit rebase sequence. This means that when you abort a rebase during a recursive rebase, magit will abort the rbr rather than a particular phase of rbr. This also adds recursive rebase as an option to the rebase popup.

For context git-rbr lives here: https://github.com/dropbox/git-rbr

### Direct link to the package repository

https://github.com/fanatoly/magit-rbr

### Your association with the package

Maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback: `package-lint` complains about redefining functions without the `magit-rbr` prefix. This is intentional and necessary for the package to function. Please, let me know whether this is ok for inclusion in MELPA.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
