### PR TITLE
Add double-saber

### DIFF
--- a/recipes/double-saber
+++ b/recipes/double-saber
@@ -1,0 +1,2 @@
+(double-saber :fetcher github :repo "dp12/double-saber")
+

--- a/recipes/parrot
+++ b/recipes/parrot
@@ -1,0 +1,4 @@
+(parrot
+ :fetcher github
+ :repo "dp12/parrot"
+ :files ("parrot.el" "party-parrot.el" "img"))


### PR DESCRIPTION
### Brief summary of what the package does
double-saber is used to filter out unwanted search output by narrowing or deleting with regular expressions. 

At the same time, it preserves parts of the search output buffer such as the search command.

### Direct link to the package repository

https://github.com/dp12/double-saber

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
