### PR TITLE
Update bbcode-mode GitHub URL

### DIFF
--- a/recipes/bbcode-mode
+++ b/recipes/bbcode-mode
@@ -1,1 +1,1 @@
-(bbcode-mode :fetcher github :repo "lassik/bbcode-mode")
+(bbcode-mode :fetcher github :repo "lassik/emacs-bbcode-mode")


### PR DESCRIPTION
I renamed my GitHub repo from `bbcode-mode` to `emacs-bbcode-mode`, i.e. added the `emacs-` prefix. No other changes.

### Direct link to the package repository

https://github.com/lassik/emacs-bbcode-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed