### PR TITLE
Realgud support for node inspect

### DIFF
--- a/recipes/realgud-node-inspect
+++ b/recipes/realgud-node-inspect
@@ -1,0 +1,5 @@
+(realgud-node-inspect
+ :fetcher github
+ :repo "realgud/realgud-node-inspect"
+ :files (:defaults
+         ("realgud-node-inspect" "realgud-node-inspect/*.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Adds newer node --inspect debugger support to the realgud debugger frontend

### Direct link to the package repository

https://github.com/realgud/realgud-node-inspect 

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

 **None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
