### PR TITLE
Add the phps-mode package recipe

### DIFF
--- a/recipes/phps-mode
+++ b/recipes/phps-mode
@@ -1,1 +1,1 @@
-(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "phps-mode-test*"))
+(phps-mode :fetcher github :repo "cjohansson/emacs-phps-mode" (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "phps-mode-test-*"))

--- a/recipes/phps-mode
+++ b/recipes/phps-mode
@@ -1,1 +1,1 @@
-(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github :exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "phps-mode-test*")
+(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "phps-mode-test*"))

--- a/recipes/phps-mode
+++ b/recipes/phps-mode
@@ -1,1 +1,1 @@
-(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github)
+(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github :exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "phps-mode-test*"))

--- a/recipes/phps-mode
+++ b/recipes/phps-mode
@@ -1,3 +1,1 @@
- (phps-mode :fetcher github :repo "cjohansson/emacs-phps-mode"
-            :files (:defaults (:exclude "phps-mode-test-*")))
-            
+(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github)

--- a/recipes/phps-mode
+++ b/recipes/phps-mode
@@ -1,1 +1,3 @@
-(phps-mode :fetcher github :repo "cjohansson/emacs-phps-mode" (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "phps-mode-test-*"))
+ (phps-mode :fetcher github :repo "cjohansson/emacs-phps-mode"
+            :files (:defaults (:exclude "phps-mode-test-*")))
+            

--- a/recipes/phps-mode
+++ b/recipes/phps-mode
@@ -1,1 +1,1 @@
-(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github :exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "phps-mode-test*"))
+(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github :exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el" "phps-mode-test*")

--- a/recipes/phps-mode
+++ b/recipes/phps-mode
@@ -1,0 +1,1 @@
+(phps-mode :repo "cjohansson/emacs-phps-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A new major-mode for PHP that is not based on cc-mode (as the original mode is). It has a built-in semantic lexer that should be equivalent to PHP re2c lexer and this is used for syntax coloring, imenu generation and indentation. It fully complies with PSR-1 and PSR-2 code styles. The future goals include eldoc support, semantic parser, code formatter, html/css/javascript indentation for inline token areas

### Direct link to the package repository

https://github.com/cjohansson/emacs-phps-mode

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
