### PR TITLE
Add recipe for comb

### DIFF
--- a/recipes/comb
+++ b/recipes/comb
@@ -1,0 +1,1 @@
+(comb :repo "cyrus-and/comb" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Comb is a native Emacs Lisp solution to search, browse and annotate occurrences of regular expressions in files. The interactive interface allows to perform an exhaustive classification of all the results to rule out false positives and asses proper matches during manual static analysis.

### Direct link to the package repository

https://github.com/cyrus-and/comb

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

The package summary is 59 characters long instead of the 50 required by package-lint, but there are plenty of packages that exceed this limit in MELPA. Since it's already quite condensed I would like to keep it as it is, but if it's a problem I can bring it down to 50.

Also package-lint and checkdoc have been run against the main `.el` file only, I don't know what are the best practices here, e.g., the commentary and the license are not present in the other files.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (**see above**)
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
