### PR TITLE
Add hercules.el recipe.

### DIFF
--- a/recipes/hercules
+++ b/recipes/hercules
@@ -1,0 +1,1 @@
+(hercules :repo "jjzmajic/hercules.el" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

An auto-magical, `which-key` based `hydra` banisher.

In at most 7 lines of set-up code, `hercules` lets you call any group
of related command sequentially with no prefix keys, while showing a
handy popup to remember the bindings for those commands. He can create
both of these (the grouped commands, and the popup) from any
keymap.

### Direct link to the package repository

https://gitlab.com/jjzmajic/hercules.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
