### PR TITLE
pretty-print archive-contents to make it human readable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ packages: $(RCPDIR)/*
 packages/archive-contents: .FORCE
 	@echo " • Updating $@ ..."
 	@$(EVAL) '(package-build-dump-archive-contents)'
+	@$(EVAL) '(progn (find-file "packages/archive-contents") (emacs-lisp-mode) (pp-buffer) (save-buffer))'
 
 cleanup:
 	@$(EVAL) '(package-build-cleanup)'


### PR DESCRIPTION
Prior to this change this file is one very long line with more than
a million bytes.

This step takes less than 3 seconds on virtual linux running on my one year old Dell laptop
to process the full 1.3 megabytes.