### PR TITLE
add q-mode recipe

### DIFF
--- a/recipes/q-mode
+++ b/recipes/q-mode
@@ -1,0 +1,1 @@
+(q-mode :fetcher github :repo "psaris/q-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for editing q (the language written by Kx Systems, see URL `http://www.kx.com') in Emacs.

### Direct link to the package repository

https://github.com/psaris/q-mode

### Your association with the package

author/maintainer

### Relevant communications with the upstream package maintainer

new package

### Checklist

Please confirm with `x`:

- [ x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [ x] `M-x checkdoc` is happy with my docstrings
- [ x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
