### PR TITLE
Oer reveal

### DIFF
--- a/recipes/emacs-reveal
+++ b/recipes/emacs-reveal
@@ -1,0 +1,5 @@
+(emacs-reveal
+ :repo "oer/emacs-reveal"
+ :branch "melpa"
+ :fetcher gitlab
+ :files (:defaults "org-reveal" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))

--- a/recipes/emacs-reveal
+++ b/recipes/emacs-reveal
@@ -2,4 +2,4 @@
  :repo "oer/emacs-reveal"
  :branch "melpa"
  :fetcher gitlab
- :files (:defaults "org-reveal" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))
+ :files (:defaults "README*" "LICENSE*" "org-reveal" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))

--- a/recipes/emacs-reveal
+++ b/recipes/emacs-reveal
@@ -1,5 +1,4 @@
 (emacs-reveal
  :repo "oer/emacs-reveal"
- :branch "melpa"
  :fetcher gitlab
- :files (:defaults "README*" "LICENSE*" "org-reveal" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))
+ :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))

--- a/recipes/emacs-reveal
+++ b/recipes/emacs-reveal
@@ -1,4 +1,4 @@
 (emacs-reveal
  :repo "oer/emacs-reveal"
  :fetcher gitlab
- :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide" "reveal.js" "reveal.js-plugins" "Reveal.js-TOC-Progress" "reveal.js-jump-plugin" "reveal.js-quiz"))
+ :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide"))

--- a/recipes/oer-reveal
+++ b/recipes/oer-reveal
@@ -1,0 +1,4 @@
+(oer-reveal
+ :repo "oer/oer-reveal"
+ :fetcher gitlab
+ :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide"))


### PR DESCRIPTION
### Brief summary of what the package does

This is a continuation of PR #6028. Changes requested there have been incorporated here (to be explained under PR #6028 shortly).

Package `oer-reveal` bundles resources for the creation of reveal.js presentations as Open Educational Resources (OER) from Org source files.  This package builds upon `org-re-reveal` for export from Org mode to HTML with reveal.js.  It provides help in installing and configuring reveal.js and several of its plugins.

### Direct link to the package repository

https://gitlab.com/oer/oer-reveal

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
It complains: "alist-get" doesn't start with package's prefix "oer-reveal". I added `alist-get` to allow the use of Emacs 24.4.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
