### PR TITLE
add org-sql recipe

### DIFF
--- a/recipes/org-sql
+++ b/recipes/org-sql
@@ -1,0 +1,1 @@
+(org-sql :repo "ndwarshuis/org-sql" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`org-sql` parses/converts org files to tabular data and inserts it into a SQL database

### Direct link to the package repository

https://github.com/ndwarshuis/org-sql

### Your association with the package

I am the author and maintainer

### Relevant communications with the upstream package maintainer

none needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
