### PR TITLE
Add a link to the opposite Melpa in the header

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -22,6 +22,7 @@
           <li><a href="#/">Packages</a></li>
           <li><a href="#/getting-started">Getting started</a></li>
           <li><a href="https://github.com/melpa/melpa">GitHub</a></li>
+          <li><a class="other-melpa-link hidden" href="https://stable.melpa.org">Melpa Stable</a></li>
         </ul>
       </nav>
     </div>

--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -2,12 +2,10 @@
 (function(m, document, _, moment, Cookies){
   "use strict";
 
-  // TODO Link to other MELPA in header, e.g. from MELPA to MELPA Stable
   // TODO Show compatible emacs versions for any package
   // TODO Google Analytics
   // TODO D3 visualisation for deps
   // TODO Voting / starring
-  // TODO Add header links from MELPA to MELPA Stable and vice-versa
 
   //////////////////////////////////////////////////////////////////////////////
   // Helpers
@@ -542,9 +540,15 @@
       // jshint unused: false
       m.mount(e, melpa.archivename);
     });
+
+    // Add a link to the other Melpa site
+    var otherMelpa = document.getElementsByClassName("other-melpa-link")[0]
     if (melpa.stable()) {
       document.getElementsByTagName("html")[0].className += " stable";
+      otherMelpa.href = "https://melpa.org"
+      otherMelpa.textContent = "Melpa"
     }
+    otherMelpa.classList.remove("hidden")
   });
 
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We initially hide the link to prevent flashing changes when the page is loading, then unhide it once we have determined which Melpa we are on.