### PR TITLE
Recipe: Add yequake

### DIFF
--- a/recipes/yequake
+++ b/recipes/yequake
@@ -1,0 +1,1 @@
+(yequake :fetcher github :repo "alphapapa/yequake")


### PR DESCRIPTION
### Brief summary of what the package does

 This package provides configurable, drop-down Emacs frames, similar to drop-down terminal windows programs, like Yakuake.  Each frame can be customized to display certain buffers in a certain way, at the desired height, width, and opacity.  The idea is to call the =yequake-toggle= command from outside Emacs, using =emacsclient=, by binding a shell command to a global keyboard shortcut in the desktop environment.  Then, with a single keypress, the desired Emacs frame can be toggled on and off, showing the desired buffers.

### Direct link to the package repository

http://github.com/alphapapa/yequake.el

### Your association with the package

Author, maintainer, enthusiastic user.

### Relevant communications with the upstream package maintainer

I consult with myself as necessary.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Thanks for all your work on MELPA!