### PR TITLE
Add ordinal recipe

### DIFF
--- a/recipes/ordinal
+++ b/recipes/ordinal
@@ -1,0 +1,1 @@
+(ordinal :fetcher github :repo "zonuexe/ordinal.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package simply provides conversion to English ordinal numbers. (ex. `1st`, `2nd`, `3rd`, `4th`… *Nth*)

### Direct link to the package repository

https://github.com/zonuexe/ordinal.el

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
