### PR TITLE
Add new recipe named elscreen-tab

### DIFF
--- a/recipes/elscreen-tab
+++ b/recipes/elscreen-tab
@@ -1,0 +1,1 @@
+(elscreen-tab :fetcher github :repo "aki-s/elscreen-tab")


### PR DESCRIPTION
### Brief summary of what the package does

- Show the dedicated buffer for `elscreen` (This can be alternaitve to `(setq elscreen-display-tab t)`.).
  - Existing `tab` of `elscreen` use `header-line-format` but using this is not preferable because;
    - The header may already be used for the other purpose (e.g. `which-func-mode`)
    - The same buffer shows the same header to show tabs of `elscreen` (e.g. When the buffer showing `tab`s is split with `C-x 3`.).

### Direct link to the package repository

https://github.com/aki-s/elscreen-tab

### Your association with the package

- Are you the maintainer? => Yes
- A contributor? => Yes
- An enthusiastic user? => Yes. I've created this mode and it's almost 2 years past since the first version.
I've fostered this mode by myself. I felt I can make public now.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback `  
<- I want to use : as a separator for namespace..., because - is ambiguous delimiter. -- is for *private* method by contract, so what shall I use...`
- [x] My elisp byte-compiles cleanly
- [△] `M-x checkdoc` is happy with my docstrings `  
<- I have omitted comment for private function such as elscreen-tab:--set-position.  
<-  I also did not added keyword function or variable for word quoted with \`', because it is not actually ambiguous. If I add keyword, then sentence becomes redundant or unclear.`
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
