### PR TITLE
Add zprint-mode

### DIFF
--- a/recipes/zprint-mode
+++ b/recipes/zprint-mode
@@ -1,0 +1,1 @@
+(zprint-mode :repo "pesterhazy/zprint-mode.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Integrates zprint, the pretty-printer for Clojure(Script) files, into Emacs

### Direct link to the package repository

https://github.com/pesterhazy/zprint-mode.el

### Your association with the package

I am the package author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
