### PR TITLE
Add debian-el and dpkg-dev-el

### DIFF
--- a/recipes/debian-changelog-mode
+++ b/recipes/debian-changelog-mode
@@ -1,2 +1,0 @@
-(debian-changelog-mode :fetcher git :url "https://salsa.debian.org/debian/emacs-goodies-el.git"
-                       :files ("elisp/dpkg-dev-el/debian-changelog-mode.el"))

--- a/recipes/debian-el
+++ b/recipes/debian-el
@@ -1,0 +1,2 @@
+(debian-el :fetcher git
+	   :url "https://salsa.debian.org/emacsen-team/debian-el.git")

--- a/recipes/dpkg-dev-el
+++ b/recipes/dpkg-dev-el
@@ -1,0 +1,3 @@
+(dpkg-dev-el :fetcher git
+	     :url "https://salsa.debian.org/emacsen-team/dpkg-dev-el.git"
+	     :old-names (debian-changelog-mode))


### PR DESCRIPTION
* https://github.com/melpa/melpa/issues/5449
* https://salsa.debian.org/emacsen-team/debian-el
* https://salsa.debian.org/emacsen-team/dpkg-dev-el

@purcell Is there anything you want to see improved in these packages before adding them here? Are you okay with just adding these two packages instead of adding the individual libraries as packages in their own right (and removing `debian-changelog-mode`)?