### PR TITLE
Add recipe for org-re-reveal-ref

### DIFF
--- a/recipes/org-re-reveal-ref
+++ b/recipes/org-re-reveal-ref
@@ -1,0 +1,4 @@
+(org-re-reveal-ref
+ :repo "oer/org-re-reveal-ref"
+ :fetcher gitlab
+ :files (:defaults "LICENSES" "README.org" "references.bib"))


### PR DESCRIPTION
### Brief summary of what the package does

This package extends `org-re-reveal` with support for a bibliography slide based on package `org-ref`.  Thus, `cite`commands of `org-ref` are translated into hyperlinks to the bibliography slide upon export by `org-re-reveal`.  Also, export to PDF via LaTeX with Org's usual export functionality works.

I created a separate package for this as `org-ref` has lots of dependencies, which I do not want to force upon users of `org-re-reveal`.

### Direct link to the package repository

https://gitlab.com/oer/org-re-reveal-ref

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
