### PR TITLE
Add hl-block-mode

### DIFF
--- a/recipes/hl-block-mode
+++ b/recipes/hl-block-mode
@@ -1,0 +1,3 @@
+(hl-block-mode
+ :repo "ideasman42/emacs-hl-block-mode"
+:fetcher github)


### PR DESCRIPTION
This adds a minor mode for recursively highlighting blocks (nested scopes).

### Brief summary of what the package does

This highlights nested blocks of code, to help see the surrounding nested scopes (a feature in QtCreator)


![alt text](https://i.redd.it/or1tn0et1av21.png "Screenshot")

### Direct link to the package repository

https://github.com/ideasman42/emacs-hl-block-mode

### Your association with the package

Maintainer.
### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
