### PR TITLE
Add algernon/brutalist-theme

### DIFF
--- a/recipes/brutalist-theme
+++ b/recipes/brutalist-theme
@@ -1,0 +1,1 @@
+(brutalist-theme :fetcher git :url "https://git.madhouse-project.org/algernon/brutalist-theme.el.git")


### PR DESCRIPTION
### Brief summary of what the package does

The Brutalist theme (originally based on eInk) is a low-distraction theme, aimed at using other properties than color for highlighting things. It still uses a small set of (hopefully) not distracting colors, mind you, but places an emphasis on weight, slant and underline instead.

![Screenshot](https://git.madhouse-project.org/algernon/brutalist-theme.el/raw/branch/master/data/screenshot.png)

### Direct link to the package repository

https://git.madhouse-project.org/algernon/brutalist-theme.el

### Your association with the package

I am the maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
