### PR TITLE
Added recipe for ox-mdx-deck

### DIFF
--- a/recipes/ox-mdx-deck
+++ b/recipes/ox-mdx-deck
@@ -1,0 +1,1 @@
+(ox-mdx-deck :fetcher github :repo "WolfeCub/ox-mdx-deck")


### PR DESCRIPTION
### Brief summary of what the package does

An org-mode exporter to export to [mdx-deck](https://github.com/jxnblk/mdx-deck).

### Direct link to the package repository

https://github.com/WolfeCub/ox-mdx-deck/

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
