### PR TITLE
Reconstruct jk-org2md-hexo to org2md : )

### DIFF
--- a/recipes/jk-org2md-hexo
+++ b/recipes/jk-org2md-hexo
@@ -1,0 +1,3 @@
+(jk-org2md-hexo 
+  :fetcher github
+  :repo "loveminimal/jk-org2md-hexo")

--- a/recipes/jk-org2md-hexo
+++ b/recipes/jk-org2md-hexo
@@ -1,3 +1,0 @@
-(jk-org2md-hexo 
-  :fetcher github
-  :repo "loveminimal/jk-org2md-hexo")

--- a/recipes/org2md
+++ b/recipes/org2md
@@ -1,0 +1,3 @@
+(org2md
+  :fetcher github
+  :repo "loveminimal/org2md")


### PR DESCRIPTION
### Brief summary of what the package does

A package render `.org` to `.md` which could be rendered by HEXO. 

### Direct link to the package repository

https://github.com/loveminimal/org2md

### Your association with the package

I'm Jack LIU, the maintainer : )

### Relevant communications with the upstream package maintainer

`org2md` based on `ox-gfm`, and more powerful.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
