### PR TITLE
Add recipe for sly-asdf

### DIFF
--- a/recipes/sly-asdf
+++ b/recipes/sly-asdf
@@ -1,0 +1,5 @@
+(sly-asdf :fetcher github
+          :repo "mmgeorge/sly-asdf"
+          :files (:defaults
+                  "*.lisp"
+                  "*.asd"))


### PR DESCRIPTION
### Brief summary of what the package does

`sly-asdf` is a contrib for [`sly`](https://github.com/joaotavora/sly) (an editing mode for Common Lisp) that provides support for working with ASDF systems. It is a port of the original [`slime-asdf`](https://github.com/slime/slime/blob/master/contrib/slime-asdf.el) contrib with changes to support `package-inferred-system` (released with ASDF 3.1). 

### Direct link to the package repository

https://github.com/mmgeorge/sly-asdf

### Your association with the package

I ported the library from SLIME and maintain it. 

### Relevant communications with the upstream package maintainer

None needed, though I do rely on a couple of internal `slynk` functions from the main `sly` project that I would like to get exposed. 

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
