### PR TITLE
Add sly-docker

### DIFF
--- a/recipes/sly-docker
+++ b/recipes/sly-docker
@@ -1,0 +1,5 @@
+(sly-docker :fetcher github
+            :repo "fisxoj/sly-docker"
+            :files (:defaults
+                    "*.lisp"
+                    "*.asd"))


### PR DESCRIPTION
### Brief summary of what the package does

This is a contrib (plugin) for sly, a package for interactive editing of common lisp code.  This contrib handles pathname translation into and out of docker containers that the code might be running in for jumping to function definitions.

### Direct link to the package repository

https://github.com/fisxoj/sly-docker

### Your association with the package

I am the maintainer!

### Relevant communications with the upstream package maintainer

*None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - There is one override of a function from the sly package, but that will be removed once I get a pull request merged there.  The maintainer is fine with the change.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
