### PR TITLE
Add recipe for org-json

### DIFF
--- a/recipes/org-json
+++ b/recipes/org-json
@@ -1,0 +1,1 @@
+(org-json :fetcher github :repo "jlumpe/org-json")


### PR DESCRIPTION
### Brief summary of what the package does

Encodes the abstract syntax tree of an org mode file in JSON format.

### Direct link to the package repository

https://github.com/jlumpe/org-json

### Your association with the package

Author/maintainer

### Relevant communications with the upstream package maintainer

None

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
