### PR TITLE
Add recipe for unicode-math-input.el

### DIFF
--- a/recipes/unicode-math-input
+++ b/recipes/unicode-math-input
@@ -1,0 +1,1 @@
+(unicode-math-input :fetcher github :repo "astoff/unicode-math-input.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package includes a more comprehensive variant of the built in TeX input method (includes all symbols listed in this file: http://ctan.org/tex-archive/macros/latex/contrib/unicode-math/unimath-symbols.pdf)

It also includes an Ivy method to browse and insert math symbols.

### Direct link to the package repository

https://github.com/astoff/unicode-math-input.el

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
