### PR TITLE
Add recipies for pretty-hydra and major-mode-hydra

### DIFF
--- a/recipes/major-mode-hydra
+++ b/recipes/major-mode-hydra
@@ -1,0 +1,3 @@
+(major-mode-hydra :repo "jerrypnz/major-mode-hydra.el"
+                  :fetcher github
+                  :files ("major-mode-hydra.el"))

--- a/recipes/pretty-hydra
+++ b/recipes/pretty-hydra
@@ -1,0 +1,3 @@
+(pretty-hydra :repo "jerrypnz/major-mode-hydra.el"
+              :fetcher github
+              :files ("pretty-hydra.el"))


### PR DESCRIPTION
### Brief summary of what the package does

- `pretty-hydra`: provides a macro to define fancy hydras easily
- `major-mode-hydra`: spacemacs style major mode leader keys powered by hydra (it depends on `pretty-hydra`)

### Direct link to the package repository

https://github.com/jerrypnz/major-mode-hydra.el

### Your association with the package

creator

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
