### PR TITLE
Add recipe for cfrs.

### DIFF
--- a/recipes/cfrs
+++ b/recipes/cfrs
@@ -1,0 +1,3 @@
+(cfrs
+ :repo "Alexander-Miller/cfrs"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

cfrs is short for `Child Frame Read String` - an alternative to the default `read-string` function that reads input from a child frame at point instead of the minibuffer.

### Direct link to the package repository

https://github.com/Alexander-Miller/cfrs

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

None needed. 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [NOPE] I have confirmed some of these without doing them
