### PR TITLE
Added poly-rst recipe.

### DIFF
--- a/recipes/poly-rst
+++ b/recipes/poly-rst
@@ -1,0 +1,3 @@
+(poly-rst
+ :fetcher github
+ :repo "polymode/poly-rst")


### PR DESCRIPTION
### Brief summary of what the package does

This is a [polymode](https://polymode.github.io/) for working with files using the ReST markup syntax. The functionality it provides is similar to [poly-markdown](https://github.com/polymode/poly-markdown), in that regions marked with `code` syntax in ReST will use the appropriate Emacs major mode in those regions.

### Direct link to the package repository

https://github.com/polymode/poly-rst

### Your association with the package

I'm co-maintaining the package along with @vspinu.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


### Misc. Notes

Package-lint will complain about at least one variable, namely `pm-poly/rst`. This appears to be a convention within `polymode`, so I'm afraid that cannot be avoided right now at least.