### PR TITLE
Add org-drill

### DIFF
--- a/recipes/org-drill
+++ b/recipes/org-drill
@@ -1,0 +1,1 @@
+(org-drill :fetcher gitlab :repo "phillord/org-drill")


### PR DESCRIPTION
### Brief summary of what the package does

A repetitive learning package based on org-mode

### Direct link to the package repository

https://gitlab.com/phillord/org-drill

### Your association with the package

I am taking over as maintainer.


### Relevant communications with the upstream package maintainer

Org-drill has not been updated in a while. I posted my intention to take it over here.

https://bitbucket.org/eeeickythump/org-drill/issues/63/maintainership

I have had communication with Paul, the original author, and he is happy to let me take over, as he doesn't really use it any more. However, he hasn't added me to the original bitbucket site, so I have forked this way instead. All this was in private email which I cannot reproduce here.

I have also posted on org-mode mailing list. Currently, org-drill.el is hosted in "contrib". The plan would be to remove it (and org-learn.el which will be incorporated here).

https://lists.gnu.org/archive/html/emacs-orgmode/2019-06/msg00019.html


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

TL:DR The package doesn't fulfil these standards, I know, I will fix eventually, but think MELPA would provide an easy upgrade path to a slightly less broken version than the current status quo.

Full Explanation....


The ones that I have not checked I have done, and fail. org-drill is currently usable and functional, but does not adhere to many of the Emacs coding standards. I submit this anyway because:
  - There are already users of it and the current version is broken
  - It exists in org-mode/contrib, but this is out of sync with the version in Paul's bitbucket
  - Addressing the issues here will take substantial time because it makes heavy user of dynamic scoping
  - There is no test set or framework
 
All of which tells me that getting it into the hands of current users sooner rather than later is the best way to prevent death by bit-rot. 