### PR TITLE
Add org-msg recipe

### DIFF
--- a/recipes/org-msg
+++ b/recipes/org-msg
@@ -1,0 +1,2 @@
+(org-msg :repo "jeremy-compostella/org-msg" :fetcher github)
+


### PR DESCRIPTION
Signed-off-by: Jeremy Compostella <jeremy.compostella@gmail.com>

### Brief summary of what the package does

OrgMsg is a [GNU/Emacs] module making use of [Org mode] to write and
reply to emails in a Outlook HTML friendly style.

Not that I really like the Outlook email style but in a work
environment dominated by this software, it is good to be able to reply
with the same style.  By default, if the original message is in text
form 'org-msg' keeps it that way and does not activate itself.  It
allows to reply to developer mailing list (or any real technical
people who knows how to handle text email) seamlessly.  If the
original message is in the HTML form, it activates the 'org-msg' mode
on the reply buffer.

*org-msg* is an derivation of [org-mode] in which some functionality
of [message-mode] are imported or replicated. For instance, A
*org-msg* buffer uses the same 'font-lock-keywords' than
[message-mode] or the 'TAB' key while the cursor is in the header
calls the 'bbdb-complete-mail()' function.

For convenience, the original message is quoted below the '--citation
follows this line (read-only)--' marker.  So you can easily refer to
the original message.  However, the entire quoted text is read-only
because *org-msg* does not support modification of the original
content.

Outlook email are really poor compared to what can be achieved by
[org-mode].  I personally use the '#+{begin|end}_quote' to quote part
of the email I am replying to.  I extensively make use of
'#+{begin|end}_src mode' to provide extract of code or example of
changes, I sometimes use [org-babel] to generate an on the fly
sequence diagram (using [plantuml]) or a simple graph (using [dot]).

### Direct link to the package repository

https://github.com/jeremy-compostella/org-msg

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
