### PR TITLE
Update cmake-mode to use its upstream git repository, not a mirror.

### DIFF
--- a/recipes/cmake-mode
+++ b/recipes/cmake-mode
@@ -1,1 +1,3 @@
-(cmake-mode :fetcher github :repo "Kitware/CMake" :files ("Auxiliary/*.el"))
+(cmake-mode :fetcher git
+            :url "https://gitlab.kitware.com/cmake/cmake.git"
+            :files ("Auxiliary/*.el"))


### PR DESCRIPTION
### Your association with the package

An enthusiastic user