### PR TITLE
add recipe for ox-slimhtml

### DIFF
--- a/recipes/ox-slimhtml
+++ b/recipes/ox-slimhtml
@@ -1,0 +1,1 @@
+(ox-slimhtml :fetcher github :repo "balddotcat/ox-slimhtml")


### PR DESCRIPTION
### Brief summary of what the package does

slimhtml is an Emacs org mode export backend.  It is a set of transcoders for common org elements which outputs minimal HTML.  The aim is not to re-invent the wheel over the default org-mode HTML exporter - as it tackles a much bigger, and different problem - but to provide a small set of components for easier customization of HTML output from org.

### Direct link to the package repository

https://github.com/balddotcat/ox-slimhtml

### Your association with the package

author

### Relevant communications with the upstream package maintainer

re-submitting [slimhtml pull request](https://github.com/melpa/melpa/pull/5826) per namespace update to ox-slimhtml
 
flycheck emits warnings for 'unused lexical arguments' that are from the original org-export function signatures, and are required for functionality

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)