### PR TITLE
Add activity-watch-mode

### DIFF
--- a/recipes/activity-watch-mode
+++ b/recipes/activity-watch-mode
@@ -1,0 +1,1 @@
+(activity-watch-mode :fetcher github :repo "pauldub/activity-watch-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`activity-watch-mode` is an automatic time tracking extension for Emacs using [ActivityWatch](https://activitywatch.net/).

### Direct link to the package repository

https://github.com/pauldub/activity-watch-mode

### Your association with the package

I am the maintainer of the package.

### Relevant communications with the upstream package maintainer

None.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
