### PR TITLE
Add insert-kaomoji

### DIFF
--- a/recipes/insert-kaomoji
+++ b/recipes/insert-kaomoji
@@ -1,0 +1,2 @@
+(insert-kaomoji :url "https://git.sr.ht/~zge/kaomoji" :fetcher git
+				:files ("insert-kaomoji.el" "KAOMOJIS"))

--- a/recipes/insert-kaomoji
+++ b/recipes/insert-kaomoji
@@ -1,2 +1,2 @@
 (insert-kaomoji :url "https://git.sr.ht/~zge/kaomoji" :fetcher git
-				:files ("insert-kaomoji.el" "KAOMOJIS"))
+				:files (:defaults "KAOMOJIS"))


### PR DESCRIPTION
### Brief summary of what the package does

Easily insert a wide variety of easter emoticons or "Kamojis" using `compleating-read`.

### Direct link to the package repository

https://git.sr.ht/~zge/kaomoji

### Your association with the package

I'm the creator and maintainor.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

    ~~I've used version 0.7 from melpa-stable.~~
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
