### PR TITLE
Add quilt package into melpa

### DIFF
--- a/recipes/quilt
+++ b/recipes/quilt
@@ -1,0 +1,1 @@
+(quilt :fetcher github :repo "jstranik/emacs-quilt")


### PR DESCRIPTION
I was surprised that quilt integration is missing in melpa. Then I
found only abandoned version of quilt code
https://www.emacswiki.org/emacs/Quilt. I did small enhancements and
published the version under a new location.

### Brief summary of what the package does

The package is an integration of quilt into emacs.

The quilt package enables convenient management of patches from 
emacs.

### Direct link to the package repository
https://github.com/jstranik/emacs-quilt.

### Your association with the package

I cloned an orphaned package and updated it to modern version of emacs. 
The package is also packaged as package.el package. 

### Relevant communications with the upstream package maintainer

**None Needed**
### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
