### PR TITLE
Remove obsolete flycheck-purescript

### DIFF
--- a/recipes/flycheck-purescript
+++ b/recipes/flycheck-purescript
@@ -1,1 +1,0 @@
-(flycheck-purescript :fetcher github :repo "emacs-pe/flycheck-purescript")


### PR DESCRIPTION
I no longer maintain this package, and it has grown obsolete

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
