### PR TITLE
Add org-clock-split recipe

### DIFF
--- a/recipes/org-clock-split
+++ b/recipes/org-clock-split
@@ -1,0 +1,1 @@
+(org-clock-split :repo "justintaft/org-clock-split" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Split org-mode CLOCK entry into two while preserving time.

### Direct link to the package repository

https://github.com/justintaft/org-clock-split

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [ x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [ x] `M-x checkdoc` is happy with my docstrings
- [ x ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
