### PR TITLE
Update contextual package source

### DIFF
--- a/recipes/contextual
+++ b/recipes/contextual
@@ -1,1 +1,1 @@
-(contextual :fetcher github :repo "lshift-de/contextual")
+(contextual :fetcher github :repo "e-user/contextual")


### PR DESCRIPTION
I'm the original author of the `contextual` package. It was originally released under copyright of my previous employer - however that company doesn't exist anymore and I've added a new feature since, so I'd like to change the source of the package to my personal GitHub account where the new, active fork lives.