### PR TITLE
add recipes/vterm-toggle

### DIFF
--- a/recipes/vterm-toggle
+++ b/recipes/vterm-toggle
@@ -1,0 +1,2 @@
+(vterm-toggle :fetcher github
+	:repo "jixiuf/vterm-toggle")


### PR DESCRIPTION
### Brief summary of what the package does
toggles between the vterm buffer and whatever buffer you are editing.

### Direct link to the package repository

https://github.com/jixiuf/vterm-toggle

### Your association with the package
the author.

### Relevant communications with the upstream package maintainer


### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them