### PR TITLE
 Add new recipe for emacs-libvterm

### DIFF
--- a/recipes/vterm
+++ b/recipes/vterm
@@ -1,0 +1,5 @@
+(vterm :fetcher github
+	:repo "akermu/emacs-libvterm"
+    :files ("*"
+        (:exclude ".dir-locals.el" ".gitignore" ".clang-format" ".travis.yml"))
+    )


### PR DESCRIPTION
### Brief summary of what the package does

This Emacs module implements a bridge to libvterm to display a terminal in a
 Emacs buffer.

### Direct link to the package repository

https://github.com/akermu/emacs-libvterm

### Your association with the package
 A contributor  

### Relevant communications with the upstream package maintainer

https://github.com/akermu/emacs-libvterm/issues/53
https://github.com/akermu/emacs-libvterm/pull/81

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
after https://github.com/akermu/emacs-libvterm/pull/81 is merged
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
after https://github.com/akermu/emacs-libvterm/pull/81 is merged
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ]  I have confirmed some of these without doing them