### PR TITLE
feat: add reciper emacs-guess-word-game

### DIFF
--- a/recipes/guess-word.el
+++ b/recipes/guess-word.el
@@ -1,0 +1,1 @@
+(guess-word :fetcher github :repo "Qquanwei/emacs-guess-word-game")


### PR DESCRIPTION
### Brief summary of what the package does

The game of guess-word for learning English

### Direct link to the package repository

https://github.com/Qquanwei/emacs-guess-word-game

### Your association with the package
maintainer


### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them
