### PR TITLE
Add recipe for named-timer.el

### DIFF
--- a/recipes/named-timer
+++ b/recipes/named-timer
@@ -1,0 +1,1 @@
+(named-timer :fetcher github :repo "DarwinAwardWinner/emacs-named-timer")


### PR DESCRIPTION
### Brief summary of what the package does

`named-timer.el` provides `named-timer-run` and other related functions. `named-timer-run` works like `run-with-timer` but takes an additional argument giving the timer a name. Crucially, creating a named timer automatically cancels any existing timer with that name. This simplifies the pattern of cancelling and restarting a timer to a single line, and ensures that no coding mistake can accidentally leave duplicate timers running.

### Direct link to the package repository

https://github.com/DarwinAwardWinner/emacs-named-timer

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
