### PR TITLE
fix ordering in builder Dockerfile

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:unstable
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get --yes install emacs25-nox git make mercurial ruby texinfo curl
+RUN DEBIAN_FRONTEND=noninteractive apt-get --yes install curl emacs25-nox git make mercurial ruby texinfo
 WORKDIR /mnt/store/melpa
 CMD docker/builder/run.sh


### PR DESCRIPTION
to satisfy the ordering we move curl to the first in the list.
