### PR TITLE
Python ipdb support as a separate realgud module

### DIFF
--- a/recipes/realgud-ipdb
+++ b/recipes/realgud-ipdb
@@ -1,5 +1,5 @@
 (realgud-ipdb
  :fetcher github
  :repo "realgud/realgud-ipdb"
- :files ("realgud-ipdb.el"
+ :files (:defaults 
          ("ipdb" "ipdb/*.el")))

--- a/recipes/realgud-ipdb
+++ b/recipes/realgud-ipdb
@@ -1,0 +1,5 @@
+(realgud-ipdb
+ :fetcher github
+ :repo "realgud/realgud-ipdb"
+ :files ("realgud-ipdb.el"
+         ("ipdb" "ipdb/*.el")))


### PR DESCRIPTION
### Brief summary of what the package does

The replaces to the emacs debugger front-end realgud python ipdb support. 

Note: after this is merged into MELPA, it will removed from realgud
(the core code).

### Direct link to the package repository

https://github.com/realgud/realgud-ipdb

I am one of the maintainers 

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
