### PR TITLE
Add recipe for hl-fill-column

### DIFF
--- a/recipes/hl-fill-column
+++ b/recipes/hl-fill-column
@@ -1,0 +1,3 @@
+(hl-fill-column
+  :fetcher github
+  :repo "laishulu/hl-fill-column")


### PR DESCRIPTION
### Brief summary of what the package does

This package provide modes to highlight fill column.

### Direct link to the package repository

https://github.com/laishulu/hl-fill-column

### Your association with the package

the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
