### PR TITLE
Add gn-mode recipe

### DIFF
--- a/recipes/gn-mode
+++ b/recipes/gn-mode
@@ -1,0 +1,3 @@
+(gn-mode
+ :fetcher github
+ :repo "lashtear/gn-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A major-mode for editing GN (ninja generator) config files in Emacs. Files of this type (e.g. BUILD.gn or *.gni) are common in Chromium-derived projects like Chrome and (Anaheim) Edge.

### Direct link to the package repository

https://github.com/lashtear/gn-mode

### Your association with the package

Author / maintainer / recipe writer

### Relevant communications with the upstream package maintainer

None needed yet!

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).

    The package is licensed with BSD 3-clause

- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

    ಠ_ಠ