### PR TITLE
adding ivy-clojuredocs

### DIFF
--- a/recipes/ivy-clojuredocs
+++ b/recipes/ivy-clojuredocs
@@ -1,0 +1,1 @@
+(ivy-clojuredocs :repo "wandersoncferreira/ivy-clojuredocs" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package is used to search for Clojure (core) documentation at the ClojureDocs.org website.

### Direct link to the package repository

https://github.com/wandersoncferreira/ivy-clojuredocs

### Your association with the package

I'm the maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
