### PR TITLE
Add django-commands

### DIFF
--- a/recipes/django-commands
+++ b/recipes/django-commands
@@ -1,0 +1,1 @@
+(django-commands :fetcher github :repo "muffinmad/emacs-django-commands")


### PR DESCRIPTION
### Brief summary of what the package does

This package allows to run django commands in comint-mode.

### Direct link to the package repository

https://github.com/muffinmad/emacs-django-commands

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)