### PR TITLE
Add dist-file-mode recipe

### DIFF
--- a/recipes/dist-file-mode
+++ b/recipes/dist-file-mode
@@ -1,0 +1,1 @@
+(dist-file-mode :fetcher github :repo "emacs-php/dist-file-mode.el")


### PR DESCRIPTION
### Brief summary of what the package does

Dispatch major mode for `.dist` suffixed files.

For example: `phpunit.xml.dist` as `xml-mode`.

### Direct link to the package repository

https://github.com/emacs-php/dist-file-mode.el

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
