### PR TITLE
Add recipe show-eol.

### DIFF
--- a/recipes/show-eol
+++ b/recipes/show-eol
@@ -1,0 +1,1 @@
+(show-eol :repo "jcs090218/show-eol" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Show end of line symbol in buffer.

This feature is from `NotePad++`.
https://unix.stackexchange.com/questions/82536/showing-type-of-newline-character-in-emacs

### Direct link to the package repository

https://github.com/jcs090218/show-eol

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
