### PR TITLE
Add recipe for ox-json

### DIFF
--- a/recipes/ox-json
+++ b/recipes/ox-json
@@ -1,0 +1,1 @@
+(ox-json :fetcher github :repo "jlumpe/ox-json")


### PR DESCRIPTION
### Brief summary of what the package does

JSON export back end for Org mode

### Direct link to the package repository

https://github.com/jlumpe/ox-json

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Replacement for #6251, I ended up rewriting from scratch. There are a few byte compilation errors about unused arguments for functions that are required to have a particular signature.