### PR TITLE
add rfc-mode

### DIFF
--- a/recipes/rfc-mode
+++ b/recipes/rfc-mode
@@ -1,0 +1,1 @@
+(rfc-mode :fetcher github :repo "galdor/rfc-mode")


### PR DESCRIPTION
### Brief summary of what the package does

rfc-mode is a browser and viewer for RFC documents. The viewer highlights headers and section titles, and create links (buttons) for references to other RFC documents. The browser uses Helm and makes it easy to search and select RFC documents.

### Direct link to the package repository

https://github.com/galdor/rfc-mode

### Your association with the package

I wrote the package and maintain it.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
