### PR TITLE
Add nix-company recipe

### DIFF
--- a/recipes/nix-company
+++ b/recipes/nix-company
@@ -1,0 +1,2 @@
+(nix-company :repo "NixOS/nix-mode" :fetcher github
+             :files ("nix-company.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds a `company` backend for `nix` files.

### Direct link to the package repository

https://github.com/NixOS/nix-mode

### Your association with the package

 An enthusiastic user.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)