### PR TITLE
Add org-d20 recipe

### DIFF
--- a/recipes/org-d20
+++ b/recipes/org-d20
@@ -1,0 +1,1 @@
+(org-d20 :fetcher git :url "https://git.spwhitton.name/org-d20")


### PR DESCRIPTION
### Brief summary of what the package does

Minor mode for for GMs running tabletop roleplaying games whose rules centre around rolling d20s

### Direct link to the package repository

https://git.spwhitton.name/org-d20

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings

- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
