### PR TITLE
Add nswbuff recipe.

### DIFF
--- a/recipes/nswbuff
+++ b/recipes/nswbuff
@@ -1,4 +1,3 @@
 (nswbuff
  :fetcher github
- :repo "joostkremers/nswbuff"
- :url "https://github.com/joostkremers/nswbuff")
+ :repo "joostkremers/nswbuff")

--- a/recipes/nswbuff
+++ b/recipes/nswbuff
@@ -1,0 +1,4 @@
+(nswbuff
+ :fetcher github
+ :repo "joostkremers/nswbuff"
+ :url "https://github.com/joostkremers/nswbuff")


### PR DESCRIPTION
### Brief summary of what the package does

Quick buffer switching.

This package is based on [`swbuff.el`](https://www.emacswiki.org/emacs/SwBuff), incorporating the changes from [`swbuff-x.el`](https://www.emacswiki.org/emacs/swbuff-x.el) with some additions of my own.


### Direct link to the package repository

https://github.com/joostkremers/nswbuff


### Your association with the package

I'm the maintainer of this package. 


### Relevant communications with the upstream package maintainer

Note that the bulk of the code was written by others (`swbuff.el` by David Ponce, `swbuff-x.el` by Kahlil Hodgson), but both of these files haven't been updated since 2003. I merged them, removing everything from `swbuff.el` that was overwritten by `swbuff-x.el`, changed relevant `defvar`s to `defcustom`s (mainly from `swbuff-x.el`), made one or two internal changes and added integration with [`projectile`](https://github.com/bbatsov/projectile).

I have not tried to contact the original authors, because I did not see any need to, but I would of course be happy to do so if you consider it necessary.


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
