### PR TITLE
Add recipe for slime-repl-ansi-color

### DIFF
--- a/recipes/slime-repl-ansi-color
+++ b/recipes/slime-repl-ansi-color
@@ -1,0 +1,1 @@
+(slime-repl-ansi-color :fetcher gitlab :repo "augfab/slime-repl-ansi-color")


### PR DESCRIPTION
### Brief summary of what the package does

Turn on ANSI colors in [SLIME](https://melpa.org/#/slime) REPL output.

### Direct link to the package repository

https://gitlab.com/augfab/slime-repl-ansi-color

### Your association with the package

I am a user of this code snippet, which I had some trouble finding online and integrating into emacs when I started using SLIME.
Making it available on MELPA will make it easier for everyone to find and use it.

### Relevant communications with the upstream package maintainer

I haven't found a maintained version of this package, only copies of the original file to make it available.
Hence I will assume the role of maintainer for this package.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
