### PR TITLE
Add evil-owl 

### DIFF
--- a/recipes/evil-owl
+++ b/recipes/evil-owl
@@ -1,0 +1,1 @@
+(evil-owl :repo "mamapanda/evil-owl" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`evil-owl` allows `evil-mode` users to preview marks and registers in a posframe before actually using them.

### Direct link to the package repository

https://github.com/mamapanda/evil-owl

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
