### PR TITLE
Add recipe for wiki-this

### DIFF
--- a/recipes/wiki-this
+++ b/recipes/wiki-this
@@ -1,0 +1,1 @@
+(wiki-this :repo "jcs090218/wiki-this" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Simply search in Wikipedia under point.

### Direct link to the package repository

https://github.com/jcs090218/wiki-this

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
