### PR TITLE
Add jest

### DIFF
--- a/recipes/jest
+++ b/recipes/jest
@@ -1,0 +1,1 @@
+(jest :repo "emiller88/emacs-jest" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Runs jest from a Magit popup the same way
[Python-pytest](https://github.com/wbolster/emacs-python-pytest) works.

### Direct link to the package repository

https://github.com/emiller88/emacs-jest

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

This is a work in progress. 

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)