### PR TITLE
add leaf-keywords recipe

### DIFF
--- a/recipes/leaf-keywords
+++ b/recipes/leaf-keywords
@@ -1,0 +1,1 @@
+(leaf-keywords :fetcher github :repo "conao3/leaf-keywords.el")


### PR DESCRIPTION
### Brief summary of what the package does

Corresponding #6192, this package provide additional `leaf` keywords for Emacs external packages.

There is room for thought about this package's dependencies, but it is a sort of transpiler and does not guarantee the viability of the conversion result.
Also, because the lines dependent on the external package are enclosed by `eval-after-load`, an error does not occur and does not prevent the user from executing init.el.

As a practical matter, I think that adding all external packages that this package supports to dependencies depends on the fact that many packages not needed by the user will be installed.

### Direct link to the package repository

https://github.com/conao3/leaf-keywords.el

### Your association with the package

I'm an author and maintainer.

### Relevant communications with the upstream package maintainer

None

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

## flycheck warnings
```
 leaf-k…    10  39 error           Package leaf is not installable. (emacs-lisp-package)
 leaf-k…    35   1 error           Cannot open load file: No such file or directory, leaf (emacs-lisp)
 leaf-k…    81  31 warning         `eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
 leaf-k…   309   1 error           "leaf-key-chord" doesn't start with package's prefix "leaf-keywords". (emacs-lisp-package)
 leaf-k…   326   1 error           "leaf-key-chord*" doesn't start with package's prefix "leaf-keywords". (emacs-lisp-package)
 leaf-k…   331   1 error           "leaf-key-chords" doesn't start with package's prefix "leaf-keywords". (emacs-lisp-package)
 leaf-k…   405   1 error           "leaf-key-chords*" doesn't start with package's prefix "leaf-keywords". (emacs-lisp-package)
```
- Because `leaf` have not part MELPA, could not retreave leaf, the error will solve when leaf recipe merged.
- `eval-after-load` issue is same reason at `leaf`, the line is not for this package, for users.
- `leaf-key-*` function and macros extend `leaf-key` at `leaf`, I think the name is appropriate.