### PR TITLE
Add recipe for color-theme-almost-mono

### DIFF
--- a/recipes/color-theme-almost-mono
+++ b/recipes/color-theme-almost-mono
@@ -1,0 +1,3 @@
+(color-theme-almost-mono
+ :fetcher github
+ :repo "cryon/almost-mono-theme")


### PR DESCRIPTION
### Brief summary of what the package does

An almost monochromatic color theme for Emacs

### Direct link to the package repository

https://github.com/cryon/almost-mono-theme

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
