### PR TITLE
add filetags.el

### DIFF
--- a/recipes/filetags
+++ b/recipes/filetags
@@ -1,0 +1,3 @@
+(filetags
+  :repo "DerBeutlin/filetags.el"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The package helps to manage filetags which are stored in the filename of files.
It can be used from dired.

### Direct link to the package repository

https://github.com/DerBeutlin/filetags.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
For some reason it complains about arguments not being in the docstring although they are.
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
