### PR TITLE
Add recipe/colorless-themes

### DIFF
--- a/recipes/colorless-themes
+++ b/recipes/colorless-themes
@@ -1,0 +1,4 @@
+(colorless-themes
+  :fetcher git
+  :url "https://git.sr.ht/~lthms/colorless-themes.el"
+  :files ("colorless-themes.el"))


### PR DESCRIPTION
### Brief summary of what the package does

colorless-themes generalize, [nordless-theme](https://github.com/lthms/nordless-theme.el), a minimalist theme inspired by [nofrils](https://github.com/robertmeta/nofrils), an extremely minimalist colorscheme for vim, and [nord](https://github.com/arcticicestudio/nord), a north-bluish color palette.  More precisely, it provides a macro called `colorless-themes-make` to easily derive new “mostly colorless” themes.

### Direct link to the package repository

https://git.sr.ht/~lthms/colorless-themes.el

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

This PR is the first of a serie; I first add colorless-themes, which provide a generic macro to generate theme. Then, I will propose one PR per theme that I have generated using this macro.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)