### PR TITLE
Add recipe for erlstack-mode

### DIFF
--- a/recipes/erlstack-mode
+++ b/recipes/erlstack-mode
@@ -1,4 +1,2 @@
 (erlstack-mode :repo "k32/erlstack-mode"
-               :fetcher github
-               :branch "stable"
-               :files ("erlstack-mode.el"))
+               :fetcher github)

--- a/recipes/erlstack-mode
+++ b/recipes/erlstack-mode
@@ -1,0 +1,4 @@
+(erlstack-mode :repo "k32/erlstack-mode"
+               :fetcher github
+               :branch "stable"
+               :files ("erlstack-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Preview source code of Erlang modules appearing in stack traces

### Direct link to the package repository

https://github.com/k32/erlstack-mode

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
