### PR TITLE
Add org-recur

### DIFF
--- a/recipes/org-recur
+++ b/recipes/org-recur
@@ -1,0 +1,1 @@
+(org-recur :fetcher github :repo "m-cat/org-recur")


### PR DESCRIPTION
### Brief summary of what the package does

This package extends org-mode and org-agenda with support for defining recurring tasks.

### Direct link to the package repository

https://github.com/m-cat/org-recur

### Your association with the package

I'm the creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed*

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
