### PR TITLE
added org-insert-url to recipes

### DIFF
--- a/recipes/org-insert-url
+++ b/recipes/org-insert-url
@@ -1,0 +1,1 @@
+(org-insert-url :repo "ramprakash-94/org-insert-url.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

org-insert-url.el is a lightweight package created to help you insert
external URLs into your org document with the webpage title. The package 
extracts the title from the webpage and inserts it into your org document 
with a hyperlink to the URL.

### Direct link to the package repository

https://github.com/ramprakash-94/org-insert-url.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
