### PR TITLE
Add flycheck-pyre

### DIFF
--- a/recipes/flycheck-pyre
+++ b/recipes/flycheck-pyre
@@ -1,0 +1,2 @@
+(flycheck-pyre :fetcher github :repo "linnik/flycheck-pyre"
+               :files (:defaults "bin"))


### PR DESCRIPTION
### Brief summary of what the package does

Flycheck extension for [Pyre](https://github.com/facebook/pyre-check) python type checker tool.

### Direct link to the package repository

https://github.com/linnik/flycheck-pyre

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)