### PR TITLE
Add right-click-context package

### DIFF
--- a/recipes/right-click-context
+++ b/recipes/right-click-context
@@ -1,0 +1,4 @@
+(right-click-context
+ :repo "zonuexe/right-click-context"
+ :fetcher github
+ :files ("right-click-context.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A customizable context menu, call it from right-click of mouse.

### Direct link to the package repository

https://github.com/zonuexe/right-click-context

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
