### PR TITLE
Add recipe for mu2tex

### DIFF
--- a/recipes/mu2tex
+++ b/recipes/mu2tex
@@ -1,0 +1,2 @@
+(mu2tex :fetcher github :repo "cdominik/mu2tex")
+


### PR DESCRIPTION
### Brief summary of what the package does

In scientific literature, it is common to format the symbols for chemical elements, molecules and unit names by using roman (as opposed to italic) letters for the names. This makes such things cumbersome to type, because one would have to do either `$\mathrm{H_2O}$` or `H$_2$O`. This package make this typing easier by providing the function `mu2tex`. This function converts plain ASCII molecule names and unit expressions into either of the above forms. It also makes it easier to write numbers times powers of 10.

### Direct link to the package repository

https://github.com/cdominik/mu2tex

### Your association with the package

I'm a contributor and user of the package. The maintainer is @cdominik

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them