### PR TITLE
add: recipe for evil-textobj-entire

### DIFF
--- a/recipes/evil-textobj-entire
+++ b/recipes/evil-textobj-entire
@@ -1,0 +1,3 @@
+(evil-textobj-entire
+  :fetcher github
+  :repo "supermomonga/evil-textobj-entire")


### PR DESCRIPTION
### Brief summary of what the package does

Entire text object for evil

### Direct link to the package repository

https://github.com/supermomonga/evil-textobj-entire

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
