### PR TITLE
Add lsp-p4

### DIFF
--- a/recipes/lsp-p4
+++ b/recipes/lsp-p4
@@ -1,0 +1,4 @@
+(lsp-p4
+ :fetcher github
+ :repo "dmakarov/p4ls"
+ :files ("clients/emacs/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package enables LSP mode for source files written in P4 programming language.

### Direct link to the package repository

https://github.com/dmakarov/p4ls

### Your association with the package

I am the creator and maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
