### PR TITLE
Add scihub

### DIFF
--- a/recipes/scihub
+++ b/recipes/scihub
@@ -1,0 +1,1 @@
+(scihub :fetcher github :repo "emacs-pe/scihub.el")


### PR DESCRIPTION
### Brief summary of what the package does
Emacs integration with Sci-Hub

### Direct link to the package repository

https://github.com/emacs-pe/scihub.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

none needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
