### PR TITLE
Add recipe for expand-region-subword

### DIFF
--- a/recipes/expand-region-subword
+++ b/recipes/expand-region-subword
@@ -1,0 +1,1 @@
+(expand-region-subword :repo "flatwhatson/expand-region-subword" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Plugin for expand-region subword-mode support.

### Direct link to the package repository

https://github.com/flatwhatson/expand-region-subword

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

This has been split from expand-region with @magnars blessing.

https://github.com/magnars/expand-region.el/commit/672e7c1842234f8c2d68bd98dc539e2180f69317#comments

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
