### PR TITLE
Add 0x0

### DIFF
--- a/recipes/0x0
+++ b/recipes/0x0
@@ -1,0 +1,1 @@
+(0x0 :url "https://git.sr.ht/~zge/nullpointer-emacs" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

A dependency-free client for the 0x0.st file upload service

### Direct link to the package repository

https://git.sr.ht/~zge/nullpointer-emacs

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
