### PR TITLE
fix creole recipe

### DIFF
--- a/recipes/creole
+++ b/recipes/creole
@@ -1,1 +1,1 @@
-(creole :fetcher github :repo "nicferrier/elwikicreole" :files ("creole.el"))
+(creole :fetcher github :repo "nicferrier/elwikicreole")


### PR DESCRIPTION
I am developing a new package manager named [feather.el](https://github.com/conao3/feather.el), and I'm using MELPA's recipe as its recipe. ([feather-recipes](https://github.com/conao3/feather-recipes))

In the process, I check all the recipes especially for the `:file` option.

If delete specify detailed specifications for the recipe, the recipe JSON file will be smaller and reduce internal process, I think that my package will run faster.
If there is no problem, please merge it.

### MELPA doc
>:files optional property specifying the elisp and info files used to build the package. Please do not override this if the default value (below) is adequate, which it should usually be:
```
  ("*.el" "*.el.in" "dir"
   "*.info" "*.texi" "*.texinfo"
   "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
   (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el"))
```

### Direct link to the package repository

https://github.com/nicferrier/elwikicreole

### Your association with the package

volunteer

### Checklist
Please confirm with `x`:

*(As this PR is a modification of existing recipe, check all the checklists below)*

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
