### PR TITLE
flycheck-pact: Fix package name

### DIFF
--- a/recipes/flycheck-pact
+++ b/recipes/flycheck-pact
@@ -1,3 +1,3 @@
-(pact-mode 
+(flycheck-pact
   :fetcher github
   :repo "kadena-io/flycheck-pact")


### PR DESCRIPTION
Package name did not match recipe file name.

### Direct link to the package repository

https://github.com/kadena-io/flycheck-pact/blob/master/flycheck-pact.el

### Your association with the package

### Relevant communications with the upstream package maintainer

This is a bugfix for the Melpa recipe. I have had no communication with upstream and no association with this package.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
