### PR TITLE
Add emacs-zmq

### DIFF
--- a/recipes/emacs-zmq
+++ b/recipes/emacs-zmq
@@ -1,0 +1,7 @@
+(emacs-zmq
+ :fetcher github
+ :repo "dzop/emacs-zmq"
+ :files (:defaults "Makefile" ("src"
+                               "src/*.c" "src/*.h"
+                               "src/Makefile.am"
+                               "src/configure.ac")))

--- a/recipes/emacs-zmq
+++ b/recipes/emacs-zmq
@@ -1,7 +1,4 @@
 (emacs-zmq
  :fetcher github
  :repo "dzop/emacs-zmq"
- :files (:defaults "Makefile" ("src"
-                               "src/*.c" "src/*.h"
-                               "src/Makefile.am"
-                               "src/configure.ac")))
+ :files (:defaults "Makefile" "src"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds Emacs bindings to the ZeroMQ (http://zeromq.org/) message passing library.

### Direct link to the package repository

https://github.com/dzop/emacs-zmq

### Your association with the package

Package mantainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
