### PR TITLE
Add recipe flycheck-grammalecte

### DIFF
--- a/recipes/flycheck-grammalecte
+++ b/recipes/flycheck-grammalecte
@@ -1,0 +1,4 @@
+(flycheck-grammalecte
+ :fetcher git
+ :url "https://git.deparis.io/flycheck-grammalecte/"
+ :files (:defaults "flycheck-grammalecte.py"))


### PR DESCRIPTION
This is the follow-up of the #5606 PR, due to a renaming of the base branch. I've juste copied/pasted the following. Please go to the #5606 to find all the previous conversation.

### Brief summary of what the package does

This package add the support of [Grammalecte](https://www.dicollecte.org/) (a french grammar checker) to `flycheck`.

### Direct link to the package repository

https://git.deparis.io/flycheck-grammalecte

### Your association with the package

I'm the new main maintainer.

I know MELPA don't like forks, but the original package development get stalled and is broken for recent version of Grammalecte. Thus, I took over the development on my own repo and get linked by the grammalecte main author : https://www.dicollecte.org/?download_div

As you can see, I released two versions since and I think it's time to ease the install by adding this package to MELPA.

For information, the original author never publish his package on MELPA or elsewhere.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
