### PR TITLE
Add hasklig-mode

### DIFF
--- a/recipes/hasklig-mode
+++ b/recipes/hasklig-mode
@@ -1,0 +1,3 @@
+(hasklig-mode
+ :repo "minad/hasklig-mode"
+ :fetcher github)


### PR DESCRIPTION
https://github.com/minad/hasklig-mode

### Brief summary of what the package does

Support for hasklig font ligatures using prettify-symbols

### Direct link to the package repository

https://github.com/minad/hasklig-mode

### Your association with the package

Maintainer

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
