### PR TITLE
Add cpp-auto-include

### DIFF
--- a/recipes/cpp-auto-include
+++ b/recipes/cpp-auto-include
@@ -1,0 +1,2 @@
+(cpp-auto-include :fetcher github
+                  :repo "syohex/emacs-cpp-auto-include")


### PR DESCRIPTION
### Brief summary of what the package does

Insert and delete C++ header files automatically.

### Direct link to the package repository

https://github.com/syohex/emacs-cpp-auto-include

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

syohex/emacs-cpp-auto-include#5

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
