### PR TITLE
Remove color-theme

### DIFF
--- a/recipes/color-theme-sanityinc-solarized
+++ b/recipes/color-theme-sanityinc-solarized
@@ -1,2 +1,0 @@
-(color-theme-sanityinc-solarized :repo "purcell/color-theme-sanityinc-solarized" :fetcher github)
-

--- a/recipes/color-theme-sanityinc-tomorrow
+++ b/recipes/color-theme-sanityinc-tomorrow
@@ -1,2 +1,0 @@
-(color-theme-sanityinc-tomorrow :repo "purcell/color-theme-sanityinc-tomorrow" :fetcher github)
-

--- a/recipes/color-theme-solarized
+++ b/recipes/color-theme-solarized
@@ -1,1 +1,0 @@
-(color-theme-solarized :repo "sellout/emacs-color-theme-solarized" :fetcher github)

--- a/recipes/sanityinc-solarized-themes
+++ b/recipes/sanityinc-solarized-themes
@@ -1,0 +1,4 @@
+(sanityinc-solarized-themes
+ :fetcher github
+ :repo "purcell/color-theme-sanityinc-solarized"
+ :files (:defaults (:exclude "color-theme-sanityinc-solarized.el")))

--- a/recipes/sanityinc-tomorrow-themes
+++ b/recipes/sanityinc-tomorrow-themes
@@ -1,0 +1,4 @@
+(sanityinc-tomorrow-themes
+ :fetcher github
+ :repo "purcell/color-theme-sanityinc-tomorrow"
+ :files (:defaults (:exclude "color-theme-sanityinc-tomorrow.el")))

--- a/recipes/sellout-solarized-theme
+++ b/recipes/sellout-solarized-theme
@@ -1,0 +1,4 @@
+(sellout-solarized-theme
+ :fetcher github
+ :repo "sellout/emacs-color-theme-solarized"
+ :files (:defaults (:exclude "color-theme-solarized.el")))


### PR DESCRIPTION
For your consideration.

```
 Remove obsolete color-theme

Since Emacs 24.1, released in 2012, Emacs comes with support
for themes, making the older `color-theme' package obsolete
and incompatible.

`color-theme' is one of the package that Melpa gets from the
Emacsorphanage, which I update semi-automatically and not very
often from the upstream non-git/hg repository.

This particular repository was not updated in ten years, which
isn't surprising since it has been obsolete for six of those.

I have stopped updating this mirror now and its recipe could be
updated to fetch "updates" from the Emacsattic instead.  But we
might as well take this opportunity and remove `color-theme'
and all old-school themes.

There are six theme packages whose repositories contain old-school
themes beside modern themes.  There are no old-school-only theme
packages.

The recipes of three of those already limit the Melpa package to
the modern theme.  The other tree, two of which by Steve, didn't
do so until this commit.

I think these packages should also be renamed from `color-theme-*'
to `*-theme(s)'.  I would also recommend that the `color-theme-*'
files be removed from all repositories (or moved to a branch named
"obsolete" or something like that).
```

```
 [WIP] Rename theme packages

!! Due to issues mentioned below, this cannot actually be merged yet.

These packages should be named after the new-style themes they provide
instead of after the old-style themes their repositories still contain.

I would encourage you to also remove the obsolete themes from the
repositories, but that can happen in a second step.

The `solarized-theme.el' library of package `sellout-solarized-theme'
conflicts with the library by the same name of the `solarized-theme'
package.  I think it should be renamed to `sellout-solarized-theme.el'
as is done for `sanityinc-solarized-theme'.
```