### PR TITLE
Add recipe for coleslaw-mode

### DIFF
--- a/recipes/coleslaw
+++ b/recipes/coleslaw
@@ -1,1 +1,2 @@
 (coleslaw :fetcher github :repo "equwal/coleslaw")
+

--- a/recipes/coleslaw
+++ b/recipes/coleslaw
@@ -1,2 +1,1 @@
 (coleslaw :fetcher github :repo "equwal/coleslaw")
-

--- a/recipes/coleslaw
+++ b/recipes/coleslaw
@@ -1,0 +1,1 @@
+(coleslaw :fetcher github :repo "equwal/coleslaw")

--- a/recipes/coleslaw-mode
+++ b/recipes/coleslaw-mode
@@ -1,0 +1,1 @@
+(coleslaw-mode :fetcher github :repo "equwal/coleslaw-mode")

--- a/recipes/coleslaw-mode
+++ b/recipes/coleslaw-mode
@@ -1,1 +1,0 @@
-(coleslaw-mode :fetcher github :repo "equwal/coleslaw-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A mode for editing files used by [kingcon's "coleslaw" site content generator](https://github.com/kingcons/coleslaw) to generate static html content. The interesting bits are:
- Every file requires a header (bound only in `.page` and `.post` files to `M-;`. It won't function otherwise).
- The type of header required changes based on the filetype: `.page` and `.post` files need different headers.
- The user specifies the style of markup in the header, so the major mode needs to be changed accordingly.

I found myself hand writing these and making plenty of errors, while also having to `M-x lisp-mode` or `M-x markdown-mode` and  `M-x markdown-preview-eww` everytime I wanted to edit or make a new page. There are no hard dependencies.

### Direct link to the package repository
https://github.com/equwal/coleslaw-mode

### Your association with the package

I am the creator. Coleslaw itself is here: https://github.com/kingcons/coleslaw

### Relevant communications with the upstream package maintainer

I am the upstream package maintainer. Coleslaw itself doesn't require any contact.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
