### PR TITLE
Update thrift-mode to use fbthrift

### DIFF
--- a/recipes/thrift
+++ b/recipes/thrift
@@ -1,1 +1,1 @@
-(thrift :fetcher github :repo "apache/thrift" :files ("contrib/thrift.el"))
+(thrift :fetcher github :repo "facebook/fbthrift" :files ("thrift/contrib/thrift.el"))


### PR DESCRIPTION
This thrift-mode has more complete and accurate syntax highlighting,
smarter indentation, and works for both Apache Thrift and fbthrift.

### Brief summary of what the package does

This package provide syntax highlighting and indentation of .thrift files, used for declaring RPC interfaces using Thrift. I've significantly expanded the highlighting and indentation ([see my commit](https://github.com/facebook/fbthrift/commit/a1960cc1a78ada27872913a145395f6bd45c8fd9)).

### Direct link to the package repository

https://github.com/facebook/fbthrift/blob/master/thrift/contrib/thrift.el

### Your association with the package

I'm a contributor.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
