### PR TITLE
Added recipe for lsp-fortran

### DIFF
--- a/recipes/lsp-fortran
+++ b/recipes/lsp-fortran
@@ -1,0 +1,1 @@
+(lsp-fortran :repo "MagB93/lsp-fortran" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package adds a new client to [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for
the [Fortran-Language-Server](https://github.com/hansec/fortran-language-server).

### Direct link to the package repository

https://github.com/MagB93/lsp-fortran

### Your association with the package

I'm the maintainer of this package. The server is maintained by [hansec](https://github.com/hansec).

### Relevant communications with the upstream package maintainer

 **None needed** 
`M-x checkdoc` complains only about a missing `;;;Commentary ...` block, but it's given in the header.

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
