### PR TITLE
Update links to ameba & flycheck-ameba

### DIFF
--- a/recipes/ameba
+++ b/recipes/ameba
@@ -1,1 +1,1 @@
-(ameba :fetcher github :repo "veelenga/ameba.el" :files ("ameba.el"))
+(ameba :fetcher github :repo "crystal-ameba/ameba.el" :files ("ameba.el"))

--- a/recipes/flycheck-ameba
+++ b/recipes/flycheck-ameba
@@ -1,1 +1,1 @@
-(flycheck-ameba :fetcher github :repo "veelenga/ameba.el" :files ("flycheck-ameba.el"))
+(flycheck-ameba :fetcher github :repo "crystal-ameba/ameba.el" :files ("flycheck-ameba.el"))


### PR DESCRIPTION
Repo has been moved to the organization:

* https://github.com/crystal-ameba/ameba

Not critical because of old link still valid and redirect to the moved repo:

* https://github.com/veelenga/ameba 