### PR TITLE
Add recipe for org-re-reveal

### DIFF
--- a/recipes/org-re-reveal
+++ b/recipes/org-re-reveal
@@ -1,0 +1,4 @@
+(org-re-reveal
+ :repo "oer/org-re-reveal"
+ :fetcher gitlab
+ :files (:defaults "LICENSES" "Readme.org" "local.css" "images"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a maintained fork of org-reveal, which is no longer maintained. As such, it provides Org export functionality to generate HTML presentations with the presentation framework reveal.js.

See PR #5979 for background and naming, which I'll close in a minute.

### Direct link to the package repository

https://gitlab.com/oer/org-re-reveal

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

Currently not possible.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
