### PR TITLE
add biblio-bibsonomy package

### DIFF
--- a/recipes/biblio-bibsonomy
+++ b/recipes/biblio-bibsonomy
@@ -1,0 +1,3 @@
+(biblio-bibsonomy
+ :fetcher github
+ :repo "andreasjansson/biblio-bibsonomy.el")


### PR DESCRIPTION
### Brief summary of what the package does

[Bibsonomy](https://www.bibsonomy.org/) backend for [biblio.el](https://melpa.org/#/biblio)

### Direct link to the package repository

https://github.com/andreasjansson/biblio-bibsonomy.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
