### PR TITLE
Add BNF Mode

### DIFF
--- a/recipes/bnf-mode
+++ b/recipes/bnf-mode
@@ -1,0 +1,2 @@
+(bnf-mode :repo "sergeyklay/bnf-mode"
+          :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A GNU Emacs major mode for editing BNF grammars. Currently provides basic syntax and font-locking for BNF files.

### Direct link to the package repository

https://github.com/sergeyklay/bnf-mode

### Your association with the package

Maintainer/Author

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
