### PR TITLE
Add ox-jekyll recipe

### DIFF
--- a/recipes/ox-jekyll
+++ b/recipes/ox-jekyll
@@ -1,0 +1,3 @@
+(ox-jekyll :repo "gonsie/ox-jekyll"
+           :fetcher github
+           :files ("ox-jekyll.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Org export engine for Jekyll on Markdown

### Direct link to the package repository

https://github.com/gonsie/ox-jekyll

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

***None needed.***

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)