### PR TITLE
phpstan: drop spurious trailing closing paren

### DIFF
--- a/recipes/phpstan
+++ b/recipes/phpstan
@@ -1,2 +1,2 @@
 (phpstan :fetcher github :repo "emacs-php/phpstan.el"
-         :files ("phpstan.el")))
+         :files ("phpstan.el"))


### PR DESCRIPTION
Found another one with a trailing character. I believe there are no more recipes with those, so I don't think you need to worry about more spam from me for now :-)