### PR TITLE
Add phpt-mode recipe

### DIFF
--- a/recipes/phpt-mode
+++ b/recipes/phpt-mode
@@ -1,0 +1,1 @@
+(phpt-mode :fetcher github :repo "emacs-php/phpt-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides major mode for editing [PHPT File format](http://qa.php.net/phpt_details.php).

Files of this format are used as test code for [the PHP interpreter](https://github.com/php/php-src).
Also, a subset of this format is included in [PHPUnit](https://phpunit.de/).

### Direct link to the package repository

https://github.com/emacs-php/phpt-mode

### Your association with the package

I'm author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
