### PR TITLE
Add recipe for moccur-edit

### DIFF
--- a/recipes/moccur-edit
+++ b/recipes/moccur-edit
@@ -1,0 +1,1 @@
+(moccur-edit :repo "myuhe/moccur-edit.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Add recipe for moccur-edit

### Direct link to the package repository

https://github.com/myuhe/moccur-edit.el

### Your association with the package

I am a user of moccur-edit

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
    I haven't fixed those, but I can start
```
8 issues found:

1:1: error: Package should have a Homepage or URL header.
7:1: warning: You should include standard keywords: see the variable `finder-known-keywords'.
139:1: error: "moccur-query-when-buffer-read-only" doesn't start with package's prefix "moccur-edit".
152:1: error: "moccur-mode-edit-set-key" doesn't start with package's prefix "moccur-edit".
171:1: error: "moccur-mode-change-face" doesn't start with package's prefix "moccur-edit".
356:1: error: "current-line" doesn't start with package's prefix "moccur-edit".
360:1: error: "max-line" doesn't start with package's prefix "moccur-edit".
457:33: warning: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
```

- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
