### PR TITLE
Add vc-hgcmd

### DIFF
--- a/recipes/vc-hgcmd
+++ b/recipes/vc-hgcmd
@@ -1,0 +1,1 @@
+(vc-hgcmd :fetcher github :repo "muffinmad/emacs-vc-hgcmd")


### PR DESCRIPTION
### Brief summary of what the package does

VC mercurial backend that uses [hg command server](https://www.mercurial-scm.org/wiki/CommandServer) to communicate with hg

### Direct link to the package repository

https://github.com/muffinmad/emacs-vc-hgcmd

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)