### PR TITLE
Add live-preview recipe

### DIFF
--- a/recipes/live-preview
+++ b/recipes/live-preview
@@ -1,0 +1,1 @@
+(live-preview :fetcher github :repo "lassik/emacs-live-preview")


### PR DESCRIPTION
### Brief summary of what the package does

Renders a live preview of whatever you are editing in a side window.

You can give any shell command or Emacs Lisp function to render the preview. The preview is rendered whenever you are idle for a few seconds. Different buffers can have different preview commands. There is only one global preview buffer; whenever you go idle in a buffer that has a preview command, the preview buffer is updated with a preview of that buffer.

This is useful for previewing e.g. manual pages or other documentation while writing them. Instead of a preview, could also run a validator or crunch some statistics.

Maybe in the future: graphics support (e.g. render HTML or TeX as an image and show it in Emacs).

### Direct link to the package repository

https://github.com/lassik/emacs-live-preview

### Your association with the package

Just wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
