### PR TITLE
Move Related package repository from Bitbucket to GitHub

### DIFF
--- a/recipes/related
+++ b/recipes/related
@@ -1,1 +1,1 @@
-(related :fetcher git :url "https://bitbucket.org/julien-montmartin/related")
+(related :fetcher github :repo "julien-montmartin/related")


### PR DESCRIPTION
Hello,

I'm moving my package from Bitbucket to GitHub. This is not a new package, but I need to update its recipe.

Please see on the old Bitbucket repo (https://bitbucket.org/julien-montmartin/related/src/master) my last commit "Moving to https://github.com/julien-montmartin/related" to be sure that I'm the real author of the package.

Best regards,

Julien