### PR TITLE
Added bap-mode, an Emacs major mode for working with BAP

### DIFF
--- a/recipes/bap-mode
+++ b/recipes/bap-mode
@@ -1,0 +1,1 @@
+(bap-mode :fetcher github :repo "fkie-cad/bap-mode")


### PR DESCRIPTION
### Brief summary of what the package does

bap-mode allows to interact with the Binary Analysis Platform (BAP) from within Emacs. It comes with quick navigation in BAP's IR and syntax highlighting.

### Direct link to the package repository

https://github.com/fkie-cad/bap-mode

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
