### PR TITLE
package-build--get-commit: Get commit for Hg repositories

### DIFF
--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -533,7 +533,12 @@ If PKG-INFO is nil, an empty one is created."
      (package-recipe--working-tree rcp)
      "git" "rev-parse" "HEAD")))
 
-(defmethod package-build--get-commit ((rcp package-hg-recipe))) ; TODO
+(defmethod package-build--get-commit ((rcp package-hg-recipe))
+  (ignore-errors
+    (package-build--run-process-match
+     "changeset:[[:space:]]+[[:digit:]]+:\\([[:xdigit:]]+\\)"
+     (package-recipe--working-tree rcp)
+     "hg" "log" "--debug" "--limit=1")))
 
 (defun package-build--archive-entry (rcp pkg-info type)
   (let ((name (intern (aref pkg-info 0)))


### PR DESCRIPTION
This pull request implements `package-build--get-commit` for Hg repositories. I have tested the change by running `make packages; make html/archive.json`, and all seems well.

### Checklist

(Because this is not a recipe pull request, I have marked out the items below which do not seem to apply.)

Please confirm with `x`:

- [ ] ~The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).~
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] ~I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback~
- [x] My elisp byte-compiles cleanly
- [ ] ~`M-x checkdoc` is happy with my docstrings~
- [ ] ~I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)~
