### PR TITLE
Make live-py-mode's Python files pattern flexible

### DIFF
--- a/recipes/live-py-mode
+++ b/recipes/live-py-mode
@@ -1,4 +1,4 @@
 (live-py-mode
  :fetcher github
  :repo "donkirkby/live-py-plugin"
- :files ("emacs-live-py-mode/live-py-mode.el" "plugin/PySrc/*.py"))
+ :files ("emacs-live-py-mode/live-py-mode.el" "plugin/PySrc/*"))


### PR DESCRIPTION
An upcoming version will use a package folder.

### Brief summary of what the package does

Adds a minor mode for live coding in Python. The mode is already packaged, I'm just changing the build.

### Direct link to the package repository

https://github.com/donkirkby/live-py-plugin

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
