### PR TITLE
adding Kubel recipe

### DIFF
--- a/recipes/kubel
+++ b/recipes/kubel
@@ -1,0 +1,1 @@
+(kubel :repo "abrochard/kubel" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs extension for controlling Kubernetes pods with limited permissions. The existing extension will not be happy if you cannot list namespaces and given the scope of the change required to support that, and the actual scope of what you need to control pods, I propose this smaller extension as a solution.

### Direct link to the package repository

https://github.com/abrochard/kubel

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
