### PR TITLE
Remove cftag-mode which is now superflous

### DIFF
--- a/recipes/cftag-mode
+++ b/recipes/cftag-mode
@@ -1,5 +1,0 @@
-(cftag-mode
- :repo "am2605/cfml-mode"
- :fetcher github
- :files ("cftag-mode.el")
- )


### PR DESCRIPTION
I am the maintainer of this package, as well as cfml-mode.

cftag-mode was previously a dependency for cfml-mode, but I have now reworked cfml-mode and it no longer needs this dependency.  