### PR TITLE
Update lua-mode recipe

### DIFF
--- a/recipes/lua-mode
+++ b/recipes/lua-mode
@@ -1,4 +1,4 @@
 (lua-mode
  :repo "immerrr/lua-mode"
  :fetcher github
- :files ("lua-mode.el" ("scripts" "scripts/*")))
+ :files (:defaults "scripts"))

--- a/recipes/lua-mode
+++ b/recipes/lua-mode
@@ -1,3 +1,4 @@
 (lua-mode
  :repo "immerrr/lua-mode"
- :fetcher github)
+ :fetcher github
+ :files ("lua-mode.el" ("scripts" "scripts/*")))


### PR DESCRIPTION
There's an [upcoming change](https://github.com/immerrr/lua-mode/pull/148) that would require to accompany the source code with a Lua initializer script for the inferior shell. This is to ensure the script is redistributed accordingly. 

Please note, that `scripts` directory is not there yet, and I'm not sure if the recipe works without it. If that's the case we can wait with merging until the scripts directory is created.

### Brief summary of what the package does

lua-mode is a major mode for editing Lua files

### Direct link to the package repository

https://github.com/immerrr/lua-mode

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

No package.el compatibility changes were introduced.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Looks like, lua-mode is quite far behind on the package quality side of things, but if it's OK I would prefer to fix it in a separate PR.