### PR TITLE
Move helm-pass to emacs-helm organization

### DIFF
--- a/recipes/helm-pass
+++ b/recipes/helm-pass
@@ -1,1 +1,1 @@
-(helm-pass :fetcher gitlab :repo "jabranham/helm-pass")
+(helm-pass :fetcher github :repo "emacs-helm/helm-pass")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs Helm interface for pass, the standard unix password manager 

### Direct link to the package repository

https://github.com/emacs-helm/helm-pass

### Your association with the package

I'm the new maintainer, see https://gitlab.com/jabranham/helm-pass/issues/13.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
