### PR TITLE
change fetcher for emacsshot to gitlab

### DIFF
--- a/recipes/emacsshot
+++ b/recipes/emacsshot
@@ -1,1 +1,1 @@
-(emacsshot :fetcher github :repo "marcowahl/emacsshot")
+(emacsshot :fetcher gitlab :repo "marcowahl/emacsshot")


### PR DESCRIPTION
Please change the fetcher for emacsshot to gitlab.

### Brief summary of what the package does

Snapshot a frame or window from within.

### Direct link to the package repository

https://gitlab.com/marcowahl/emacsshot

### Your association with the package

Maintainer, contributor, user.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I'm not so easily tricked. ;)
