### PR TITLE
Add recipe for agtags

### DIFF
--- a/recipes/agtags
+++ b/recipes/agtags
@@ -1,0 +1,3 @@
+(agtags
+ :repo "vietor/agtags"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Another Emacs frontend to GNU Global. It support [**wgrep**](https://github.com/mhayashi1120/Emacs-wgrep) in **agtags-grep-mode**. Add simple Xref support.

### Direct link to the package repository

https://github.com/vietor/agtags

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
