### PR TITLE
Add pdfgrep recipe

### DIFF
--- a/recipes/pdfgrep
+++ b/recipes/pdfgrep
@@ -1,0 +1,1 @@
+(pdfgrep :repo "jeremy-compostella/pdfgrep" :fetcher github)


### PR DESCRIPTION
Signed-off-by: Jeremy Compostella <jeremy.compostella@gmail.com>

### Brief summary of what the package does

*pdfgrep* is a [GNU/Emacs] module providing `grep' comparable facilities
but for PDF files.  Its usage is similar to the `grep' function: using
the `next-error' function gets you to the next matching page...

The `pdfgrep' program must be installed on your system.

If the [pdf-tools] module is installed and enabled, when a matching page
is displayed, the matching regions are highlighted.

### Direct link to the package repository

https://github.com/jeremy-compostella/pdfgrep

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
