### PR TITLE
Ownership transfer php-mode to emacs-php

### DIFF
--- a/recipes/php-mode
+++ b/recipes/php-mode
@@ -1,2 +1,2 @@
-(php-mode :repo "ejmr/php-mode" :fetcher github
+(php-mode :repo "emacs-php/php-mode" :fetcher github
           :files (:defaults "skeleton/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does



refs https://github.com/emacs-php/php-mode/issues/387

### Direct link to the package repository

https://github.com/emacs-php/php-mode

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
