### PR TITLE
update the upstream url

### DIFF
--- a/recipes/typescript-mode
+++ b/recipes/typescript-mode
@@ -1,1 +1,1 @@
-(typescript-mode :fetcher github :repo "ananthakumaran/typescript.el")
+(typescript-mode :fetcher github :repo "emacs-typescript/typescript.el")


### PR DESCRIPTION
The project repo has been moved from ananthakumaran/typescript.el to emacs-typescript/typescript.el

### Brief summary of what the package does

Major mode for TypeScript

### Direct link to the package repository

https://github.com/emacs-typescript/typescript.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
