### PR TITLE
Add recipe for pytest-pdb-break

### DIFF
--- a/recipes/pytest-pdb-break
+++ b/recipes/pytest-pdb-break
@@ -1,0 +1,6 @@
+(pytest-pdb-break
+ :fetcher github
+ :repo "poppyschmo/pytest-pdb-break"
+ :files ("emacs/*.el"
+         ("lib" "*.py" "helpers" ("emacs" "emacs/*.py"))
+         (:exclude "emacs/*-test.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Pytest is popular testing framework for Python. This package provides a single command that teleports the user into the pytest debugger, breaking at the line from which it was invoked. It respects the built-in `python.el` API.

### Direct link to the package repository

https://github.com/poppyschmo/pytest-pdb-break/tree/master
[![Build Status](https://travis-ci.com/poppyschmo/pytest-pdb-break.svg?branch=master)](https://travis-ci.com/poppyschmo/pytest-pdb-break)

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
