### PR TITLE
Add 'evil-nl-break-undo' recipe to MELPA.

### DIFF
--- a/recipes/evil-nl-break-undo
+++ b/recipes/evil-nl-break-undo
@@ -1,0 +1,3 @@
+(evil-nl-break-undo
+  :fetcher github
+  :repo "VanLaser/evil-nl-break-undo")


### PR DESCRIPTION
### Brief summary of what the package does

evil-nl-break-undo is a (very simple) evil-mode add-on that breaks the undo sequence in the insert state, when the buffer is changed over a line boundary, i.e. when at least one line is created or deleted. It does not depend on how the key RET is mapped. The 'boundary' is actually customizable using a regex. It is a (better) equivalent of the following Vim mapping:

```vimscript
inoremap <silent> <cr> <c-g>u<cr>
```

Note: it assumes that `evil-mode` is enabled, and that the variable `evil-want-fine-undo` is `nil` (this is the default in `evil-mode`, but not with Spacemacs).

### Direct link to the package repository

https://github.com/VanLaser/evil-nl-break-undo

### Your association with the package

I am the author/maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [ x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] My elisp byte-compiles cleanly
- [ x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
