### PR TITLE
Move plain-theme upstream to GitHub

### DIFF
--- a/recipes/plain-theme
+++ b/recipes/plain-theme
@@ -1,1 +1,1 @@
-(plain-theme :fetcher gitlab :repo "yegortimoshenko/plain-theme")
+(plain-theme :fetcher github :repo "yegortimoshenko/plain-theme")


### PR DESCRIPTION
### Brief summary of what the package does

Package is an Emacs theme w/o syntax highlighting. This pull request moves upstream from GitLab to GitHub.

### Direct link to the package repository

https://github.com/yegortimoshenko/plain-theme

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
