### PR TITLE
Add org-lookup-dnd

### DIFF
--- a/recipes/org-lookup-dnd
+++ b/recipes/org-lookup-dnd
@@ -1,0 +1,1 @@
+(org-lookup-dnd :repo "maltelau/org-lookup-dnd" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Index your pdfs' table of contents (tabletop rpg rulebooks f.ex.) and filter through them live to insert an org-pdfview link to the right page.

### Direct link to the package repository

https://gitlab.com/maltelau/org-lookup-dnd

### Your association with the package

I am the package and recipe author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
