### PR TITLE
Add smart-mode-line-atom-one-dark-theme recipe

### DIFF
--- a/recipes/smart-mode-line-atom-one-dark-theme
+++ b/recipes/smart-mode-line-atom-one-dark-theme
@@ -1,0 +1,1 @@
+(smart-mode-line-atom-one-dark-theme :repo "daviderestivo/smart-mode-line-atom-one-dark-theme" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
This package adds a smart-mode-line theme that matches the
atom-one-dark one.

### Direct link to the package repository
https://github.com/daviderestivo/smart-mode-line-atom-one-dark-theme

### Your association with the package
I'm the creator and current maintainer.

### Relevant communications with the upstream package maintainer
None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)