### PR TITLE
Add ivy-omni-org

### DIFF
--- a/recipes/ivy-omni-org
+++ b/recipes/ivy-omni-org
@@ -1,0 +1,1 @@
+(ivy-omni-org :repo "akirak/ivy-omni-org" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Unified Ivy interface to access Org buffers, Org files, and Org bookmarks

### Direct link to the package repository

https://github.com/akirak/ivy-omni-org

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
