### PR TITLE
Add ox-latex-subfigure

### DIFF
--- a/recipes/ox-latex-subfigure
+++ b/recipes/ox-latex-subfigure
@@ -1,0 +1,1 @@
+(ox-latex-subfigure :repo "linktohack/ox-latex-subfigure" :fetcher github)


### PR DESCRIPTION
Should resolve https://github.com/linktohack/ox-latex-subfigure/issues/15

### Brief summary of what the package does

ox-latex-subfigure.el permits to export subfigure to latex

### Direct link to the package repository

https://github.com/linktohack/ox-latex-subfigure

### Your association with the package

[Are you the maintainer? A contributor? An enthusiastic user?]

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them