### PR TITLE
Add ellocate

### DIFF
--- a/recipes/ellocate
+++ b/recipes/ellocate
@@ -1,0 +1,1 @@
+(ellocate :fetcher github :repo "walseb/ellocate")


### PR DESCRIPTION
### Brief summary of what the package does

It's a re-implementation of the locate command written in emacs-lisp. Like `counsel-locate` but without the wierd args to get it to use different databases than the default one

### Direct link to the package repository

https://github.com/walseb/ellocate

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them