### PR TITLE
Add recipe for abs-mode, a major mode for the modeling language Abs

### DIFF
--- a/recipes/abs-mode
+++ b/recipes/abs-mode
@@ -1,0 +1,3 @@
+(abs-mode :repo "abstools/abs-mode"
+          :fetcher github
+          :files ("abs-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for the modeling language Abs (http://docs.abs-models.org/)

### Direct link to the package repository

https://github.com/abstools/abs-mode/

### Your association with the package

Author, maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
(note: package-lint complains about unversioned dependencies, but these are legal and I don't depend on specific versions for `erlang' and `maude-mode')
- [x] My elisp byte-compiles cleanly
(note: two deprecation warnings wrt flymake on emacs 26.1, but I want to support emacs 25 if possible)
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)