### PR TITLE
Update: Change source repo for ts-comint due to transferred ownership.

### DIFF
--- a/recipes/ts-comint
+++ b/recipes/ts-comint
@@ -1,2 +1,2 @@
 (ts-comint
- :fetcher github :repo "josteink/ts-comint")
+ :fetcher github :repo "emacs-typescript/ts-comint")


### PR DESCRIPTION
### Brief summary of what the package does

Same as before.

### Direct link to the package repository

Used to be: https://github.com/josteink/ts-comint

Transferred ownership to new organization here: https://github.com/emacs-typescript/ts-comint

### Your association with the package

Original author. Original MELPA recipie provider.

### Relevant communications with the upstream package maintainer

Basic ownership transfer.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
