### PR TITLE
Added the TeaCodeExpand package to use TeaCode with Emacs on macOS.

### DIFF
--- a/recipes/TeaCodeExpand
+++ b/recipes/TeaCodeExpand
@@ -1,0 +1,3 @@
+(TeaCodeExpand
+   :fetcher GitHub
+   :repo "raguay/TeaCodeExpand")


### PR DESCRIPTION
### Brief summary of what the package does

This package allows for the insertion of snippets from the (TeaCode)[https://www.apptorium.com/teacode] for the macOS.

### Direct link to the package repository

https://github.com/raguay/TeaCodeExpand

### Your association with the package

I'm the package creator and maintainer. My first one!

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
