### PR TITLE
Move emacs-dashboard to it's own organization

### DIFF
--- a/recipes/dashboard
+++ b/recipes/dashboard
@@ -1,3 +1,3 @@
 (dashboard :fetcher github
-	   :repo "rakanalh/emacs-dashboard"
+	   :repo "emacs-dashboard/emacs-dashboard"
 	   :files (:defaults "banners"))


### PR DESCRIPTION
As part of giving up emacs-dashboard to the Emacs community, i have began the initial steps of moving the package to it's own organization. 

Many thanks Melpa Maintainers!