### PR TITLE
Add emacs-buttons recipe

### DIFF
--- a/recipes/buttons
+++ b/recipes/buttons
@@ -1,0 +1,1 @@
+(buttons :fetcher github :repo "erjoalgo/emacs-buttons")


### PR DESCRIPTION
### Brief summary of what the package does

An emacs lisp mini-language to help organize emacs-lisp commands and code templates into a hierarchy of keymaps, and to facilitate installing and visualizing them.

### Direct link to the package repository

https://github.com/erjoalgo/emacs-buttons

### Your association with the package

Author, maintainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)