### PR TITLE
Document requirement for GPL compatible licenses

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -90,6 +90,9 @@ New recipe submissions should adhere to the following guidelines:
      update the README at the old location with a link to the new
      location.
 
+- GPL compatible license :: The package is released under a 
+     [[https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses][GPL-Compatible Free Software License]].
+
 ** Making your package ready for inclusion
 
 MELPA maintainers control the quality of each recipe and associated


### PR DESCRIPTION
I was looking at the contributing requirements and noticed that the requirement to have a GPL compatible license was in the PR template, but not in the CONTRIBUTING file. I didn't have any firm details on the background of this, so I left it pretty minimal, but a maintainer might want to add more context to this requirement.