### PR TITLE
Add emidje

### DIFF
--- a/recipes/emidje
+++ b/recipes/emidje
@@ -1,4 +1,3 @@
 (emidje :fetcher github
 :repo "nubank/emidje")
-(emidje :fetcher github
-:repo "nubank/emidje")
+

--- a/recipes/emidje
+++ b/recipes/emidje
@@ -1,0 +1,4 @@
+(emidje :fetcher github
+:repo "nubank/emidje")
+(emidje :fetcher github
+:repo "nubank/emidje")


### PR DESCRIPTION
[Emidje](https://github.com/nubank/emidje) integrates
[Cider](https://github.com/clojure-emacs/cider) and
[Midje](https://github.com/marick/Midje) in a more pleasant way. It is a nREPL
based replacement for the old midje-mode.


https://github.com/nubank/emidje


I'm the package author and one of the maintainers.


**None needed**


Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in
- [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

