### PR TITLE
Add multi-magit

### DIFF
--- a/recipes/multi-magit
+++ b/recipes/multi-magit
@@ -1,0 +1,1 @@
+(multi-magit :repo "luismbo/multi-magit" :fetcher github)


### PR DESCRIPTION
I still have issues to deal with in the checklist. Can you help me with the last one? Are the other ones showstoppers?


### Brief summary of what the package does

Multi-magit is a set extensions to Magit for handling multiple git repositories simultaneously.

### Direct link to the package repository

https://github.com/luismbo/multi-magit

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback. (I've addressed most of it, but can't get rid of `692:1: error: "magit-multi-magit-repo-section-map" doesn't start with package's prefix "multi-magit".` because magit expects this variable to start with `magit-`.)
- [ ] My elisp byte-compiles cleanly. (Not yet: `multi-magit.el:252:14:Warning: ‘magit-branch-delete’ is for interactive use only.` don't know how to fix this yet.)
- [ ] `M-x checkdoc` is happy with my docstrings. (Not yet.)
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org) (Building the recipe complains about magit-2.11 not being available. What should I depend on instead?)
