### PR TITLE
Split Git repository of right-click-context and region-convert

### DIFF
--- a/recipes/region-convert
+++ b/recipes/region-convert
@@ -1,4 +1,1 @@
-(region-convert
- :repo "zonuexe/right-click-context"
- :fetcher github
- :files ("region-convert.el"))
+(region-convert :fetcher github :repo "zonuexe/region-convert.el")

--- a/recipes/right-click-context
+++ b/recipes/right-click-context
@@ -1,4 +1,1 @@
-(right-click-context
- :repo "zonuexe/right-click-context"
- :fetcher github
- :files ("right-click-context.el"))
+(right-click-context :fetcher github :repo "zonuexe/right-click-context")


### PR DESCRIPTION
Fixes https://github.com/melpa/melpa/pull/5860#issuecomment-450284458

### Brief summary of what the package does

`region-convert` was a small function for `right-click-context`, so we shared the repository from the beginning. However, I have not posted `right-click-context` to MELPA until last month. Now both `region-convert` and `right-click-context` belong to MELPA, so the repository has been organized.

After this recipe is merged, `region-convert.el` in `right-click-context.git` is deleted.

refs #5860

### Direct link to the package repository

* https://github.com/zonuexe/region-convert.el
* https://github.com/zonuexe/right-click-context

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

 **None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
