### PR TITLE
Added recipe for lsp-sh

### DIFF
--- a/recipes/lsp-sh
+++ b/recipes/lsp-sh
@@ -1,0 +1,1 @@
+(lsp-sh :repo "emacs-lsp/lsp-sh" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
This package adds a new client to lsp-mode for
the Sh-Language-Server.

### Direct link to the package repository
https://github.com/emacs-lsp/lsp-sh

### Your association with the package
I am a user of lsp-sh.

### Relevant communications with the upstream package maintainer
I have talked with the package maintainer and he agreed [here](https://github.com/emacs-lsp/lsp-sh/issues/1).

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

None needed.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
