### PR TITLE
Add highlight-doxygen

### DIFF
--- a/recipes/highlight-doxygen
+++ b/recipes/highlight-doxygen
@@ -1,0 +1,1 @@
+(highlight-doxygen :repo "Lindydancer/highlight-doxygen" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Highlight Doxygen comments.

In addition to highlighting Doxygen commands and their arguments, the entire comment is highlighted as a block. In addition, code blocks inside Doxygen comments are highlighted as code, according to the language they written in.

### Direct link to the package repository

https://github.com/Lindydancer/highlight-doxygen

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
