### PR TITLE
Update caml recipe

### DIFF
--- a/recipes/caml
+++ b/recipes/caml
@@ -1,3 +1,1 @@
-(caml :fetcher github
- :repo "ocaml/ocaml"
- :files ("emacs/*.el"))
+(caml :repo "ocaml/caml-mode" :fetcher github)


### PR DESCRIPTION
In https://github.com/ocaml/ocaml/pull/2182 the Emacs package `caml`
providing `caml-mode` was moved from the `ocaml/ocaml` repository to an
independent repository `ocaml/caml-mode`. This commit updates the Melpa
package to point to the new location.

### Brief summary of what the package does

The `caml` package provides an Emacs mode for the OCaml language.

### Direct link to the package repository

https://github.com/ocaml/caml-mode

### Your association with the package

Enthusiastic user.

### Relevant communications with the upstream package maintainer

This [comment](https://github.com/ocaml/ocaml/pull/2182#issuecomment-444196492) on the PR which moved the location of the package indicated that Melpa would get updated, but this did not happen.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- ~~[ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback~~
- ~~[ ] My elisp byte-compiles cleanly~~
- [x] `M-x checkdoc` is happy with my docstrings (mostly, given https://github.com/ocaml/caml-mode/pull/3)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

I am simply updating the location of the package in accordance to what its maintainers did. This package already exists in Melpa, so I assume a few of the last checklist items are not necessary from me.