### PR TITLE
Replace ':defaults' with '":defaults"' at create recipes json file.

### DIFF
--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -940,15 +940,14 @@ artifacts, and return a list of the up-to-date archive entries."
          (lambda (lst)
            (let (frg)
              (mapcar (lambda (x)
-                       (cond ((eq x :files) (prog1 x (setq frg t)))
-                             (frg (prog1 x
-                                    (setq frg nil)
-                                    (cl-mapcan
-                                     (lambda (y)
-                                       (if (listp y)
-                                           (if (eq (car y) :exclude)
-                                               `((:exclude ,(cdr y))) y)
-                                         (list y))))))
+                       (cond ((eq x :files) (setq frg t) x)
+                             (frg (setq frg nil)
+                                  (cl-mapcan
+                                   (lambda (y)
+                                     (if (listp y)
+                                         (if (eq (car y) :exclude)
+                                             `((:exclude ,(cdr y))) y)
+                                       (list y))) x))
                              (t x))) lst)))))
     (with-temp-file file
       (insert

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -932,10 +932,10 @@ artifacts, and return a list of the up-to-date archive entries."
 (defun package-build-recipe-alist-as-json (file)
   "Dump the recipe list to FILE as json."
   (interactive)
-  (let ((escape-fn (lambda ()
+  (let ((escape-fn (lambda (find-str replace-str)
                      (goto-char (point-min))
-                     (while (search-forward ":defaults" nil t)
-                       (replace-match "\"//:defaults//\"" nil t)))))
+                     (while (search-forward find-str nil t)
+                       (replace-match replace-str nil t)))))
     (with-temp-file file
       (insert
        (json-encode
@@ -946,7 +946,8 @@ artifacts, and return a list of the up-to-date archive entries."
                            (with-temp-buffer
                              (insert-file-contents
                               (expand-file-name name package-build-recipes-dir))
-                             (funcall escape-fn)
+                             (funcall escape-fn ":defaults" "\"//:defaults//\"")
+                             (funcall escape-fn ":exclude" "\"//:exclude//\"")
                              (list (read (buffer-string)))))))
                    (package-recipe-recipes)))))))
 

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -943,7 +943,7 @@ artifacts, and return a list of the up-to-date archive entries."
                        (cond ((eq x :files) (prog1 x (setq frg t)))
                              (frg (prog1 x
                                     (setq frg nil)
-                                    (mapcan
+                                    (cl-mapcan
                                      (lambda (y)
                                        (if (listp y)
                                            (if (eq (car y) :exclude)

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -940,15 +940,15 @@ artifacts, and return a list of the up-to-date archive entries."
          (lambda (lst)
            (let ((frg))
              (mapcar (lambda (x)
-                       (cond ((eq x :files) (setq frg t) x)
-                             (frg (setq frg nil)
-                                  (mapcan
-                                   (lambda (y)
-                                     (if (listp y)
-                                         (if (eq (car y) :exclude)
-                                             `((:exclude ,(cdr y))) y)
-                                       (list y)))
-                                   x))
+                       (cond ((eq x :files) (prog1 x (setq frg t)))
+                             (frg (prog1 x
+                                    (setq frg nil)
+                                    (mapcan
+                                     (lambda (y)
+                                       (if (listp y)
+                                           (if (eq (car y) :exclude)
+                                               `((:exclude ,(cdr y))) y)
+                                         (list y))))))
                              (t x)))
                      lst)))))
     (with-temp-file file

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -949,8 +949,7 @@ artifacts, and return a list of the up-to-date archive entries."
                                            (if (eq (car y) :exclude)
                                                `((:exclude ,(cdr y))) y)
                                          (list y))))))
-                             (t x)))
-                     lst)))))
+                             (t x))) lst)))))
     (with-temp-file file
       (insert
        (json-encode

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -935,7 +935,7 @@ artifacts, and return a list of the up-to-date archive entries."
   (let ((escape-fn (lambda ()
                      (goto-char (point-min))
                      (while (search-forward ":defaults" nil t)
-                       (replace-match "\":defaults\"" nil t)))))
+                       (replace-match "\"//:defaults//\"" nil t)))))
     (with-temp-file file
       (insert
        (json-encode

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -938,7 +938,7 @@ artifacts, and return a list of the up-to-date archive entries."
                        (replace-match replace-str nil t))))
         (escape-:exclude-fn
          (lambda (lst)
-           (let ((frg))
+           (let (frg)
              (mapcar (lambda (x)
                        (cond ((eq x :files) (prog1 x (setq frg t)))
                              (frg (prog1 x

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -942,13 +942,13 @@ artifacts, and return a list of the up-to-date archive entries."
              (mapcar (lambda (x)
                        (cond ((eq x :files) (setq frg t) x)
                              (frg (setq frg nil)
-                                  (mapcan (lambda (y)
-                                            (if (listp y)
-                                                (if (eq (car y) :exclude)
-                                                    `((:exclude ,(cdr y)))
-                                                  y)
-                                              (list y)))
-                                          x))
+                                  (mapcan
+                                   (lambda (y)
+                                     (if (listp y)
+                                         (if (eq (car y) :exclude)
+                                             `((:exclude ,(cdr y))) y)
+                                       (list y)))
+                                   x))
                              (t x)))
                      lst)))))
     (with-temp-file file
@@ -963,7 +963,6 @@ artifacts, and return a list of the up-to-date archive entries."
                    (insert-file-contents
                     (expand-file-name name package-build-recipes-dir))
                    (funcall escape-fn ":defaults" "\"//:defaults//\"")
-                   ;; (funcall escape-fn ":exclude" "\"exclude\"")
                    (list (funcall escape-:exclude-fn
                                   (read (buffer-string))))))))
          (package-recipe-recipes)))))))

--- a/recipes/slime
+++ b/recipes/slime
@@ -5,7 +5,8 @@
                "swank"
                "*.lisp"
                "*.asd"
-               ("contrib" "contrib/*" (:exclude "contrib/test"))
+               "contrib" "contrib/*"
+               (:exclude "contrib/test")
                "doc/slime.texi"
                "doc/slime.info"
                "doc/dir"

--- a/recipes/slime
+++ b/recipes/slime
@@ -5,8 +5,8 @@
                "swank"
                "*.lisp"
                "*.asd"
-               "contrib" "contrib/*"
-               (:exclude "contrib/test")
+               ("contrib" "contrib/*")
+               (:exclude "contrib/test" "contrib/Makefile")
                "doc/slime.texi"
                "doc/slime.info"
                "doc/dir"


### PR DESCRIPTION
This pull request is not a package addition, but a proposal to change MELPA's core file.

I have created a new package manager named [feather.el](https://github.com/conao3/feather.el), and I'm using MELPA's recipe as its recipe. ([feather-recipes](https://github.com/conao3/feather-recipes))

In the process, I found mysterious points in the [JSON file](https://melpa.org/recipes.json) hosted by MELPA and I will propose a fix.

### fix point
Before, `json-encode` mistakenly recognized `:defualts` as a key.
```
(json-encode '(((dyalog-mode :fetcher bitbucket :repo "harsman/dyalog-mode" :files (":defaults" "Emacs.apl")))))
=> [{"dyalog-mode":{"fetcher":"bitbucket","repo":"harsman/dyalog-mode","files":{"defaults":"Emacs.apl"}}}]
```

After, by replacing `:defaults` with `":defaults"`, `json-encode` is now able to recognize it correctly as array.
```
(json-encode '(((dyalog-mode :fetcher bitbucket :repo "harsman/dyalog-mode" :files (":defaults" "Emacs.apl")))))
=> [{"dyalog-mode":{"fetcher":"bitbucket","repo":"harsman/dyalog-mode","files":["//:defaults//","Emacs.apl"]}}]
```


Replaced with `//:defaults//`  because it does not conflict with the user's file, and I will change it if other strings are recommended.