### PR TITLE
Add `ewal` package.

### DIFF
--- a/recipes/ewal
+++ b/recipes/ewal
@@ -1,3 +1,4 @@
 (ewal
  :fetcher gitlab
- :repo "jjzmajic/ewal")
+ :repo "jjzmajic/ewal"
+ :files ("ewal.el"))

--- a/recipes/ewal
+++ b/recipes/ewal
@@ -1,0 +1,3 @@
+(ewal
+ :fetcher gitlab
+ :repo "jjzmajic/ewal")

--- a/recipes/ewal-evil-cursors
+++ b/recipes/ewal-evil-cursors
@@ -1,0 +1,4 @@
+(ewal-evil-cursors
+ :fetcher gitlab
+ :repo "jjzmajic/ewal"
+ :files ("evil-cursors/*.el"))

--- a/recipes/ewal-spacemacs-theme
+++ b/recipes/ewal-spacemacs-theme
@@ -1,0 +1,4 @@
+(ewal-spacemacs-theme
+ :fetcher gitlab
+ :repo "jjzmajic/ewal"
+ :files ("spacemacs-theme/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`ewal` is a pywal-based theme generator for Emacs. It extracts
special and regular `pywal` colors, and adds extra shades that are
intelligently suppressed in a TTY setting. It also provides functions that
expose those colors for granular theming configurations, and functions that
automatically customize different themes with your preferred colorscheme. It
already provides such a function for `spacemacs-theme`, and more will be added
over time.

### Direct link to the package repository

https://gitlab.com/jjzmajic/ewal

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

The occasional introspective episode.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (It's not due to one long URL in a docstring.)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
