### PR TITLE
Add realgud support for Java jdb

### DIFF
--- a/recipes/realgud-jdb
+++ b/recipes/realgud-jdb
@@ -1,0 +1,5 @@
+(realgud-jdb
+ :fetcher github
+ :repo "realgud/realgud-jdb"
+ :files (:defaults
+         ("realgud-jdb" "realgud-jdb/*.el")))


### PR DESCRIPTION
Once this is in, we will remove it from realgud (the core)

### Brief summary of what the package does

Separates jdb support in realgud from core package. 

### Direct link to the package repository

https://github.com/realgud/realgud-jdb

### Your association with the package

Author/maintainer

### Relevant communications with the upstream package maintainer

**None needed** i

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
