### PR TITLE
lammps-mode: Init recipe

### DIFF
--- a/recipes/lammps-mode
+++ b/recipes/lammps-mode
@@ -1,0 +1,1 @@
+(lammps-mode :fetcher github :repo "HaoZeke/lammps-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Font locking rules for [LAMMPS](https://lammps.sandia.gov/) input scripts.

### Direct link to the package repository

https://github.com/HaoZeke/lammps-mode

### Your association with the package

The package has not been updated for use in around 8 years.
The old maintainer has cordially given me the green light (reproduced below)

### Relevant communications with the upstream package maintainer
I received the following kind communique ([permissionForMELPA.pdf](https://github.com/melpa/melpa/files/2242286/aidanLammpsMELPA.pdf)) from the original maintainer (Aidan)

> to whom it concerns:
>
>
>
>I am Aidan Thompson, the original author of lammps.el distributed with LAMMPS in directory tools/emacs under the GNU GPL license.  I hereby grant permission for lammps.el to be distributed in MELPA. It is an honor.
>
>Aidan
>--
>Aidan P. Thompson
>01444 Multiscale Science
>Sandia National Laboratories
>PO Box 5800, MS 1322      Phone: 505-844-9702
>Albuquerque, NM 87185     Fax  : 505-845-7442
>E-mail:athomps@sandia.gov Cell : 505-218-1011

Also, a pull request has been reviewed favorably at https://github.com/lammps/lammps/pull/1022.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
