### PR TITLE
Add dap-mode recipe

### DIFF
--- a/recipes/dap-mode
+++ b/recipes/dap-mode
@@ -1,0 +1,1 @@
+(dap-mode :repo "yyoncho/dap-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`dap-mode` is an emacs integration for Debug Adapter Protocol which is the protocol used by VScode/Eclipse Che for integration with the debugger. Together with LSP mode the package aims to provide full IDE experince for Emacs. Currently supports Java debugger.

### Direct link to the package repository

https://github.com/yyoncho/dap-mode

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
