### PR TITLE
Add 'mood-one-theme' package

### DIFF
--- a/recipes/mood-one-theme
+++ b/recipes/mood-one-theme
@@ -1,0 +1,1 @@
+(mood-one-theme :fetcher gitlab :repo "jessieh/mood-one-theme")


### PR DESCRIPTION
### Brief summary of what the package does

mood-one-theme is a dark color scheme inspired by the appearance of the Doom One theme from the doom-themes package, but with zero dependencies and a minimal performance footprint.

### Direct link to the package repository

https://gitlab.com/jessieh/mood-one-theme

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
