### PR TITLE
Add vscode-icon

### DIFF
--- a/recipes/vscode-icon
+++ b/recipes/vscode-icon
@@ -1,0 +1,5 @@
+(vscode-icon
+ :fetcher github
+ :repo "jojojames/vscode-icon-emacs"
+ :files (:defaults
+         "icons"))


### PR DESCRIPTION
### Brief summary of what the package does

Utility package to return an icon that other packages can use to insert an image.

### Direct link to the package repository

https://github.com/jojojames/vscode-icon-emacs

### Your association with the package

Author, maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
