### PR TITLE
Add face-shift

### DIFF
--- a/recipes/face-shift
+++ b/recipes/face-shift
@@ -1,0 +1,1 @@
+(face-shift :url "https://git.sr.ht/~zge/face-shift" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

Face-shift distorts the default colours of faces in a buffer, making a white background slightly more blue, green, pink, etc. An example of how this looks like can be found [here](https://icosahedron.website/@zge/102229312631398520).

### Direct link to the package repository

https://git.sr.ht/~zge/face-shift

### Your association with the package

I'm the creator and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

    ~~(I've used the 0.7 release, from melpa-stable.)~~
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
