### PR TITLE
Add org-pivotal

### DIFF
--- a/recipes/org-pivotal
+++ b/recipes/org-pivotal
@@ -1,0 +1,3 @@
+(org-pivotal
+ :fetcher github
+ :repo "org-pivotal/org-pivotal")


### PR DESCRIPTION
### Brief summary of what the package does

org-pivotal is an Emacs minor mode to extend org-mode with Pivotal Tracker abilities

### Direct link to the package repository

https://github.com/org-pivotal/org-pivotal

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
