### PR TITLE
Update ruby-test-mode repository

### DIFF
--- a/recipes/ruby-test-mode
+++ b/recipes/ruby-test-mode
@@ -1,1 +1,1 @@
-(ruby-test-mode :fetcher github :repo "r0man/ruby-test-mode")
+(ruby-test-mode :fetcher github :repo "ruby-test-mode/ruby-test-mode")


### PR DESCRIPTION
The ruby-test-mode repository is going to move over here:

https://github.com/ruby-test-mode/ruby-test-mode

This PR updates the melpa recipe.

### Brief summary of what the package does

Emacs minor mode for Behaviour and Test Driven Development in Ruby

### Direct link to the package repository

https://github.com/ruby-test-mode/ruby-test-mode

### Your association with the package

I was the maintainer and I'm still a contributor.

### Relevant communications with the upstream package maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
