### PR TITLE
Include .nosearch in realgud recipe

### DIFF
--- a/recipes/realgud
+++ b/recipes/realgud
@@ -1,7 +1,7 @@
 (realgud
  :fetcher github
  :repo "realgud/realgud"
- :files ("realgud.el"
+ :files ("realgud.el" "realgud/.nosearch"
          ("realgud/common"             "realgud/common/*.el")
          ("realgud/common/buffer"      "realgud/common/buffer/*.el")
          ("realgud/debugger/bashdb"    "realgud/debugger/bashdb/*.el")


### PR DESCRIPTION
When using realgud together with subdirs.el it will include some
directories that should not be in the load-path, however they should be
part of the distribution.

Adding the .nosearch file will make realgud work together with site-lisp
which is what NixOS use for example.

See:
- https://github.com/realgud/realgud/issues/234
- https://github.com/NixOS/nixpkgs/issues/57622

### Direct link to the package repository

https://github.com/realgud/realgud

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

I suppose none needed.