### PR TITLE
Add recipe for csproj-mode

### DIFF
--- a/recipes/csproj-mode
+++ b/recipes/csproj-mode
@@ -1,0 +1,4 @@
+(csproj-mode
+ :repo "omajid/csproj-mode"
+ :fetcher github
+ :files (:defaults "snippets"))


### PR DESCRIPTION
### Brief summary of what the package does

This packages provides a major mode called csproj-mode which tries to make it easier to work with .csproj and other *proj files used by msbuild and .NET Core.

### Direct link to the package repository

https://github.com/omajid/csproj-mode

### Your association with the package

I wrote and maintain this package

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - package-lint warned about using `eval-after-load`, but [several](https://github.com/nekop/yasnippet-java-mode/blob/6d0e2768823be27dbe07448f4cb244cd657a7136/java-snippets.el#L26) [other](https://github.com/Malabarba/aggressive-indent-mode/blob/master/aggressive-indent.el#L195) packages use this and I can't find a better way to do what I need to.
- [x] My elisp byte-compiles cleanly
 - I dont see any warnings when I run `byte-compile-file`. Is there something else I should use?
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
