### PR TITLE
Add recipe for ox-slack

### DIFF
--- a/recipes/ox-slack
+++ b/recipes/ox-slack
@@ -1,0 +1,1 @@
+(ox-slack :fetcher github :repo "titaniumbones/ox-slack")


### PR DESCRIPTION
Please see PR for more details.

### Brief summary of what the package does

ox-slack provides a simple org-mode export backend for the slack instant messaging syntax.

### Direct link to the package repository

https://github.com/titaniumbones/ox-slack

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

I'm the author, so while some changes may be needed, I'm the one responsible for fixing them :-) 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback **see below**
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

**Note:** I've followed what I believe is the convention for org-mode exporters: functions are named `org-slack-xxx`, but the package is named `ox-slack`. `package-lint` gives a set of warnings for this, but I believe I'm still following best practice for org-mode extensions.