### PR TITLE
Create mint-mode

### DIFF
--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -1,0 +1,5 @@
+(mint-mode
+ :fetcher github
+ :url "https://github.com/creatorrr/emacs-mint-mode"
+ :repo "creatorrr/emacs-mint-mode"
+ :files ("mint-mode.el"))

--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -1,6 +1,5 @@
 (mint-mode
  :fetcher github
- :url "https://github.com/creatorrr/emacs-mint-mode"
  :repo "creatorrr/emacs-mint-mode"
  :version-regexp "0\\.4\\..+"
  :files ("mint-mode.el" "tokens"))

--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -2,4 +2,5 @@
  :fetcher github
  :url "https://github.com/creatorrr/emacs-mint-mode"
  :repo "creatorrr/emacs-mint-mode"
- :files ("mint-mode.el"))
+ :version-regexp "0\\.4\\..+"
+ :files ("mint-mode.el" "tokens"))

--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -1,5 +1,5 @@
 (mint-mode
  :fetcher github
  :repo "creatorrr/emacs-mint-mode"
- :version-regexp "0\\.4\\..+"
+ :version-regexp "0\\.5\\..+"
  :files ("mint-mode.el" "tokens"))


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for [mint lang](https://mint-lang.com). Provides:
 - Syntax highlighting
 - Auto format on save using `mint format`

### Direct link to the package repository

https://github.com/creatorrr/emacs-mint-mode

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
