### PR TITLE
add novels.org

### DIFF
--- a/recipes/novels.org
+++ b/recipes/novels.org
@@ -1,0 +1,2 @@
+(novels.org :repo "eubarbosa/novels.org"
+:fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Random classic novels ported to org format. 

### Direct link to the package repository

https://github.com/eubarbosa/novels.org

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
