### PR TITLE
Add Easy Frame

### DIFF
--- a/recipes/easy-frame
+++ b/recipes/easy-frame
@@ -1,0 +1,1 @@
+(easy-frame :repo "onixie/easy-fwb" :fetcher github :files ("easy-frame.el"))


### PR DESCRIPTION
Easy Frame provides key bindings to manipulate frames easily.

### Brief summary of what the package does

Easy Frame binds arrow keys [+ modifier keys] for various frame placement commands in an X window environment.

### Direct link to the package repository

https://github.com/onixie/easy-fwb

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
