### PR TITLE
Transfer haxe-mode.

### DIFF
--- a/recipes/haxe-mode
+++ b/recipes/haxe-mode
@@ -1,1 +1,1 @@
-(haxe-mode :fetcher bitbucket :repo "jpsecher/haxe-mode")
+(haxe-mode :repo "elpa-host/haxe-mode" :fetcher github )


### PR DESCRIPTION
I had contacted `haxe-mode`'s author `Jens Peter Secher`. As he mentioned in his own repo's issue page, he is no longer maintaining this package and willing to transfer to me, so people can actively contribute to this package. This PR to make `haxe-mode`'s recipe point to the new and currently maintaining address.

**Original Repo:** https://bitbucket.org/jpsecher/haxe-mode/src/default/
**New Repo:** https://github.com/elpa-host/haxe-mode