### PR TITLE
Add cc-cedict recipe

### DIFF
--- a/recipes/cc-cedict
+++ b/recipes/cc-cedict
@@ -1,0 +1,1 @@
+(cc-cedict :fetcher github :repo "xuchunyang/cc-cedict.el")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs interface for CC-CEDICT (a free Chinese-English Dictionary)

### Direct link to the package repository

https://github.com/xuchunyang/cc-cedict.el

### Your association with the package

[Are you the maintainer? A contributor? An enthusiastic user?]

I am the maintainer.

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
