### PR TITLE
Add recipe: use-package-hydra

### DIFF
--- a/recipes/use-package-hydra
+++ b/recipes/use-package-hydra
@@ -1,3 +1,2 @@
 (use-package-hydra :repo "to1ne/use-package-hydra"
-                    :fetcher gitlab
-                    :files ("use-package-hydra.el"))
+                    :fetcher gitlab)

--- a/recipes/use-package-hydra
+++ b/recipes/use-package-hydra
@@ -1,0 +1,3 @@
+(use-package-hydra :repo "to1ne/use-package-hydra"
+                    :fetcher gitlab
+                    :files ("use-package-hydra.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`use-package-hydra` is the glue between use-package and hydra. It adds
the `:hydra` keyword support to the `(use-package)` macro.

### Direct link to the package repository

https://gitlab.com/to1ne/use-package-hydra

### Your association with the package

I'm the original author of the package.

### Relevant communications with the upstream package maintainer

None needed. 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

#### package-lint

2 issues I could not fix cause of the naming conventions in `use-package` core.

```
79:1: error: "use-package-handler/:hydra" doesn't start with package's prefix "use-package-hydra".
79:1: error: `use-package-handler/:hydra' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions).
```
