### PR TITLE
Add treemacs-icons-dired.

### DIFF
--- a/recipes/treemacs
+++ b/recipes/treemacs
@@ -5,5 +5,4 @@
          "icons"
          "src/elisp/treemacs*.el"
          "src/scripts/treemacs*.py"
-         (:exclude "src/elisp/treemacs-evil.el"
-                   "src/elisp/treemacs-projectile.el")))
+         (:exclude "src/extra/*")))

--- a/recipes/treemacs-evil
+++ b/recipes/treemacs-evil
@@ -1,4 +1,4 @@
 (treemacs-evil
  :fetcher github
  :repo "Alexander-Miller/treemacs"
- :files ("src/elisp/treemacs-evil.el"))
+ :files ("src/extra/treemacs-evil.el"))

--- a/recipes/treemacs-icons-dired
+++ b/recipes/treemacs-icons-dired
@@ -1,0 +1,4 @@
+(treemacs-icons-dired
+ :fetcher github
+ :repo "Alexander-Miller/treemacs"
+ :files ("src/extra/treemacs-icons-dired.el"))

--- a/recipes/treemacs-projectile
+++ b/recipes/treemacs-projectile
@@ -1,4 +1,4 @@
 (treemacs-projectile
  :fetcher github
  :repo "Alexander-Miller/treemacs"
- :files ("src/elisp/treemacs-projectile.el"))
+ :files ("src/extra/treemacs-projectile.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Small extra package for treemacs (mostly based on all-the-icons-dired) that'll [add treemacs' icons to dired buffers](https://github.com/Alexander-Miller/treemacs/blob/master/screenshots/dired-icons.png).

I have also included changes to the file structure to move the growing number of extra packages like this one from the main elisp directory into their own. For now these extra packages (treemacs-evil, treemacs-projectile and the unfinished treemacs-magit) are copied in both directories. Once this PR is merged I will delete them from /src/elisp.

### Direct link to the package repository

https://github.com/Alexander-Miller/treemacs
https://github.com/Alexander-Miller/treemacs/blob/master/src/extra/treemacs-icons-dired.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
