### PR TITLE
add nz-holidays recipe

### DIFF
--- a/recipes/nz-holidays
+++ b/recipes/nz-holidays
@@ -1,0 +1,3 @@
+(nz-holidays
+  :repo "techquila/nz-holidays"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
adds the NZ public holidays, including town anniversary days, for emacs calendar.  

### Direct link to the package repository

https://github.com/techquila/nz-holidays

### Your association with the package

contributor/maintainer/enthusiast

### Relevant communications with the upstream package maintainer

greetings upstream package maintainer.  I appreciate you.  here is a gift.  you may add it to your collection if you choose.  may good fortune smile upon you.

### Checklist

Please confirm with `x`:

- [x ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
