### PR TITLE
Add recipe for evil-ruby-text-objects

### DIFF
--- a/recipes/evil-ruby-text-objects
+++ b/recipes/evil-ruby-text-objects
@@ -1,0 +1,1 @@
+(evil-ruby-text-objects :fetcher github :repo "porras/evil-ruby-text-objects")


### PR DESCRIPTION
### Brief summary of what the package does

Adds some text objects and keybindings to work with Ruby code with Evil.

### Direct link to the package repository

https://github.com/porras/evil-ruby-text-objects

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
