### PR TITLE
Add catkin package for ROS compilation

### DIFF
--- a/recipes/catkin
+++ b/recipes/catkin
@@ -1,0 +1,4 @@
+(catkin
+ :fetcher github
+ :repo "gollth/catkin"
+ :branch "master")

--- a/recipes/catkin
+++ b/recipes/catkin
@@ -1,4 +1,3 @@
 (catkin
  :fetcher github
- :repo "gollth/catkin"
- :branch "master")
+ :repo "gollth/helm-catkin")


### PR DESCRIPTION
### Brief summary of what the package does
This package integrates the [catkin](http://wiki.ros.org/catkin) build tool for [ROS](http://ros.org) packages into Emacs. With it you can:

- Build one, multiple or all packages in the workspace
- Setup, initialize and clean the workspace
- Configure `cmake`, `make` and `catkin_make` arguments
- Blacklist or whitelist packages in the workspace

### Direct link to the package repository

https://github.com/gollth/catkin

### Your association with the package

Maintainer/Author/Main Requester =P

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


### Note
flycheck, package-lint and also the make file from Melpa give me warnings that my requires of "helm" and "xterm-color" are missing version numbers.

``` Package-Requires: ((emacs "24.3") helm xterm-color (cl-lib "0.5"))```

I understand this warning and tried to provide a "snapshot commit" to both (e.g. "201903015.35" or so) but this was again warned about I shall not do that. When I run `M-x  list-packages` I can only see these version however.

If this warning is a concern for your, please tell me who to find out which version of the packages I'm currently using. Thanks!