### PR TITLE
Transfer Ponylang related modes to Ponylang organization

### DIFF
--- a/recipes/flycheck-pony
+++ b/recipes/flycheck-pony
@@ -1,1 +1,1 @@
-(flycheck-pony :fetcher github :repo "SeanTAllen/flycheck-pony")
+(flycheck-pony :fetcher github :repo "ponylang/flycheck-pony")

--- a/recipes/pony-snippets
+++ b/recipes/pony-snippets
@@ -1,4 +1,4 @@
 (pony-snippets
- :repo "SeanTAllen/pony-snippets"
+ :repo "ponylang/pony-snippets"
  :fetcher github
  :files (:defaults "snippets"))

--- a/recipes/ponylang-mode
+++ b/recipes/ponylang-mode
@@ -1,1 +1,1 @@
-(ponylang-mode :fetcher github :repo "SeanTAllen/ponylang-mode")
+(ponylang-mode :fetcher github :repo "ponylang/ponylang-mode")


### PR DESCRIPTION
Hi,

I'm the maintainer of these 3 Pony related modes. I've transferred them to the Ponylang org as they will have a more sustainable existence there rather than in a repository that only I have access to.