### PR TITLE
Added a package file for poet-client

### DIFF
--- a/recipes/poet-client
+++ b/recipes/poet-client
@@ -1,0 +1,1 @@
+(poet-client :repo "wailo/emacs-poet" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs client for po.et. A decentralized protocol for content ownership, discovery and monetization in media.

### Direct link to the package repository

https://github.com/wailo/emacs-poet

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)