### PR TITLE
[slime] [update recipe] Exclude contrib/{test, Makefile}

### DIFF
--- a/recipes/slime
+++ b/recipes/slime
@@ -5,8 +5,8 @@
                "swank"
                "*.lisp"
                "*.asd"
-               "contrib" "contrib/*"
-               (:exclude "contrib/test")
+               ("contrib" "contrib/*")
+               (:exclude "contrib/test" "contrib/Makefile")
                "doc/slime.texi"
                "doc/slime.info"
                "doc/dir"


### PR DESCRIPTION
Mon Jan 14 00:37:58 GMT 2019

### Direct link to the package repository

https://github.com/slime/slime

### Your association with the package

[A user]

### Relevant communications with the upstream package maintainer

See https://github.com/slime/slime/issues/484

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
