### PR TITLE
Add ox-rfc package recipe.

### DIFF
--- a/recipes/ox-rfc
+++ b/recipes/ox-rfc
@@ -1,0 +1,1 @@
+(ox-rfc :fetcher github :repo "choppsv1/org-rfc-export")


### PR DESCRIPTION
### Brief summary of what the package does

Adds support for generating internet drafts written using Org mode.

### Direct link to the package repository

https://github.com/choppsv1/org-rfc-export

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

I cannot avoid the package-lint errors "org-rfc" vs. "ox-rfc". The Org package expects the back-end functions and variables to be named "org-<backend>" and also by convention the exporting backends are named "ox-<backend>".

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
