### PR TITLE
Add nix-haskell-mode

### DIFF
--- a/recipes/nix-haskell-mode
+++ b/recipes/nix-haskell-mode
@@ -1,0 +1,1 @@
+(nix-haskell-mode :fetcher github :repo "matthewbauer/nix-haskell-mode")


### PR DESCRIPTION
URL: https://github.com/matthewbauer/nix-haskell-mode

### Brief summary of what the package does

Configures Haskell projects with packages downloaded from Nix.

### Direct link to the package repository

https://github.com/matthewbauer/nix-haskell-mode

### Your association with the package

Creator

### Relevant communications with the upstream package maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
