### PR TITLE
magit-libgit: drop spurious trailing quote

### DIFF
--- a/recipes/magit-libgit
+++ b/recipes/magit-libgit
@@ -1,3 +1,3 @@
 (magit-libgit :fetcher github
               :repo "magit/magit"
-              :files ("lisp/magit-libgit.el"))"
+              :files ("lisp/magit-libgit.el"))


### PR DESCRIPTION
While Emacs' Lisp reader is perhaps fine with the dangling double quote at the end of the recipe expression, a (non-Lisp) tool which I wrote for local use caught it and barfed on it.