### PR TITLE
Update polymode recipes

### DIFF
--- a/recipes/poly-R
+++ b/recipes/poly-R
@@ -1,0 +1,3 @@
+(poly-R
+ :fetcher github
+ :repo "polymode/poly-R")

--- a/recipes/poly-erb
+++ b/recipes/poly-erb
@@ -1,0 +1,3 @@
+(poly-erb
+ :fetcher github
+ :repo "polymode/poly-erb")

--- a/recipes/poly-markdown
+++ b/recipes/poly-markdown
@@ -1,0 +1,3 @@
+(poly-markdown
+ :fetcher github
+ :repo "polymode/poly-markdown")

--- a/recipes/poly-noweb
+++ b/recipes/poly-noweb
@@ -1,0 +1,3 @@
+(poly-noweb
+ :fetcher github
+ :repo "polymode/poly-noweb")

--- a/recipes/poly-org
+++ b/recipes/poly-org
@@ -1,0 +1,3 @@
+(poly-org
+ :fetcher github
+ :repo "polymode/poly-org")

--- a/recipes/poly-slim
+++ b/recipes/poly-slim
@@ -1,0 +1,3 @@
+(poly-slim
+ :fetcher github
+ :repo "polymode/poly-slim")

--- a/recipes/polymode
+++ b/recipes/polymode
@@ -1,4 +1,3 @@
 (polymode
  :fetcher github
- :repo "vspinu/polymode"
- :files ("*.el" "modes/*.el"))
+ :repo "polymode/polymode")


### PR DESCRIPTION

I have rewritten and split polymode into multiple packages. The new version still lives on "next" branch which I will merge once the recipes are merged.

### Brief summary of what the package does

A framework for multiple major modes (MMM) inside a single Emacs buffer. 

### Direct link to the package repository

https://github.com/polymode/polymode
https://polymode.github.io/

### Your association with the package

Author and maintainer. 

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
