### PR TITLE
Add eldoc-cmake

### DIFF
--- a/recipes/eldoc-cmake
+++ b/recipes/eldoc-cmake
@@ -1,4 +1,3 @@
 (eldoc-cmake
  :fetcher github
- :repo "ikirill/eldoc-cmake"
- :files ("eldoc-cmake.el"))
+ :repo "ikirill/eldoc-cmake")

--- a/recipes/eldoc-cmake
+++ b/recipes/eldoc-cmake
@@ -1,0 +1,4 @@
+(eldoc-cmake
+ :fetcher github
+ :repo "ikirill/eldoc-cmake"
+ :files ("eldoc-cmake.el"))


### PR DESCRIPTION
Support for eldoc when editing CMake files.

### Brief summary of what the package does

Add eldoc-documentation-function that understands CMake functions.

### Direct link to the package repository

https://github.com/ikirill/eldoc-cmake

### Your association with the package

I wrote it, it is a simple short one-file package, with hard-coded pre-extracted docstrings for CMake functions.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
