### PR TITLE
js/melpa.js: allow https://git.* fallback for other forges

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -136,7 +136,8 @@
                 urlMatch(/(gitlab\.com\/[^\/]+\/[^.]+)/, "https://") ||
                 urlMatch(/^lp:(.*)/, "https://launchpad.net/") ||
                 urlMatch(/^(https?:\/\/code\.google\.com\/p\/[^\/]+\/)/) ||
-                urlMatch(/^(https?:\/\/[^.]+\.googlecode\.com\/)/));
+                urlMatch(/^(https?:\/\/[^.]+\.googlecode\.com\/)/) ||
+                urlMatch(/^(https?:\/\/git.*)/));
       }
       return null;
     };


### PR DESCRIPTION
The calculateSourceURL function has special handling for a selection
of forges and other hosting sites. Rather than adding new special
handling for forges like sr.ht lets just assume that a modern https://
website starting with git with do the right thing when a browser
visits.
