### PR TITLE
Add whois recipe

### DIFF
--- a/recipes/whois
+++ b/recipes/whois
@@ -1,0 +1,1 @@
+(whois :fetcher github :repo "lassik/emacs-whois")


### PR DESCRIPTION
### Brief summary of what the package does

This package complements (does not replace) the standard whois
functionality of GNU Emacs. It provides:

* A `whois-mode` with font-lock highlighting to make whois responses
  easier to read.

* A `whois-shell` function to make a whois query using the system
  whois program instead of Emacs` own (often not up to date) whois
  client.

### Direct link to the package repository

https://github.com/lassik/emacs-whois

### Your association with the package

Just wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them