### PR TITLE
Add goto-last-point

### DIFF
--- a/recipes/goto-last-point
+++ b/recipes/goto-last-point
@@ -1,0 +1,1 @@
+(goto-last-point :fetcher github :repo "manuel-uberti/goto-last-point")


### PR DESCRIPTION
### Brief summary of what the package does

A minor mode to record and jump to the last point in the buffer.

Original author is @chrisdone, I hope he'll be happy with this. :)

### Direct link to the package repository

https://github.com/manuel-uberti/goto-last-point

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
