### PR TITLE
Delete olivetti

### DIFF
--- a/recipes/olivetti
+++ b/recipes/olivetti
@@ -1,2 +1,0 @@
-(olivetti :fetcher github
-          :repo "rnkn/olivetti")


### PR DESCRIPTION
Now part of GNU ELPA

### Direct link to the package repository

https://elpa.gnu.org/packages/olivetti.html

### Your association with the package

Maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
