### PR TITLE
Add new recipe for evil-better-visual-line

### DIFF
--- a/recipes/evil-better-visual-move
+++ b/recipes/evil-better-visual-move
@@ -1,0 +1,1 @@
+(evil-better-visual-move :fetcher github :repo "YourFin/evil-better-visual-move")


### PR DESCRIPTION
### Brief summary of what the package does

Provides an improved experience on `evil-[next/previous]-visual-line` (common stand in j/k) in that it falls back to non-visual line movement in visual line and block mode

### Direct link to the package repository

https://github.com/yourfin/evil-better-visual-line

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

Got the package linting correctly!

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
