### PR TITLE
Add jupyter recipe

### DIFF
--- a/recipes/jupyter
+++ b/recipes/jupyter
@@ -1,0 +1,4 @@
+(jupyter
+ :fetcher github
+ :repo "dzop/emacs-jupyter"
+ :files (:defaults "Makefile" "widget.html" "js"))


### PR DESCRIPTION
### Brief summary of what the package does

An interface for communicating with Jupyter kernels that currently has a REPL frontend and `org-mode` src-block frontend.

### Direct link to the package repository

https://github.com/dzop/emacs-jupyter

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)