### PR TITLE
Add magik-mode recipe

### DIFF
--- a/recipes/magik-mode
+++ b/recipes/magik-mode
@@ -1,0 +1,2 @@
+(magik-mode :fetcher github
+	    :repo "roadrunner1776/magik")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a major mode for editing Smallworld (GIS) Magik files.

### Direct link to the package repository

https://github.com/roadrunner1776/magik

### Your association with the package

Revived this old Emacs 19 package since I need it.

### Relevant communications with the upstream package maintainer

**None needed**. Package repository above is mine.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)