### PR TITLE
gnus-recent

### DIFF
--- a/recipes/gnus-recent
+++ b/recipes/gnus-recent
@@ -1,2 +1,3 @@
 (gnus-recent :fetcher github
-             :repo "unhammer/gnus-recent")
+             :repo "unhammer/gnus-recent"
+             :files ("gnus-recent.el"))

--- a/recipes/gnus-recent
+++ b/recipes/gnus-recent
@@ -1,0 +1,2 @@
+(gnus-recent :fetcher github
+             :repo "unhammer/gnus-recent")


### PR DESCRIPTION
### Brief summary of what the package does

Maintains a list of recently read Gnus articles, to easily go
back through previously read articles, or optionally pick from a list
shown with ivy.

### Direct link to the package repository

https://github.com/unhammer/gnus-recent


### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

 **None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

I'd prefer ivy to be an optional dependency, but this means I get warnings about missing ivy functions from byte compilation. I don't know if there's a way to avoid that without making ivy a hard requirement.
EDIT: declare-function'd 

The `make recipes/gnus-recent` goes fine, but the `$ EMACS_COMMAND=/usr/bin/emacs make sandbox INSTALL=gnus-recent` complains about emacs 25.3.2 not being available(?).