### PR TITLE
Add org-msg recipe

### DIFF
--- a/recipes/org-msg
+++ b/recipes/org-msg
@@ -1,0 +1,2 @@
+(org-msg :repo "jeremy-compostella/org-msg" :fetcher github)
+


### PR DESCRIPTION
Signed-off-by: Jeremy Compostella <jeremy.compostella@intel.com>

### Brief summary of what the package does

OrgMsg is a [GNU/Emacs] module making use of [Org mode] to write and
reply to emails in a Outlook HTML friendly style.

### Direct link to the package repository

https://github.com/jeremy-compostella/org-msg

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
