### PR TITLE
update literate-elisp recipe to include org file as source.

### DIFF
--- a/recipes/literate-elisp
+++ b/recipes/literate-elisp
@@ -1,1 +1,1 @@
-(literate-elisp :fetcher github :repo "jingtaozf/literate-elisp")
+(literate-elisp :fetcher github :repo "jingtaozf/literate-elisp" :files ("*.el" "*.org"))


### PR DESCRIPTION
### Brief summary of what the package does
a literate programming tool to load emacs lisp codes from org mode file directly

### Direct link to the package repository

https://github.com/jingtaozf/literate-elisp

### Your association with the package

author/maintainer

### Relevant communications with the upstream package maintainer

exist package


### Checklist

Please confirm with `x`:

- [X ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ X] My elisp byte-compiles cleanly
- [ X] `M-x checkdoc` is happy with my docstrings
- [ X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)