### PR TITLE
Add recipe for wiki-drill

### DIFF
--- a/recipes/wiki-drill
+++ b/recipes/wiki-drill
@@ -1,0 +1,1 @@
+(wiki-drill :fetcher github :repo "mtekman/wiki-drill.el")


### PR DESCRIPTION
### Brief summary of what the package does

Use the Wikipedia summaries from jozefg's wiki-summary package and generates org-drill entries from them.

### Direct link to the package repository

https://github.com/mtekman/wiki-drill.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
