### PR TITLE
Add magit-reviewboard

### DIFF
--- a/recipes/magit-reviewboard
+++ b/recipes/magit-reviewboard
@@ -1,0 +1,1 @@
+(magit-reviewboard :fetcher github :repo "jtamagnan/magit-reviewboard")


### PR DESCRIPTION
### Brief summary of what the package does

This package aims to integrate the ReviewBoard review software into magit the Emacs Git interface. It inserts a list of all open review-requests for the repository in the Magit status buffer.

### Direct link to the package repository

https://github.com/jtamagnan/magit-reviewboard

### Your association with the package

I am the maintainer and auther

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)