### PR TITLE
Add a recipe for parseedn

### DIFF
--- a/recipes/parseedn
+++ b/recipes/parseedn
@@ -1,0 +1,1 @@
+(parseedn :repo "clojure-emacs/parseedn" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

An EDN parser/reader for Emacs. That's a follow up of #5258. Seem we forgot to add a recipe for the second package.

### Direct link to the package repository

https://github.com/clojure-emacs/parseedn

### Your association with the package

Co-maintainer. 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them (🤣 )
