### PR TITLE
Add recipe for dash-docs

### DIFF
--- a/recipes/dash-docs
+++ b/recipes/dash-docs
@@ -1,0 +1,2 @@
+(dash-docs :repo "gilbertw1/dash-docs"
+                 :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The `dash-docs` package is the result of extracting the dash specific logic from `helm-dash`. This will allow dash documentation to be leverage from other packages such as `counsel-dash` without needing to require `helm` and helm specific logic.

There is a detailed issue containing information on this restructuring that you can find here: areina/helm-dash#173

### Direct link to the package repository

https://github.com/gilbertw1/dash-docs

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
