### PR TITLE
Add recipe for aio

### DIFF
--- a/recipes/aio
+++ b/recipes/aio
@@ -1,0 +1,3 @@
+(aio :fetcher github
+     :repo "skeeto/emacs-aio"
+     :files ("aio.el" "README.md" "UNLICENSE"))


### PR DESCRIPTION
### Brief summary of what the package does

Provides async/await much like Python's `asyncio`. I wrote an in-depth article about it: [An Async / Await Library for Emacs Lisp](https://nullprogram.com/blog/2019/03/10/). I don't expect to make significant changes to the API at this point, so I'm submitting it as a package. I gave it about a month: skeeto/emacs-aio#1.

I used `:files` in my recipe since `aio-contrib.el` shouldn't be included in the package. Its purpose is to provide examples of how `aio` might be used with other packages and optional Emacs features. It shouldn't be used directly and won't compile cleanly unless all of these extra, mostly unrelated packages are actually installed. `aio` will always be a single-file package, so I explicitly listed all of the relevant files.

### Direct link to the package repository

https://github.com/skeeto/emacs-aio

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

`M-x checkdoc` has some minor complaints. I fixed one of them, and I'm using personal judgement for the rest.
