### PR TITLE
Add recipe for flycheck-indicator

### DIFF
--- a/recipes/flycheck-indicator
+++ b/recipes/flycheck-indicator
@@ -1,0 +1,1 @@
+(flycheck-indicator :fetcher github :repo "gexplorer/flycheck-indicator")


### PR DESCRIPTION
A fancy mode line indicator for flycheck

### Brief summary of what the package does

Adds some icons and colors for the flycheck errors and statuses

### Direct link to the package repository

https://github.com/gexplorer/flycheck-indicator

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
