### PR TITLE
Add recipe for ob-html-chrome.

### DIFF
--- a/recipes/ob-html-chrome
+++ b/recipes/ob-html-chrome
@@ -1,0 +1,1 @@
+(ob-html-chrome :repo "nikclayton/ob-html-chrome" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Org-Babel support for rendering HTML to PNG files using Chrome.

This is similar functionality to ob-browser, without the PhantomJS requirement.

### Direct link to the package repository

https://github.com/nikclayton/ob-html-chrome

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
