### PR TITLE
Update nordless-theme recipe to use colorless-themes repo

### DIFF
--- a/recipes/nordless-theme
+++ b/recipes/nordless-theme
@@ -1,4 +1,4 @@
 (nordless-theme
-  :repo "lthms/nordless-theme.el"
-  :files ("nordless-theme.el")
-  :fetcher github)
+  :fetcher git
+  :url "https://git.sr.ht/~lthms/colorless-themes.el"
+  :files ("nordless-theme.el"))


### PR DESCRIPTION
### Brief summary of what the package does

nordless is a “mostly colorless theme” (that is, a theme with almost no syntax highlighting).

The previous version of nordless was standalone.  Nowadays, it is built thanks to colorless-themes, a package which provides a macro to easily derive “mostly colorless theme”.

### Direct link to the package repository

https://git.sr.ht/~lthms/colorless-themes.el

### Your association with the package

I am the author and the maintainer of the package.

### Relevant communications with the upstream package maintainer

The current version of `nordless-theme` hosted at github already uses `colorless-themes`, but I find it more convenient to have my themes in the same location.

Once this PR is merged, I will probably do several others to add my other themes.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
