### PR TITLE
Update racket-mode :files to support racket/ subdir

### DIFF
--- a/recipes/racket-mode
+++ b/recipes/racket-mode
@@ -1,2 +1,10 @@
-(racket-mode :repo "greghendershott/racket-mode" :fetcher github
-             :files ("*.el" "*.rkt"))
+(racket-mode
+ :repo    "greghendershott/racket-mode"
+ :fetcher github
+ :files   ("*.el"
+           "*.rkt"
+           (:exclude ".dir-locals.el"
+                     "racket-tests.el")
+           ("racket" "racket/*")
+           (:exclude "racket/example/*"
+                     "racket/test/*")))

--- a/recipes/racket-mode
+++ b/recipes/racket-mode
@@ -1,10 +1,8 @@
 (racket-mode
  :repo    "greghendershott/racket-mode"
  :fetcher github
- :files   ("*.el"
+ :files   (:defaults
            "*.rkt"
-           (:exclude ".dir-locals.el"
-                     "racket-tests.el")
            ("racket" "racket/*")
            (:exclude "racket/example/*"
                      "racket/test/*")))


### PR DESCRIPTION
- Handle *.rkt files in a `racket/` subdir in both source and target.

  Note: To smooth the transition, keep the top-level `"*.rkt"` for now,
        so that the recipe works for both the status quo flat file
        layout and the new nested layout.

- Exclude some test and example files.

---

### Brief summary of what the package does

Major mode for Racket lang.

### Direct link to the package repository

https://github.com/greghendershott/racket-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

n/a

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
