### PR TITLE
ADD/urscript-mode: major mode for URScript by universal-robots.com

### DIFF
--- a/recipes/urscript-mode
+++ b/recipes/urscript-mode
@@ -1,0 +1,1 @@
+(urscript-mode :fetcher github :repo "guidoschmidt/urscript-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A simple major mode for syntax highlighting of URScript, which can be used to program Universal Robots robotic arms. Details can be found in the [URScript Manual](https://s3-eu-west-1.amazonaws.com/ur-support-site/46196/scriptManual.pdf)

### Direct link to the package repository

https://github.com/guidoschmidt/urscript-mode

### Your association with the package

I created that package to have at least some syntax highlighting while working on URScripts.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
