### PR TITLE
Add recipe for `json-rpc-server`

### DIFF
--- a/recipes/json-rpc-server
+++ b/recipes/json-rpc-server
@@ -1,0 +1,3 @@
+(json-rpc-server
+ :fetcher github
+ :repo "jcaw/json-rpc-server.el")


### PR DESCRIPTION
### Brief summary of what the package does

This is a full implementation of the JSON-RPC 2.0 protocol for Emacs. You pass in a JSON string, Emacs executes the specified function(s), and a JSON-RPC 2.0 response is returned.

This package is designed sit underneath a transport layer. No transport logic is included. The transport layer is responsible for communicating with external clients. 

This package was originally part of [porthole](https://github.com/jcaw/porthole), a full-fledged RPC server system, but I abstracted it into its own package so it could be used as a framework for other RPC servers. It's just the JSON-RPC 2.0 protocol, plus function logic.

### Direct link to the package repository

https://github.com/jcaw/json-rpc-server.el

### Your association with the package

Author & Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

---

`package-lint` did warn me about using a contraction as my package prefix. I'm not sure how to stop it from complaining about that. No other issues were raised.