### PR TITLE
Include the default sound file for alarm-clock

### DIFF
--- a/recipes/alarm-clock
+++ b/recipes/alarm-clock
@@ -1,1 +1,3 @@
-(alarm-clock :fetcher github :repo "wlemuel/alarm-clock")
+(alarm-clock :fetcher github
+             :repo "wlemuel/alarm-clock"
+             :files (:defaults "*.mp3"))


### PR DESCRIPTION
### Brief summary of what the package does

An alarm clock management tool for Emacs.

### Direct link to the package repository

https://github.com/wlemuel/alarm-clock

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)