### PR TITLE
Deprecation of lsp-fortran

### DIFF
--- a/recipes/lsp-fortran
+++ b/recipes/lsp-fortran
@@ -1,0 +1,1 @@
+(lsp-fortran :repo "MagB93/lsp-fortran" :fetcher github)

--- a/recipes/lsp-fortran
+++ b/recipes/lsp-fortran
@@ -1,1 +1,0 @@
-(lsp-fortran :repo "MagB93/lsp-fortran" :fetcher github)


### PR DESCRIPTION
### Deprecation of [lsp-fortran](https://github.com/MagB93/lsp-fortran)

Due to [fortls support in lsp-mode](https://github.com/emacs-lsp/lsp-mode/pull/590) my previously added recipe can now be considered obsolete.


