### PR TITLE
add seml-mode recipe

### DIFF
--- a/recipes/seml-mode
+++ b/recipes/seml-mode
@@ -1,0 +1,1 @@
+(seml-mode :fetcher github :repo "conao3/seml-mode.el")


### PR DESCRIPTION
### Brief summary of what the package does
`seml-mode` provide major mode for editing SEML (S-Expression Markup Language) files.

`libxml-parse-html-region` returns sexp when feed HTML string but decode function (sexp -> HTML) is missing.
So I implemented it and also implemented the corresponding API.

### Direct link to the package repository

https://github.com/conao3/seml-mode.el

### Your association with the package

I'm maintainer.

### Relevant communications with the upstream package maintainer

None

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

---
## package lint warnings
```
1 issue found:

133:1: error: "with-seml-elisp" doesn't start with package's prefix "seml".
```
But macro provide evaluation environment start `with` prefix.
## compiler warnings
```
$ emacs-25.3 -Q --batch -L . -f batch-byte-compile seml-mode.el

In seml-encode-html-from-region:
seml-mode.el:316:34:Warning: function ‘mapcan’ from cl package called at
    runtime
seml-mode.el:326:66:Warning: function ‘mapcan’ from cl package called at
    runtime
seml-mode.el:335:22:Warning: function ‘mapcan’ from cl package called at
    runtime
seml-mode.el:336:48:Warning: function ‘mapcan’ from cl package called at
    runtime

In seml-decode-seml-from-sexp:
seml-mode.el:431:16:Warning: function ‘mapcan’ from cl package called at
    runtime

$ emacs-26.1 -Q --batch -L . -f batch-byte-compile seml-mode.el
(no output)
```
Emacs 25's byte-compiler warn corresponding `mapcan`, but Emacs-26's byte-compiler not warn.
How should I handle this warning?