### PR TITLE
Add snippets directory to ejc-sql.

### DIFF
--- a/recipes/ejc-sql
+++ b/recipes/ejc-sql
@@ -1,3 +1,3 @@
 (ejc-sql :repo "kostafey/ejc-sql"
-         :files (:defaults "project.clj" "src")
+         :files (:defaults "project.clj" "src" "snippets")
          :fetcher github)


### PR DESCRIPTION
Add snippets directory to ejc-sql.

Emacs SQL client uses Clojure JDBC.

### Direct link to the package repository

https://github.com/kostafey/ejc-sql

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
