### PR TITLE
New recipe: detour

### DIFF
--- a/recipes/detour
+++ b/recipes/detour
@@ -1,0 +1,2 @@
+(detour	:repo "ska2342/detour"
+        :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Detour provides two small functions which allow storing the current position in a register, going somewhere else, and then quickly jumping between those positions. The benefit over just using registers for this is speed when bound to easily reachable keys. 

### Direct link to the package repository

https://github.com/ska2342/detour

### Your association with the package

Sole author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the version of [package-lint](https://github.com/purcell/package-lint) shipped with Emacs 25.2.2 to check for packaging issues, and addressed its feedback. (Not sure if this is the _latest_ version, though.)
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
