### PR TITLE
Add recipe for dart-server

### DIFF
--- a/recipes/dart-server
+++ b/recipes/dart-server
@@ -1,0 +1,2 @@
+(dart-server :fetcher github :repo "bradyt/dart-server"
+             :version-regexp "dart-server-\\(.*\\)")


### PR DESCRIPTION
### Brief summary of what the package does

Factors out the features from dart-mode.el that relied on external executables, thus improving availability, reliability, testing and development of dart-mode.el.

~~Once on melpa, I can push the slimmed down dart-mode.el to master.~~

### Direct link to the package repository

https://github.com/bradyt/dart-server

Commits splitting project into two roughly disjoint projects: 
- https://github.com/bradyt/dart-mode/commit/c5681185359c7db54756d7935de421da8eef37c7
- https://github.com/bradyt/dart-server/commit/a9f2034f29ad106b14947c10950da6671687e73a

### Your association with the package

I am the maintainer of the original combined package, and am nearly the sole author of what is left now in [current working tree of dart-mode.el](https://github.com/bradyt/dart-mode).

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] ~~`M-x checkdoc` is happy with my docstrings~~
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
