### PR TITLE
Remove all deprecated lsp packages whose functionality is part of lsp

### DIFF
--- a/recipes/lsp-clangd
+++ b/recipes/lsp-clangd
@@ -1,3 +1,0 @@
-(lsp-clangd
- :fetcher github
- :repo "emacs-lsp/lsp-clangd")

--- a/recipes/lsp-css
+++ b/recipes/lsp-css
@@ -1,3 +1,0 @@
-(lsp-css
- :fetcher github
- :repo "emacs-lsp/lsp-css")

--- a/recipes/lsp-dart
+++ b/recipes/lsp-dart
@@ -1,3 +1,0 @@
-(lsp-dart
- :fetcher github
- :repo "twlz0ne/lsp-dart")

--- a/recipes/lsp-fortran
+++ b/recipes/lsp-fortran
@@ -1,1 +1,0 @@
-(lsp-fortran :repo "MagB93/lsp-fortran" :fetcher github)

--- a/recipes/lsp-go
+++ b/recipes/lsp-go
@@ -1,1 +1,0 @@
-(lsp-go :repo "emacs-lsp/lsp-go" :fetcher github)

--- a/recipes/lsp-html
+++ b/recipes/lsp-html
@@ -1,3 +1,0 @@
-(lsp-html
- :fetcher github
- :repo "emacs-lsp/lsp-html")

--- a/recipes/lsp-javascript-typescript
+++ b/recipes/lsp-javascript-typescript
@@ -1,4 +1,0 @@
-(lsp-javascript-typescript
- :fetcher github
- :repo "emacs-lsp/lsp-javascript"
- :files ("lsp-javascript-typescript.el"))

--- a/recipes/lsp-ocaml
+++ b/recipes/lsp-ocaml
@@ -1,1 +1,0 @@
-(lsp-ocaml :repo "emacs-lsp/lsp-ocaml" :fetcher github)

--- a/recipes/lsp-php
+++ b/recipes/lsp-php
@@ -1,1 +1,0 @@
-(lsp-php :repo "emacs-lsp/lsp-php" :fetcher github)

--- a/recipes/lsp-python
+++ b/recipes/lsp-python
@@ -1,1 +1,0 @@
-(lsp-python :repo "emacs-lsp/lsp-python" :fetcher github)

--- a/recipes/lsp-ruby
+++ b/recipes/lsp-ruby
@@ -1,3 +1,0 @@
-(lsp-ruby
- :fetcher github
- :repo "emacs-lsp/lsp-ruby")

--- a/recipes/lsp-rust
+++ b/recipes/lsp-rust
@@ -1,1 +1,0 @@
-(lsp-rust :repo "emacs-lsp/lsp-rust" :fetcher github)

--- a/recipes/lsp-sh
+++ b/recipes/lsp-sh
@@ -1,1 +1,0 @@
-(lsp-sh :repo "emacs-lsp/lsp-sh" :fetcher github)

--- a/recipes/lsp-typescript
+++ b/recipes/lsp-typescript
@@ -1,4 +1,0 @@
-(lsp-typescript
- :fetcher github
- :repo "emacs-lsp/lsp-javascript"
- :files ("lsp-typescript.el"))

--- a/recipes/lsp-vue
+++ b/recipes/lsp-vue
@@ -1,1 +1,0 @@
-(lsp-vue :repo "emacs-lsp/lsp-vue" :fetcher github)


### PR DESCRIPTION
All the packages are now part of _lsp-mode_ itself. Most of them even mention it in the README.

Superseedes #5971 and #5894

Left are:

* lsp-hack
* lsp-intellij
* lsp-javacomp
* lsp-haskell
* lsp-java
* lsp-javascript-flow
* lsp-p4

### Brief summary of what the package does

Example:

```markdown
# DEPRECATED

You do not need this package anymore! Just use `lsp-mode` directly. Read [the docs](https://github.com/emacs-lsp/lsp-mode/#configuration).

tl;dr:
```

### Direct link to the package repository

https://github.com/emacs-lsp
* lsp-clangd
* lsp-css
* lsp-dart
* lsp-fortran
* lsp-go
* lsp-html
* lsp-javascript-typescript
* lsp-ocaml
* lsp-php
* lsp-python
* lsp-ruby
* lsp-rust
* lsp-sh
* lsp-typescript
* lsp-vue

### Your association with the package

User

### Relevant communications with the upstream package maintainer

//cc @gpittarelli

### Checklist

N/A

