### PR TITLE
Recipe: Add org-ql

### DIFF
--- a/recipes/org-ql
+++ b/recipes/org-ql
@@ -1,0 +1,1 @@
+(org-ql :fetcher github :repo "alphapapa/org-ql")


### PR DESCRIPTION
### Brief summary of what the package does

`org-ql` is a lispy query language for Org files. It allows you to find Org entries matching certain criteria and return a list of them or perform actions on them. Commands are also provided which display a buffer with matching results, similar to an Org Agenda buffer.

### Direct link to the package repository
https://github.com/alphapapa/org-ql

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (*see notes*)
- [x] My elisp byte-compiles cleanly (*see notes*)
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

# Notes

* Using the latest version of `package-lint`, it's showing these spurious errors for top-level forms in `org-ql.el`, and a similar list in `org-ql-agenda.el`:
```
20:1: error: "cl-lib" doesn't start with package's prefix "org-ql".
21:1: error: "org" doesn't start with package's prefix "org-ql".
22:1: error: "org-habit" doesn't start with package's prefix "org-ql".
23:1: error: "seq" doesn't start with package's prefix "org-ql".
24:1: error: "subr-x" doesn't start with package's prefix "org-ql".
26:1: error: "dash" doesn't start with package's prefix "org-ql".
30:1: error: "when" doesn't start with package's prefix "org-ql".
53:1: error: "cl-defmacro" doesn't start with package's prefix "org-ql".
63:1: error: "cl-defmacro" doesn't start with package's prefix "org-ql".
114:1: error: "cl-defun" doesn't start with package's prefix "org-ql".
234:1: error: "define-hash-table-test" doesn't start with package's prefix "org-ql".
308:1: error: "cl-defun" doesn't start with package's prefix "org-ql".
```

* Also, the `*Package-Lint*` buffer doesn't properly jump to lines when I press `RET` on the items.  Something seems to be wrong with it.  Is it just me?

* These errors from `package-lint` are not spurious, but the aliases are necessary for compatibility with Org versions 9.0-9.1:
```
31:2: error: Aliases should start with the package's prefix "org-ql".
32:2: error: Aliases should start with the package's prefix "org-ql".

54:2: error: Aliases should start with the package's prefix "org-ql-agenda".
```

* As well, when byte-compiling, the `org-get-tags` compatibility alias may cause a spurious warning about number of arguments, depending on the version of Org being used.  It may be safely ignored, and won't matter in the future when support for Org <9.2 is dropped.