### PR TITLE
change fetcher for rope-read-mode to gitlab

### DIFF
--- a/recipes/rope-read-mode
+++ b/recipes/rope-read-mode
@@ -1,1 +1,1 @@
-(rope-read-mode :fetcher github :repo "marcowahl/rope-read-mode")
+(rope-read-mode :fetcher gitlab :repo "marcowahl/rope-read-mode")


### PR DESCRIPTION
Please change fetcher for rope-read-mode to gitlab.


### Brief summary of what the package does

Rearrange lines to read text smoothly

### Direct link to the package repository

https://gitlab.com/marcowahl/rope-read-mode

### Your association with the package

Maintainer! A contributor! An enthusiastic user!

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
