### PR TITLE
Add recipe for swedish calendar names

### DIFF
--- a/recipes/sv-kalender-namnsdagar
+++ b/recipes/sv-kalender-namnsdagar
@@ -1,0 +1,1 @@
+(sv-kalender-namnsdagar :repo "matsl/sv-kalender-namnsdagar" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The package provides a list of names associated with each day in the Swedish calendar. In addition to that it provides a function suitable for inclusion in the `.diary` file so that the names are displayed when viewing the diary from calendar, org-agenda or similar.

### Direct link to the package repository

https://github.com/matsl/sv-kalender-namnsdagar

### Your association with the package

I'm the maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

The function has a free variable `date` as that is bound when it is called from `diary-list-sexp-entries`. This gives a byte compilation warning.

