### PR TITLE
node-debug support in realgud

### DIFF
--- a/recipes/realgud-node-debug
+++ b/recipes/realgud-node-debug
@@ -1,0 +1,5 @@
+(realgud-node-debug
+ :fetcher github
+ :repo "realgud/realgud-node-debug"
+ :files (:defaults
+         ("realgud-node-debug" "realgud-node-debug/*.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Adds realgud support for the older nodejs `node debug` debugger

### Direct link to the package repository

https://github.com/realgud/realgud-node-debug

### Your association with the package

Author/maintainer

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
