### PR TITLE
Add recipe with-os

### DIFF
--- a/recipes/with-os
+++ b/recipes/with-os
@@ -1,0 +1,1 @@
+(with-os :fetcher github :repo "EricCrosson/with-os")


### PR DESCRIPTION
### Brief summary of what the package does

Provide a `use-package`-esque way to conditionally execute sexp's by current operating system.

### Direct link to the package repository

https://github.com/EricCrosson/with-os

### Your association with the package

- [X] maintainer
- [X] contributor

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


### Notes

It's a rough-but-functional initial version.  More experienced elispers might gasp at the contents.  I'm all ears if anybody is kind enough to offer feedback.

Cheers and thanks for all your help, melpa crew!
