### PR TITLE
Recipe: Add ts.el

### DIFF
--- a/recipes/ts
+++ b/recipes/ts
@@ -1,0 +1,1 @@
+(ts :fetcher github :repo "alphapapa/ts.el")


### PR DESCRIPTION
### Brief summary of what the package does

`ts` is a date and time library for Emacs. It aims to be more convenient than patterns like `(string-to-number (format-time-string "%Y"))` by providing easy accessors, like `(ts-year (ts-now))`.

### Direct link to the package repository

https://github.com/alphapapa/ts.el

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (*Note that this package actually exposes a bug in the current version of `package-lint`, which I'll file.*)
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (*Note one erroneous flag about spacing after a period which does not end a sentence.*)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
