### PR TITLE
Add recipe for mini-modeline

### DIFF
--- a/recipes/mini-modeline
+++ b/recipes/mini-modeline
@@ -1,0 +1,1 @@
+(mini-modeline :repo "kiennq/emacs-mini-modeline" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Merge mode line and minibuffer into one.

### Direct link to the package repository

https://github.com/kiennq/emacs-mini-modeline

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
