### PR TITLE
Add recipe for treemacs-magit.

### DIFF
--- a/recipes/treemacs-magit
+++ b/recipes/treemacs-magit
@@ -1,0 +1,4 @@
+(treemacs-magit
+ :fetcher github
+ :repo "Alexander-Miller/treemacs"
+ :files ("src/extra/treemacs-magit.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package will use some of magit's hooks to inform treemacs about (un)staging of files and commits happening in magit. Normally treemacs would not know this is happening, so its git highlighting would become out of date with the files' actual states.

### Direct link to the package repository

https://github.com/Alexander-Miller/treemacs
https://github.com/Alexander-Miller/treemacs/blob/master/src/extra/treemacs-magit.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
