### PR TITLE
Adopt counsel-gtags package

### DIFF
--- a/recipes/counsel-gtags
+++ b/recipes/counsel-gtags
@@ -1,1 +1,1 @@
-(counsel-gtags :fetcher github :repo "syohex/emacs-counsel-gtags")
+(counsel-gtags :fetcher github :repo "FelipeLema/emacs-counsel-gtags")


### PR DESCRIPTION
### Brief summary of what the package does

[Original counsel-gtags repo](https://github.com/syohex/emacs-counsel-gtags) seems abandoned. I've tried contacting the author through pull requests and mail without success

### Direct link to the package repository

https://github.com/FelipeLema/emacs-counsel-gtags

### Your association with the package

Maintainer of the fork.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
