### PR TITLE
Add recipe for keystore-mode

### DIFF
--- a/recipes/keystore-mode
+++ b/recipes/keystore-mode
@@ -1,0 +1,4 @@
+(keystore-mode
+ :repo "peterpaul/keystore-mode"
+ :fetcher github
+ :files ("*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a major mode based on `tabulated-list` for viewing and editing jks and pkcs12 keystores using the `keytool` command.

### Direct link to the package repository

https://github.com/peterpaul/keystore-mode

### Your association with the package

I am the author/maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
