### PR TITLE
Add flymake-quickdef

### DIFF
--- a/recipes/flymake-quickdef
+++ b/recipes/flymake-quickdef
@@ -1,0 +1,1 @@
+(flymake-quickdef :fetcher github :repo "karlotness/flymake-quickdef")


### PR DESCRIPTION
### Brief summary of what the package does

Helps write diagnostic/backend functions for the new Flymake (functions like the [example in the docs](https://www.gnu.org/software/emacs/manual/html_node/flymake/An-annotated-example-backend.html)).

It provides a skeleton that handles running an external check program, processing its output, and cleaning up scratch buffers and files.

### Direct link to the package repository

https://github.com/karlotness/flymake-quickdef

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

n/a

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
