### PR TITLE
Add recipe for load-bash-alias

### DIFF
--- a/recipes/load-bash-alias
+++ b/recipes/load-bash-alias
@@ -1,0 +1,1 @@
+(load-bash-alias :repo "daviderestivo/load-bash-alias" :fetcher github)

--- a/recipes/load-bash-shell-aliases
+++ b/recipes/load-bash-shell-aliases
@@ -1,1 +1,0 @@
-(load-bash-shell-aliases :repo "daviderestivo/load-bash-shell-aliases" :fetcher github)

--- a/recipes/load-bash-shell-aliases
+++ b/recipes/load-bash-shell-aliases
@@ -1,0 +1,1 @@
+(load-bash-shell-aliases :repo "daviderestivo/load-bash-shell-aliases" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Convert bash aliases into eshell ones.

### Direct link to the package repository

https://github.com/daviderestivo/load-bash-alias

### Your association with the package

I'm the creator and current maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)