### PR TITLE
Add recipe for writefreely

### DIFF
--- a/recipes/writefreely
+++ b/recipes/writefreely
@@ -1,0 +1,1 @@
+(writefreely :repo "dangom/writefreely.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Writefreely allows users to immediately publish their Org files to any instance of the federated blogging platform Write Freely.

### Direct link to the package repository

https://github.com/dangom/writefreely.el

### Your association with the package

Author and maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
