### PR TITLE
Add recipe for lisp-butt-mode

### DIFF
--- a/recipes/lisp-butt-mode
+++ b/recipes/lisp-butt-mode
@@ -1,0 +1,1 @@
+(lisp-butt-mode :repo "marcowahl/lisp-butt-mode" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This is a minor mode to make fat lisp butts appear slim.

### Direct link to the package repository

https://gitlab.com/marcowahl/lisp-butt-mode

### Your association with the package

 maintainer, contributor, An enthusiastic user

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
