### PR TITLE
Add recipe for emacs-pubmed

### DIFF
--- a/recipes/pubmed
+++ b/recipes/pubmed
@@ -1,0 +1,3 @@
+(pubmed
+ :fetcher gitlab
+ :repo "fvdbeek/emacs-pubmed")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs-pubmed is a GNU Emacs interface to the [PubMed database](https://www.ncbi.nlm.nih.gov/pubmed/). It is in an early state of development and far from complete, but already usable.

### Direct link to the package repository

https://gitlab.com/fvdbeek/emacs-pubmed

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
