### PR TITLE
Add recipe for line-indicators.

### DIFF
--- a/recipes/line-indicators
+++ b/recipes/line-indicators
@@ -1,0 +1,1 @@
+(line-indicators :repo "jcs090218/line-indicators" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Line annotation similar to Visual Studio.

This package is basically the same to [line-reminder](https://github.com/elpa-host/line-reminder). But now this doesn't required `linum` and display it using [indicators](https://github.com/Fuco1/indicators.el).

### Direct link to the package repository

https://github.com/jcs090218/line-indicators

### Your association with the package

The maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
