### PR TITLE
Add hg-histedit

### DIFF
--- a/recipes/hg-histedit
+++ b/recipes/hg-histedit
@@ -1,0 +1,1 @@
+(hg-histedit :fetcher github :repo "jojojames/hg-histedit")


### PR DESCRIPTION
### Brief summary of what the package does

Interface to mercurial/hg's histedit (similar to git rebase -i).

### Direct link to the package repository

https://github.com/jojojames/hg-histedit

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
