### PR TITLE
Add recipe for theme-magic

### DIFF
--- a/recipes/theme-magic
+++ b/recipes/theme-magic
@@ -1,0 +1,5 @@
+(theme-magic
+ :fetcher github
+ :repo "jcaw/theme-magic"
+ ;; Must explicitly download the python scripts folder
+ :files (:defaults "python"))


### PR DESCRIPTION
### Brief summary of what the package does

Theme-magic automatically applies the current Emacs theme to all your Linux terminals using [Pywal](https://github.com/dylanaraps/pywal), to create a cohesive color scheme across your desktop. (There's a demo gif in the readme, which may be clearer).

### Direct link to the package repository

https://github.com/jcaw/theme-magic

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
