### PR TITLE
Add json-reformatter-jq package

### DIFF
--- a/recipes/json-reformatter-jq
+++ b/recipes/json-reformatter-jq
@@ -1,0 +1,3 @@
+(json-reformatter-jq
+ :fetcher github
+ :repo "wbolster/emacs-json-reformatter-jq")


### PR DESCRIPTION
### Brief summary of what the package does

This Emacs package provides a [reformatter](https://github.com/purcell/reformatter.el) for [json](https://www.json.org/) and [jsonlines](http://jsonlines.org/) files using the `jq` utility.

### Direct link to the package repository

https://github.com/wbolster/emacs-json-reformatter-jq

### Your association with the package

Author/maintainer.

### Relevant communications with the upstream package maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
