### PR TITLE
Delete tern-django recipe.

### DIFF
--- a/recipes/tern-django
+++ b/recipes/tern-django
@@ -1,4 +1,0 @@
-(tern-django
- :fetcher github
- :repo "proofit404/tern-django"
- :files ("*.el" "*.py" (:exclude "setup.py")))


### PR DESCRIPTION
`tern-django` was unmaintained for a while. It is an insecure broken package. I decide to remove it since no community interest occurs for a few years.