### PR TITLE
Add flow-js2-mode

### DIFF
--- a/recipes/flow-js2-mode
+++ b/recipes/flow-js2-mode
@@ -1,0 +1,2 @@
+(flow-js2-mode :repo "Fuco1/flow-js2-mode" :fetcher github)
+

--- a/recipes/flow-js2-mode
+++ b/recipes/flow-js2-mode
@@ -1,2 +1,1 @@
-(flow-js2-mode :repo "Fuco1/flow-js2-mode" :fetcher github)
-
+(flow-js2-mode :repo "Fuco1/flow-js2-mode" :fetcher github :files ("flow-js2-mode.el"))


### PR DESCRIPTION
Add flow-js2-mode

### Brief summary of what the package does

Major mode supporting flow type annotations in JavaScript.

### Direct link to the package repository

https://github.com/Fuco1/flow-js2-mode

### Your association with the package

I'm a user

### Relevant communications with the upstream package maintainer

https://github.com/Fuco1/flow-js2-mode/issues/19

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)