### PR TITLE
add ammonite-term-repl

### DIFF
--- a/recipes/ammonite-term-repl
+++ b/recipes/ammonite-term-repl
@@ -1,0 +1,2 @@
+(ammonite-term-repl :fetcher github
+                    :repo "zwild/ammonite-term-repl")


### PR DESCRIPTION
### Brief summary of what the package does

Scala Ammonite REPL in Emacs term mode

### Direct link to the package repository

https://github.com/zwild/ammonite-term-repl

### Your association with the package

I'm the creator of this package

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
