### PR TITLE
merlin: beta branch is outdated, use master

### DIFF
--- a/recipes/merlin
+++ b/recipes/merlin
@@ -1,4 +1,3 @@
 (merlin :fetcher github
         :repo "ocaml/merlin"
-        :branch "beta"
         :files ("emacs/*.el"))


### PR DESCRIPTION
`beta` branch of merlin is 105 commits behind latest release v3.1.0.
It would be better to fetch master or the latest release instead.

/cc upstream maintainers @let-def @trefis 