### PR TITLE
Add recipe for use-package-company

### DIFF
--- a/recipes/use-package-company
+++ b/recipes/use-package-company
@@ -1,0 +1,2 @@
+(use-package-company :repo "foltik/use-package-company" :fetcher github)
+


### PR DESCRIPTION
### Brief summary of what the package does

Adds the keyword `:company` to `use-package`, which simplifies the process of adding 
mode-specific `company` backends.

Examples shown in [README.md](https://github.com/Foltik/use-package-company/blob/master/README.md)

### Direct link to the package repository

https://github.com/foltik/use-package-company

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
