### PR TITLE
Add janet-mode package

### DIFF
--- a/recipes/janet-mode
+++ b/recipes/janet-mode
@@ -1,0 +1,1 @@
+(janet-mode :repo "ALSchwalm/janet-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Adds a new major mode for the Janet programming language: https://janet-lang.org/

### Direct link to the package repository

https://github.com/ALSchwalm/janet-mode/

### Your association with the package

Package author

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Note that `package-lint` reports 3 errors erroneously. 