### PR TITLE
Add recipe for arc-dark-theme

### DIFF
--- a/recipes/arc-dark-theme
+++ b/recipes/arc-dark-theme
@@ -1,0 +1,3 @@
+(arc-dark-theme
+ :repo "cfraz89/arc-dark-theme"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
Provides a theme to emacs matching the arc-dark gtk theme

### Direct link to the package repository
https://github.com/cfraz89/arc-dark-theme

### Your association with the package
Mantainer

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist
- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
