### PR TITLE
In HTML5 the meta and link tags don't need a closing slash.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en-US">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <title>MELPA</title>
-  <meta name="description" lang="en" content="The largest and most up-to-date repository of Emacs packages."/>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-  <link rel="shortcut icon" href="favicon.ico" />
-  <link href="/updates.rss" rel="alternate" title="MELPA updates" type="application/rss+xml" />
+  <meta name="description" lang="en" content="The largest and most up-to-date repository of Emacs packages.">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <link rel="shortcut icon" href="favicon.ico">
+  <link href="/updates.rss" rel="alternate" title="MELPA updates" type="application/rss+xml">
   <!--[if lt IE 9]><script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7/html5shiv.min.js" type="text/javascript"></script><![endif]-->
   <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="css/melpa.css" type="text/css" />
+  <link rel="stylesheet" href="css/melpa.css" type="text/css">
 </head>
 <body>
   <header class="navbar navbar-fixed-top">

--- a/html/jslicense.html
+++ b/html/jslicense.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>MELPA</title>
-    <meta name="description" lang="en" content="The largest and most up-to-date repository of Emacs packages."/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <link rel="shortcut icon" href="favicon.ico" />
-    <link href="/updates.rss" rel="alternate" title="MELPA updates" type="application/rss+xml" />
+    <meta name="description" lang="en" content="The largest and most up-to-date repository of Emacs packages.">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <link rel="shortcut icon" href="favicon.ico">
+    <link href="/updates.rss" rel="alternate" title="MELPA updates" type="application/rss+xml">
     <!--[if lt IE 9]><script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7/html5shiv.min.js" type="text/javascript"></script><![endif]-->
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="css/melpa.css" type="text/css" />
+    <link rel="stylesheet" href="css/melpa.css" type="text/css">
     <style>
       #jslicense-labels1 td,th {
 	padding: 4px;


### PR DESCRIPTION
Minor fix to use HTML5 for the `meta` and `link` tags on the web pages.
