### PR TITLE
constant-theme: Add recipe

### DIFF
--- a/recipes/constant-theme
+++ b/recipes/constant-theme
@@ -1,0 +1,1 @@
+(constant-theme :fetcher github :repo "jannis/emacs-constant-theme")


### PR DESCRIPTION
### Brief summary of what the package does

The package provides a new Emacs theme called (`constant-theme`) with two variants: `constant` and `constant-light`.

### Direct link to the package repository

https://github.com/jannis/emacs-constant-theme

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

--

Note: I couldn't figure out how to build the recipe on macOS. I'm fairly new to Emacs and this is my first package. Any hints would be appreciated.

I have, however, verified that both included theme variants load and work fine.