### PR TITLE
Add flycheck-clj-kondo

### DIFF
--- a/recipes/flycheck-clj-kondo
+++ b/recipes/flycheck-clj-kondo
@@ -1,0 +1,1 @@
+(flycheck-clj-kondo :fetcher github :repo "borkdude/flycheck-clj-kondo")


### PR DESCRIPTION
### Brief summary of what the package does

This packages integrates flycheck with the [clj-kondo](https://github.com/borkdude/clj-kondo) linter.

### Direct link to the package repository

https://github.com/borkdude/flycheck-clj-kondo

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
