### PR TITLE
Add with-emacs

### DIFF
--- a/recipes/with-emacs
+++ b/recipes/with-emacs
@@ -1,0 +1,3 @@
+(with-emacs
+ :fetcher github
+ :repo "twlz0ne/with-emacs.el")


### PR DESCRIPTION
### Brief summary of what the package does

Evaluate Emacs Lisp expressions in a separate Emacs process

```elisp
(with-emacs
  :path "/path/to/version/emacs" ;; optional
  :lexical t                     ;;
  (do-something)
  ...)
```



### Direct link to the package repository

https://github.com/twlz0ne/with-emacs.el

### Your association with the package

Author & Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
