### PR TITLE
Add idle-org-agenda

### DIFF
--- a/recipes/idle-org-agenda
+++ b/recipes/idle-org-agenda
@@ -1,0 +1,1 @@
+(idle-org-agenda :fetcher github :repo "enisozgen/idle-org-agenda")


### PR DESCRIPTION
### Brief summary of what the package does

Basically, if you don't touch Emacs `idle-org-agenda' will display your
org-agenda after certain time.
That can be useful to remember tasks after come back to work.
This project is comes from John Wiegley's mail at the gmane mailing list


### Direct link to the package repository

https://github.com/enisozgen/idle-org-agenda

### Your association with the package

I am maintainer. I informed the code author.

### Relevant communications with the upstream package maintainer

No Needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
