### PR TITLE
Add git-time-metric

### DIFF
--- a/recipes/git-time-metric
+++ b/recipes/git-time-metric
@@ -1,0 +1,2 @@
+(git-time-metric :repo "c301/gtm-emacs-plugin"
+			:fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Plugin for the Emacs editor to be used with the [Git Time Metric](https://github.com/git-time-metric/gtm) platform

### Direct link to the package repository

https://github.com/c301/gtm-emacs-plugin

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
