### PR TITLE
Add ox-haunt

### DIFF
--- a/recipes/ox-haunt
+++ b/recipes/ox-haunt
@@ -1,0 +1,1 @@
+(ox-haunt :url "https://git.sr.ht/~jakob/ox-haunt" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

Minor modifications to `ox-html` for producing files with a metadata header readable by `html-reader` in the [Haunt](https://dthompson.us/projects/haunt.html) static site generator.

### Direct link to the package repository

https://git.sr.ht/~jakob/ox-haunt

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
