### PR TITLE
add dired-rmshit

### DIFF
--- a/recipes/dired-rmjunk
+++ b/recipes/dired-rmjunk
@@ -1,0 +1,1 @@
+(dired-rmjunk :url "https://git.sr.ht/~jakob/dired-rmjunk" :fetcher git)

--- a/recipes/dired-rmshit
+++ b/recipes/dired-rmshit
@@ -1,1 +1,0 @@
-(dired-rmshit :url "https://git.sr.ht/~jakob/dired-rmshit" :fetcher git)

--- a/recipes/dired-rmshit
+++ b/recipes/dired-rmshit
@@ -1,0 +1,1 @@
+(dired-rmshit :url "https://git.sr.ht/~jakob/dired-rmshit" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

The interactive function, `dired-rmshit` will mark all files in the current Dired buffer that match one of the patterns specified in `dired-rmshit-shitty-files`. The tool is intended as a simple means for keeping one's home directory tidy -- removing "junk" dotfiles.

### Direct link to the package repository

https://git.sr.ht/~jakob/dired-rmshit

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
