### PR TITLE
Add pinboard.el

### DIFF
--- a/recipes/pinboard
+++ b/recipes/pinboard
@@ -1,0 +1,1 @@
+(pinboard :fetcher github :repo "davep/pinboard.el")


### PR DESCRIPTION
### Brief summary of what the package does

`pinboard.el` is an Emacs client for [pinboard.in](https://pinboard.in/). It allows for the browsing of, viewing of, adding, editing and deletion of URLs for later reading, etc.

### Direct link to the package repository

https://github.com/davep/pinboard.el

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
