### PR TITLE
add recipe org-pretty-tags

### DIFF
--- a/recipes/org-pretty-tags
+++ b/recipes/org-pretty-tags
@@ -1,3 +1,2 @@
 (org-pretty-tags :repo "marcowahl/org-pretty-tags"
-           :fetcher gitlab
-           :files ("org-pretty-tags.el"))
+           :fetcher gitlab)

--- a/recipes/org-pretty-tags
+++ b/recipes/org-pretty-tags
@@ -1,0 +1,3 @@
+(org-pretty-tags :repo "marcowahl/org-pretty-tags"
+           :fetcher gitlab
+           :files ("org-pretty-tags.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Display text or image surrogates for org mode tags.

### Direct link to the package repository

https://gitlab.com/marcowahl/org-pretty-tags

### Your association with the package

maintainer, contributor, user

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
