### PR TITLE
add haskell-tng

### DIFF
--- a/recipes/haskell-tng
+++ b/recipes/haskell-tng
@@ -2,4 +2,4 @@
  :repo "tseenshe/haskell-tng.el"
  :branch "tng"
  :fetcher gitlab
- :files ("*.el" "snippets" ".nosearch"))
+ :files (:defaults "snippets"))

--- a/recipes/haskell-tng
+++ b/recipes/haskell-tng
@@ -1,0 +1,4 @@
+(haskell-tng
+ :repo "tseenshe/haskell-tng.el"
+ :branch "tng"
+ :fetcher gitlab)

--- a/recipes/haskell-tng
+++ b/recipes/haskell-tng
@@ -1,4 +1,5 @@
 (haskell-tng
  :repo "tseenshe/haskell-tng.el"
  :branch "tng"
- :fetcher gitlab)
+ :fetcher gitlab
+ :files ("*.el" "snippets" ".nosearch"))


### PR DESCRIPTION
### Brief summary of what the package does

A modern alternative to `haskell-mode`

### Direct link to the package repository

https://gitlab.com/tseenshe/haskell-tng.el

### Your association with the package

Author.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
  - DISCLAIMER: I disagree with some of the lint messages (doesn't like `:` for package-internal symbols, maybe I'll use double dash in a future version)
