### PR TITLE
Add rust-auto-use.el

### DIFF
--- a/recipes/rust-auto-use
+++ b/recipes/rust-auto-use
@@ -1,0 +1,1 @@
+(rust-auto-use :repo "vmalloc/rust-auto-use.el" :fetcher github :files ( "rust-auto-use.el"))

--- a/recipes/rust-auto-use
+++ b/recipes/rust-auto-use
@@ -1,1 +1,1 @@
-(rust-auto-use :repo "vmalloc/rust-auto-use.el" :fetcher github :files ( "rust-auto-use.el"))
+(rust-auto-use :repo "vmalloc/rust-auto-use.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
This package automatically inserts `use` statements in Rust code based on the current symbol.

### Direct link to the package repository

https://github.com/vmalloc/rust-auto-use.el

### Your association with the package
I am the developer and current maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
