### PR TITLE
Add leaf recipe

### DIFF
--- a/recipes/leaf
+++ b/recipes/leaf
@@ -1,0 +1,1 @@
+(leaf :fetcher github :repo "conao3/leaf.el")


### PR DESCRIPTION
### Brief summary of what the package does
Hi!
I have developed yet another implementation of `use-package`. I know the functionality is duplicated, but my package has more advanced keywords and does more reasonable keyword processing. Adding keywords is also easy.

The following is a description of the repository.

> leaf.el is yet another use-package.
> 
> leaf solves the stress of using use-package for 2 years. By developing from scratch, we have a cleaner and more predictable implementation than use-package.
> 
> This makes it easy to maintain and add new keywords. (see leaf-keywords.el)
> 
> leaf has keywords almost identical to use-package, but some of usage of the keywords is different.
> 
> The quickest way to solve problem is to use macroexpand-1 to see the unfolded result if it is not what you intended. And also there are also a number of samples in this README and more in the test file.
> 
> In addition, since it works with Emacs-22, you can use your usual init.el as usual, even if you are temporarily using fossil-like Emacs on loan.
> 
> (Of course, there are not many packages that work perfectly with Emacs-22. These packages will be installed by the package manager and will probably report an error.
leaf processes this and cancels the configuration for that package. It then attempts to process the next package.)

### Direct link to the package repository

https://github.com/conao3/leaf.el

### Your association with the package

I'm an author and maintainer.

### Relevant communications with the upstream package maintainer

None.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

## Flycheck warnings
```
leaf.el   274  93 warning         `eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
```
However, this line is written for user deployment and is not required for package operation.

Best,