### PR TITLE
switch gocode from nsf/gocode to mdempsky/gocode

### DIFF
--- a/recipes/company-go
+++ b/recipes/company-go
@@ -1,3 +1,3 @@
-(company-go :repo "nsf/gocode" :fetcher github
+(company-go :repo "mdempsky/gocode" :fetcher github
             :files ("emacs-company/company-go.el")
             :version-regexp "v\\.\\(.*\\)")

--- a/recipes/go-autocomplete
+++ b/recipes/go-autocomplete
@@ -1,5 +1,5 @@
 (go-autocomplete
  :fetcher github
- :repo "nsf/gocode"
+ :repo "mdempsky/gocode"
  :files ("emacs/go-autocomplete.el")
  :version-regexp "v\\.\\(.*\\)")


### PR DESCRIPTION
### Brief summary of what the package does

gocode is provides autocompletion for Go. https://github.com/nsf/gocode is no longer maintained, so the switch is being made to https://github.com/mdempsky/gocode.

### Direct link to the package repository

https://github.com/mdempsky/gocode

### Your association with the package

I am a member of the Go team, who will be supporting https://github.com/mdempsky/gocode.

### Relevant communications with the upstream package maintainer

None.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
