### PR TITLE
Remove deprecated lsp-ruby package

### DIFF
--- a/recipes/lsp-ruby
+++ b/recipes/lsp-ruby
@@ -1,3 +1,0 @@
-(lsp-ruby
- :fetcher github
- :repo "emacs-lsp/lsp-ruby")


### PR DESCRIPTION
README from the github repo reads that the package is deprecated, as lsp-mode
supports ruby out of the box. The presence in the package list is confusing.

### Brief summary of what the package does

```markdown
# DEPRECATED

You do not need this package anymore! Just use `lsp-mode` directly. Read [the docs](https://github.com/emacs-lsp/lsp-mode/#configuration).

tl;dr:
```

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-ruby

### Your association with the package

User

### Relevant communications with the upstream package maintainer

//cc @gpittarelli

### Checklist

N/A

