### PR TITLE
Added Recipe for ruby-extra-mode

### DIFF
--- a/recipes/ruby-extra-mode
+++ b/recipes/ruby-extra-mode
@@ -1,0 +1,1 @@
+(ruby-extra-mode :fetcher gitlab :repo "samuelfirst/ruby-extra-mode")


### PR DESCRIPTION
### Brief summary of what the package does

The package provides a minor mode meant to be used along side the ruby major mode.  The minor mode gives the user the ability to easily run linters, pull up documentation, generate documentation, and prototype programs via an interactive ruby interpreter.

### Direct link to the package repository

https://gitlab.com/samuelfirst/ruby-extra-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Notes

- Checkdoc doesn't like that some of my docstrings contain the word flag.  In those docstrings, flag does not refer to an internal boolean value, but rather to a flag meant to be passed to a command-line program.  It also does not like places where I reference ruby-lint, which it believes is a lisp symbol.  It actually refers to a ruby linting tool that the mode uses as the default linter.
- `-*- lexical-binding: t; -*-` is on the second line, rather than at the end of the first line.  From what I can tell from the documentation I can find, it shouldn't make a difference functionality-wise, however, putting it on the second line allows me to avoid breaking the 80-character limit.
- There are some complaints from `flycheck` about references to free variables defined with `setq`.  I believe that the magic `-*- lexical-binding: t; -*-` comment should fix this, although, I am new to elisp, so if I'm missing something here, or if there is a cleaner way to handle this, I am willing to change these parts of the script.
- `Flycheck` complains about some functions that are not known to be defined.  One of those functions, `markdown-mode` is not a hard requirement, but rather something that is used only if it is available.  The other `eshell-send-input` is defined when `eshell` starts, so it shouldn't be a problem.