### PR TITLE
adding ox-jekyll-md

### DIFF
--- a/recipes/ox-jekyll-md
+++ b/recipes/ox-jekyll-md
@@ -1,0 +1,2 @@
+(ox-jekyll-md :repo "gonsie/ox-jekyll-md"
+              :fetcher github)


### PR DESCRIPTION
Fixes name conflict from melpa/melpa#5688.