### PR TITLE
shrink-whitespace's home has moved to gitlab

### DIFF
--- a/recipes/shrink-whitespace
+++ b/recipes/shrink-whitespace
@@ -1,1 +1,1 @@
-(shrink-whitespace :repo "jcpetkovich/shrink-whitespace.el" :fetcher github)
+(shrink-whitespace :repo "jcpetkovich/shrink-whitespace.el" :fetcher gitlab)


### PR DESCRIPTION
I've updated the recipe to reflect the change. The package documentation now points to
gitlab as well.

### Brief summary of what the package does

`shrink-whitespace` lets you remove whitespace with a dwim keybinding.

### Direct link to the package repository

https://gitlab.com/jcpetkovich/shrink-whitespace.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
