### PR TITLE
Add exwm-firefox-core

### DIFF
--- a/recipes/exwm-firefox-core
+++ b/recipes/exwm-firefox-core
@@ -1,0 +1,1 @@
+(exwm-firefox-core :fetcher github :repo "walseb/exwm-firefox-core")


### PR DESCRIPTION
### Brief summary of what the package does

This package defines functions that execute hotkeys relevant to firefox so that you can bind your keys inside emacs instead of relying on (unreliable) firefox keybind packages. This is a library so it's not functional without user configuration or the use of an implementation of it like exwm-firefox-evil which i will be submitting here too.

### Direct link to the package repository

https://github.com/your/awesome_package

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
