### PR TITLE
Add Emacs reveal

### DIFF
--- a/recipes/emacs-reveal
+++ b/recipes/emacs-reveal
@@ -1,0 +1,5 @@
+(emacs-reveal
+ :repo "oer/emacs-reveal"
+ :branch "melpa"
+ :fetcher gitlab
+ :files (:defaults "org-reveal" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))

--- a/recipes/emacs-reveal
+++ b/recipes/emacs-reveal
@@ -2,4 +2,4 @@
  :repo "oer/emacs-reveal"
  :branch "melpa"
  :fetcher gitlab
- :files (:defaults "org-reveal" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))
+ :files (:defaults "README*" "LICENSE*" "org-reveal" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))

--- a/recipes/emacs-reveal
+++ b/recipes/emacs-reveal
@@ -1,5 +1,4 @@
 (emacs-reveal
  :repo "oer/emacs-reveal"
- :branch "melpa"
  :fetcher gitlab
- :files (:defaults "README*" "LICENSE*" "org-reveal" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))
+ :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))

--- a/recipes/emacs-reveal
+++ b/recipes/emacs-reveal
@@ -1,4 +1,4 @@
 (emacs-reveal
  :repo "oer/emacs-reveal"
  :fetcher gitlab
- :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))
+ :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide"))


### PR DESCRIPTION
### Brief summary of what the package does

The software emacs-reveal allows to create HTML presentations (with audio explanations if you wish) with reveal.js from Org mode files in GNU Emacs with org-re-reveal (a fork of org-reveal) and several reveal.js plugins. Generated presentations are usable with standard browsers, also mobile and offline.

This is a continuation of PR #5901. Compared to that PR, reveal.js and its submodules have now been moved to a separate repository. Also, org-reveal has turned into org-re-reveal. Its extension org-re-reveal-ref is a required package for emacs-reveal.

### Direct link to the package repository

https://gitlab.com/oer/emacs-reveal

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 It claims that I need Emacs 25, which I don't need as explained in comments underneath my Package-Requires header.
- [x] My elisp byte-compiles cleanly
 There are warnings about obsolete functions, which are not used.
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
