### PR TITLE
Add recipe for the redtt proof assistant

### DIFF
--- a/recipes/redtt
+++ b/recipes/redtt
@@ -1,0 +1,4 @@
+(redtt
+ :fetcher github
+ :repo "RedPRL/redtt"
+ :files ("emacs/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`redtt` is a proof assistant for cartesian cubical type theory, a higher dimensional type theory with support for both univalence and higher inductive types. This package provides a rudimentary editing mode for `redtt`, with syntax highlighting and a compilation buffer.

### Direct link to the package repository

https://github.com/RedPRL/redtt

### Your association with the package

I am the maintainer of this package.


### Relevant communications with the upstream package maintainer

**None needed**


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
