### PR TITLE
Remove cryptsy-public-api recipe

### DIFF
--- a/recipes/cryptsy-public-api
+++ b/recipes/cryptsy-public-api
@@ -1,2 +1,0 @@
-(cryptsy-public-api :repo "Sodaware/cryptsy-public-api.el"
-                    :fetcher github)


### PR DESCRIPTION
The Cryptsy exchange has closed and the api is no longer functional.

### Direct link to the package repository

https://github.com/sodaware/cryptsy-public-api.el

### Your association with the package

Project author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

N/A