### PR TITLE
Add Poetry.el package

### DIFF
--- a/recipes/poetry
+++ b/recipes/poetry
@@ -1,0 +1,3 @@
+(poetry
+ :fetcher github
+ :repo "galaunay/poetry.el")


### PR DESCRIPTION
### Brief summary of what the package does

`Poetry.el` provides an interface to use [poetry](https://poetry.eustace.io/) in Emacs
(poetry is a python dependency management and packaging tool).
It uses [transient](https://github.com/magit/transient) to provide a magit-like interface.

Poetry.el is almost fully tested (coverage available on the github page).

### Direct link to the package repository

https://github.com/galaunay/poetry.el

### Your association with the package

Maintainer (of poetry.el, not poetry)

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
