### PR TITLE
add frog-jump-buffer recipe

### DIFF
--- a/recipes/frog-jump-buffer
+++ b/recipes/frog-jump-buffer
@@ -1,0 +1,1 @@
+(frog-jump-buffer :repo "waymondo/frog-jump-buffer" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`frog-jump-buffer` is a convenience package that allows one to hop to any Emacs buffer in 2-3 key
strokes.

### Direct link to the package repository

https://github.com/waymondo/frog-jump-buffer

### Your association with the package

Maintainer & enthusiastic user.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
