### PR TITLE
Include obsolete ESS lisp files

### DIFF
--- a/recipes/ess
+++ b/recipes/ess
@@ -4,5 +4,5 @@
  :files ("*.el" "lisp/*.el"
          "doc/*.texi" "doc/info/dir"
          ("etc" "etc/*")
-         ("obsolete" "obsolete/*.el")
+         ("obsolete" "lisp/obsolete/*")
          (:exclude "etc/other")))


### PR DESCRIPTION
This fixes ESS's recipe to include obsolete files, see https://github.com/emacs-ess/ESS/issues/894
