### PR TITLE
Add eyezoom recipe.

### DIFF
--- a/recipes/eyezoom
+++ b/recipes/eyezoom
@@ -1,0 +1,1 @@
+(eyezoom :fetcher github :repo "sandinmyjoints/eyezoom")


### PR DESCRIPTION
### Brief summary of what the package does

[Eyebrowse](https://github.com/wasamasa/eyebrowse) and [Zoom](https://github.com/cyrus-and/zoom) are both great packages. Sometimes you may want Zoom to apply only to some Eyebrowse workspaces (window layouts) but not others. Out of the box, it does not support this; it can only be turned on or off. So if you have workspaces you'd prefer to manage yourself, it will mess with them whenever you switch to them. This package lets you specify the tags of which workspaces Zoom should apply to. Workspaces that don't have such a tag are left alone.

### Direct link to the package repository

https://github.com/sandinmyjoints/eyezoom

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
