### PR TITLE
Add swift-playground-mode

### DIFF
--- a/recipes/swift-playground-mode
+++ b/recipes/swift-playground-mode
@@ -1,0 +1,5 @@
+(swift-playground-mode :repo "michael.sanders/swift-playground-mode"
+                       :fetcher gitlab
+                       :files (:defaults
+                               "SwiftPlayground.vim/runner.sh"
+                               "SwiftPlayground.vim/*.swift"))


### PR DESCRIPTION
### Brief summary of what the package does

Emacs support for Swift playgrounds.

### Direct link to the package repository

https://gitlab.com/michael.sanders/swift-playground-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)