### PR TITLE
Return helm-words back

### DIFF
--- a/recipes/helm-words
+++ b/recipes/helm-words
@@ -1,0 +1,2 @@
+(helm-words :repo "pronobis/helm-words"
+            :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Customizable Helm extension for easy looking up words in various online/offline dictionaries and thesauri.

Refs:
- https://github.com/pronobis/helm-words/pull/2
- https://github.com/melpa/melpa/commit/cc53e7c

### Direct link to the package repository

https://github.com/pronobis/helm-words

### Your association with the package

I'm an enthusiastic user

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
