### PR TITLE
Add lsp-ruby

### DIFF
--- a/recipes/lsp-ruby
+++ b/recipes/lsp-ruby
@@ -1,0 +1,3 @@
+(lsp-ruby
+ :fetcher github
+ :repo "emacs-lsp/lsp-ruby")


### PR DESCRIPTION
### Brief summary of what the package does

Implements some Ruby IDE features via [lsp-mode](https://github.com/emacs-lsp/lsp-mode) and [this solargraph gem](https://github.com/castwide/solargraph)

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-ruby

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
