### PR TITLE
Add outline-minor-faces

### DIFF
--- a/recipes/backline
+++ b/recipes/backline
@@ -1,0 +1,1 @@
+(backline :fetcher github :repo "tarsius/backline")

--- a/recipes/outline-minor-faces
+++ b/recipes/outline-minor-faces
@@ -1,0 +1,1 @@
+(outline-minor-faces :fetcher github :repo "tarsius/outline-minor-faces")


### PR DESCRIPTION
I am opening a pull-request for these because the faces defined by `outline-minor-faces` do not use the prefix `outline-minor-faces`. In my opinion it would be silly to name those faces `outline-minor-faces-N` (where N is a number between 0 and 8). Instead I use `outline-minor-N` which corresponds to the `outline-N` faces that `outline.el` defines for use in `outline-mode`.

`backline` depends on `outline-minor-faces`. Adding it here so it is ready when you approve `outline-minor-faces`.

### Brief summary of what the package does

* `outline-minor-faces` adds heading faces for outline-minor-mode.
* `backline` extends the appearance of headings of collapsed sections until right edge of window.

### Direct link to the package repository

* https://github.com/tarsius/outline-minor-faces
* https://github.com/tarsius/backline

### Your association with the package

I am the author.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - It complains about the lack of a Version header, but in the age of git I don't do those anymore.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
  - It complains about the doc-string of an advice not documenting the arguments of the adviced function.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
