### PR TITLE
Add eldoc-box

### DIFF
--- a/recipes/eldoc-box
+++ b/recipes/eldoc-box
@@ -1,0 +1,1 @@
+(eldoc-box :repo "casouri/eldoc-box" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Make eldoc display document messages in childframe

### Direct link to the package repository

https://github.com/casouri/eldoc-box

### Your association with the package

Maintainer (wrote the package but copied code from lsp-ui, hence maintainer)

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (except a minor one)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
