### PR TITLE
Add monokai-pro-theme recipe

### DIFF
--- a/recipes/monokai-pro-theme
+++ b/recipes/monokai-pro-theme
@@ -1,0 +1,1 @@
+(monokai-pro-theme :fetcher github :repo "belak/emacs-monokai-pro-theme")


### PR DESCRIPTION
### Brief summary of what the package does

A simple theme based on the monokai pro themes from VSCode and Monokai.

### Direct link to the package repository

https://github.com/belak/emacs-monokai-pro-theme

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Note that I've built the package successfully, but installing it gives the error "Package does not untar cleanly into monokai-pro-theme-20190425.1245/". I've untarred it manually and it seems to work fine, so I'm not sure what the issue is. It's also based on another theme package of mine which I know works.