### PR TITLE
Add language-id recipe

### DIFF
--- a/recipes/language-id
+++ b/recipes/language-id
@@ -1,0 +1,1 @@
+(language-id :fetcher github :repo "lassik/emacs-language-id")


### PR DESCRIPTION
### Brief summary of what the package does

*language-id* is a small, focused library that helps other Emacs packages identify the programming languages and markup languages used in Emacs buffers. The main point is that it contains an evolving table of language definitions that doesn't need to be replicated in other packages.

Right now there is only one public function, *language-id-buffer*. It looks at the major mode and other variables and returns the language's GitHub Linguist identifier. We can add support for other kinds of identifiers if there is demand.

This library does not do any statistical text matching to guess the language.

### Direct link to the package repository

https://github.com/lassik/emacs-language-id

### Your association with the package

Just wrote it ;-)

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
