### PR TITLE
Add recipe for comment-or-uncomment-sexp mode

### DIFF
--- a/recipes/comment-or-uncomment-sexp
+++ b/recipes/comment-or-uncomment-sexp
@@ -1,0 +1,3 @@
+(comment-or-uncomment-sexp
+ :fetcher github
+ :repo "Malabarba/comment-or-uncomment-sexp")


### PR DESCRIPTION
Adds `comment-or-uncomment-sexp` which allows easy commenting and un-commenting of sexps.

### Brief summary of what the package does

The package allows easy commenting and un-commenting of sexps.

For more details see the blog post here, which even has an animated gif show how the mode works in practice: http://endlessparentheses.com/a-comment-or-uncomment-sexp-command.html

### Direct link to the package repository

https://github.com/Malabarba/comment-or-uncomment-sexp

### Your association with the package

An enthusiastic user.

### Relevant communications with the upstream package maintainer

The official author @Malabarba has posted this package after I've bugged him about it.
So he's fully aware that this is being submitted to MELPA.

### Checklist

**NOTE:** all confirmed.

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
