### PR TITLE
Open recipe files in emacs-lisp-mode

### DIFF
--- a/recipes/.dir-locals.el
+++ b/recipes/.dir-locals.el
@@ -1,4 +1,5 @@
-((nil . ((eval . (when (and 
+((nil . ((mode . emacs-lisp)
+         (eval . (when (and
                         (buffer-file-name)
                         (file-regular-p (buffer-file-name))
                         (string-match-p "^[^.]" (buffer-file-name)))


### PR DESCRIPTION
Recipe files have the same structure as S-expressions.

For example, paredit and smartparens can help developers edit recipe
files, and an easy way to enable them is to open them in
`emacs-lisp-mode` instead of `fundamental-mode`.