### PR TITLE
Add bang

### DIFF
--- a/recipes/bang
+++ b/recipes/bang
@@ -1,0 +1,1 @@
+(bang :url "https://git.sr.ht/~zge/bang" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

Bang extends the default `shell-command` by behaving differently based on the first character.  To quote the docstring:

    When COMMAND starts with
      <  the output of COMMAND replaces the current selection
      >  COMMAND is run with the current selection as input
      |  the current selection is filtered through COMMAND
      !  executes the last command that started with COMMAND,
         or if a number, re-execute nth last command

Based on [Leah Neukirchen's](http://leahneukirchen.org/dotfiles/.emacs) function of the same name.

### Direct link to the package repository

https://git.sr.ht/~zge/bang

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

    ~~I've used version 0.7 from melpa-stable.~~
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
