### PR TITLE
add magit-diff-flycheck recipe

### DIFF
--- a/recipes/magit-diff-flycheck
+++ b/recipes/magit-diff-flycheck
@@ -1,0 +1,1 @@
+(magit-diff-flycheck :repo "ragone/magit-diff-flycheck" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Run `M-x magit-diff-flycheck` in a magit-diff buffer to display a
filtered list of errors for the added/modified lines only.

This is primarily meant to be used on legacy projects where you do
not want to see errors for the whole file but only for the added/modified
lines.

This works across multiple files in the same error-list.

![output-2019-05-05-21:49:56](https://user-images.githubusercontent.com/5365116/57192003-d402e500-6f7f-11e9-8580-0c1193d34574.gif)

### Direct link to the package repository

https://github.com/ragone/magit-diff-flycheck

### Your association with the package

Maintainer and author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
