### PR TITLE
Add  jk-org2md-hexo package.

### DIFF
--- a/recipes/jk-org2md-hexo
+++ b/recipes/jk-org2md-hexo
@@ -1,0 +1,3 @@
+(jk-org2md-hexo 
+  :fetcher github
+  :repo "loveminimal/jk-org2md-hexo")


### PR DESCRIPTION
### Brief summary of `jk-org2md-hexo`

A package render `.org` to `.md` which can be rendered by HEXO. 

### Github Repo

https://github.com/loveminimal/jk-org2md-hexo

### About Me

Hello, I'm Jack Liu. 
I build it just for sloving the problem of org's rendering. Now, it make it easies.


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
