### PR TITLE
Add exwm-firefox-evil

### DIFF
--- a/recipes/exwm-firefox-evil
+++ b/recipes/exwm-firefox-evil
@@ -1,0 +1,1 @@
+(exwm-firefox-evil :fetcher github :repo "walseb/exwm-firefox-evil")


### PR DESCRIPTION
### Brief summary of what the package does

exwm-firefox-evil makes firefox's control scheme modal. It uses vi-like keys and doesn't require any addons. It does this by implementing [exwm-firefox-core](https://github.com/walseb/exwm-firefox-core) which sends fake keys to firefox using exwm.

### Direct link to the package repository

https://github.com/walseb/exwm-firefox-evil

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
