### PR TITLE
Add recipe for `porthole`

### DIFF
--- a/recipes/porthole
+++ b/recipes/porthole
@@ -1,0 +1,3 @@
+(porthole
+ :fetcher github
+ :repo "jcaw/porthole")


### PR DESCRIPTION
### Brief summary of what the package does

Porthole lets you start RPC servers in Emacs. 

These servers allow Elisp to be invoked remotely via HTTP requests. These servers are designed to be automatic (when running locally), meaning they require no configuration from the client to work. All the client needs is a name, and it can execute remote Elisp procedure calls automatically.

Many Porthole servers can run independently without worrying about one another. It's designed to act as a framework that other packages can build on. 

A full Python client is available on `pip`, repo [here](https://github.com/jcaw/porthole-python-client). It allows one-liner RPC calls to Emacs, from Python.

This package depends on [`json-rpc-server`](https://github.com/jcaw/json-rpc-server.el), which handles the underlying JSON-RPC protocol. I've also opened a pull request to add `json-rpc-server` to MELPA [here](https://github.com/melpa/melpa/pull/6217). 

### Direct link to the package repository

https://github.com/jcaw/porthole

### Your association with the package

Author & Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

---

- `package-lint` didn't want me to include Emacs in the package name - kept it to make it obvious the RPC functionality exposes *Emacs* - Emacs isn't the client, it's the server.
- Byte compilation just gives me two warnings:
  - `porthole.el:839:1:Warning: Unused lexical variable ‘i’` - Not sure how to `dotimes` without a variable to hold the count.
  - `porthole.el:71:1:Warning: Package assoc is obsolete!` - Only gives me this warning sometimes (?), not sure what I should use instead in this instance - should I explicitly use `alist-get` with a `testfn`?