### PR TITLE
Add recipe for ProofGeneral

### DIFF
--- a/recipes/proof-general
+++ b/recipes/proof-general
@@ -1,0 +1,9 @@
+(proof-general
+ :fetcher github
+ :repo "ProofGeneral/PG"
+ :branch "master"
+ :files (:defaults "CHANGES" "AUTHORS" "COPYING"
+                   "generic" "images" "lib"
+                   ("coq" "coq/*.el")
+                   "easycrypt" "phox"
+                   "pghaskell" "pgocaml" "pgshell"))


### PR DESCRIPTION
### Brief summary of what the package does

Developed since 1994, ProofGeneral is a generic Emacs front-end for formal proof assistants.
This packaged version of ProofGeneral supports Coq, EasyCrypt and PhoX.

### Direct link to the package repository

https://github.com/ProofGeneral/PG

### Your association with the package

I am one of the maintainers of ProofGeneral.

### Relevant communications with the upstream package maintainer

None needed (`package.el` compatibility has already been addressed by my colleague @cpitclaudel)

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Regarding the `M-x checkdoc` requirement, I did a careful pass on the docstrings of ProofGeneral before submitting this recipe, but there are some remaining warnings (notably as there are a number of internal functions that have no docstring).