### PR TITLE
Add recipe for indian-ext

### DIFF
--- a/recipes/indian-ext
+++ b/recipes/indian-ext
@@ -1,0 +1,1 @@
+(indian-ext :fetcher github :repo "paddymcall/indian-ext.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package extends the functionality of ind-utils in GNU/Emacs to support more encoding/decoding formats for transliterating Indic scripts.  It also adds an input method for IAST encoding.

### Direct link to the package repository

https://github.com/paddymcall/indian-ext

### Your association with the package

I am its maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
