### PR TITLE
Remove obsolete lsp-clangd and lsp-python

### DIFF
--- a/recipes/lsp-clangd
+++ b/recipes/lsp-clangd
@@ -1,3 +1,0 @@
-(lsp-clangd
- :fetcher github
- :repo "emacs-lsp/lsp-clangd")

--- a/recipes/lsp-python
+++ b/recipes/lsp-python
@@ -1,1 +1,0 @@
-(lsp-python :repo "emacs-lsp/lsp-python" :fetcher github)


### PR DESCRIPTION
These packages are no longer needed when using `lsp-mode`'s `master` branch and they also fail to load because they require `lsp-common`, which no longer exists. However when installing from Melpa Stable, then they are probably still required, so we can't really remove them yet.

Maybe there should be a way to remove a package from Melpa but keep it in Melpa Stable?