### PR TITLE
add flymake-diagnostic-at-point recipe

### DIFF
--- a/recipes/flymake-diagnostic-at-point
+++ b/recipes/flymake-diagnostic-at-point
@@ -1,0 +1,1 @@
+(flymake-diagnostic-at-point :repo "meqif/flymake-diagnostic-at-point" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This provides a handy minor mode to show the diagnostic information at point for newer versions of flymake.

### Direct link to the package repository

https://github.com/meqif/flymake-diagnostic-at-point

### Your association with the package

enthusiastic user

### Relevant communications with the upstream package maintainer

none needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

connect to https://github.com/meqif/flymake-diagnostic-at-point/issues/3