### PR TITLE
Add idle-highlight-in-visible-buffers-mode

### DIFF
--- a/recipes/idle-highlight-in-visible-buffers-mode
+++ b/recipes/idle-highlight-in-visible-buffers-mode
@@ -1,0 +1,1 @@
+(idle-highlight-in-visible-buffers-mode :repo "ignacy/idle-highlight-in-visible-buffers-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

idle-highlight-in-visible-buffers works exactly like idle-highlight but in all visible buffers.

### Direct link to the package repository

https://github.com/ignacy/idle-highlight-in-visible-buffers-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
