### PR TITLE
rename json-reformatter-jq to jq-format

### DIFF
--- a/recipes/jq-format
+++ b/recipes/jq-format
@@ -1,0 +1,3 @@
+(jq-format
+ :fetcher github
+ :repo "wbolster/emacs-jq-format")

--- a/recipes/json-reformatter-jq
+++ b/recipes/json-reformatter-jq
@@ -1,3 +1,0 @@
-(json-reformatter-jq
- :fetcher github
- :repo "wbolster/emacs-json-reformatter-jq")


### PR DESCRIPTION
the upstream package changed its name:
https://github.com/wbolster/emacs-jq-format/issues/2

see https://github.com/melpa/melpa/pull/6140 for original discussion.

(backwards compatibility is not a concern; this package is only a week old.)