### PR TITLE
Add recipe help-find-org-mode

### DIFF
--- a/recipes/help-find-org-mode
+++ b/recipes/help-find-org-mode
@@ -1,0 +1,1 @@
+(help-find-org-mode :fetcher github :repo "EricCrosson/help-find-org-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Advises built-in help functions to find org source-bocks over tangled-code where possible

### Direct link to the package repository

https://github.com/ericcrosson/help-find-org-mode

### Your association with the package

- author
- maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)