### PR TITLE
Add recipe for org-journal-list

### DIFF
--- a/recipes/org-journal-list
+++ b/recipes/org-journal-list
@@ -1,0 +1,1 @@
+(org-journal-list :fetcher github :repo "huytd/org-journal-list")


### PR DESCRIPTION
### Brief summary of what the package does

This package help displaying a list of your org-notes with a brief preview, just like the UI of Evernote or any modern notetaking software nowaday.

### Direct link to the package repository

https://github.com/huytd/org-journal-list

### Your association with the package

I'm the creator/maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
