### PR TITLE
Fix spelling on the Getting Started page

### DIFF
--- a/html/partials/getting-started.html
+++ b/html/partials/getting-started.html
@@ -58,7 +58,7 @@ There are two things you can do about this warning:
       <p>
         <strong>Note:</strong> <em>There are some problems using the
           <code>https</code> location with Emacs on Windows. There is
-          currently no know easy fix for this. You can still use MELPA
+          currently no known easy fix for this. You can still use MELPA
           by using the non-SSL location by replacing <code>https</code>
           with <code>http</code>.</em>
       </p>


### PR DESCRIPTION
Fixes a minor spelling mistake on the getting started web page.
