### PR TITLE
sql-presto: Add New Recipe

### DIFF
--- a/recipes/sql-presto
+++ b/recipes/sql-presto
@@ -1,4 +1,4 @@
 (sql-presto
  :fetcher github
  :repo "kat-co/sql-prestodb"
- :files ("artifacts/*"))
+ :files ("artifacts/*.el"))

--- a/recipes/sql-presto
+++ b/recipes/sql-presto
@@ -1,0 +1,4 @@
+(sql-presto
+ :fetcher github
+ :repo "kat-co/sql-prestodb"
+ :files ("artifacts/*"))


### PR DESCRIPTION
### Brief summary of what the package does

Allows users to utilize [Presto](https://prestodb.io/) via SQLi.

### Direct link to the package repository

https://github.com/kat-co/sql-prestodb

### Your association with the package

It me: the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
