### PR TITLE
Removing deprecated package

### DIFF
--- a/recipes/lsp-hack
+++ b/recipes/lsp-hack
@@ -1,1 +1,0 @@
-(lsp-hack :repo "jra3/lsp-hack" :fetcher github)


### PR DESCRIPTION
lsp-hack was folded directly into lsp-mode, so the extra dep is no longer needed

### Brief summary of what the package does

Removing this package, as it's no longer needed

### Direct link to the package repository

https://github.com/jra3/lsp-hack

### Your association with the package

I'm the author and maintainer (and murderer)

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them
