### PR TITLE
Add recipe for q-mode

### DIFF
--- a/recipes/q-mode
+++ b/recipes/q-mode
@@ -1,0 +1,1 @@
+(q-mode :fetcher github :repo "psaris/q-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs mode for editing q scripts and communicating with inferior q/qcon buffers

### Direct link to the package repository

https://github.com/psaris/q-mode

### Your association with the package

A user.

### Relevant communications with the upstream package maintainer

I contacted @psaris and he gave me permission.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
