### PR TITLE
Add go-capf

### DIFF
--- a/recipes/go-capf
+++ b/recipes/go-capf
@@ -1,0 +1,1 @@
+(go-capf :url "https://git.sr.ht/~zge/go-capf" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

A gocode based completion backend from `completion-at-point`.

### Direct link to the package repository

https://git.sr.ht/~zge/go-capf

### Your association with the package

I'm the maintainer and creator.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

    ~~I've used version 0.7 from melpa-stable.~~
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
