### PR TITLE
change fetcher for underline-with-char

### DIFF
--- a/recipes/underline-with-char
+++ b/recipes/underline-with-char
@@ -1,1 +1,1 @@
-(underline-with-char :fetcher github :repo "marcowahl/underline-with-char")
+(underline-with-char :fetcher gitlab :repo "marcowahl/underline-with-char")


### PR DESCRIPTION
This is an attempt to move from github to gitlab.

Underline with a char

### Direct link to the package repository

https://gitlab.com/marcowahl/underline-with-char

### Your association with the package

 maintainer, contributor, occasional user

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Thanks!