### PR TITLE
Add terminal-focus-reporting.el

### DIFF
--- a/recipes/terminal-focus-reporting
+++ b/recipes/terminal-focus-reporting
@@ -1,0 +1,1 @@
+(terminal-focus-reporting :repo "veelenga/terminal-focus-reporting.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Make Emacs play nicely with iTerm2 and tmux.

This plugin restores `focus-in-hook`, `focus-out-hook` functionality. Now Emacs can save when the terminal loses a focus, even if it's inside the tmux.

### Direct link to the package repository

https://github.com/veelenga/terminal-focus-reporting.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed** 


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
