### PR TITLE
Recipe: Add org-rifle, change helm-org-rifle

### DIFF
--- a/recipes/helm-org-rifle
+++ b/recipes/helm-org-rifle
@@ -1,1 +1,2 @@
-(helm-org-rifle :fetcher github :repo "alphapapa/helm-org-rifle")
+(helm-org-rifle :fetcher github :repo "alphapapa/org-rifle"
+                :files ("helm-org-rifle.el"))

--- a/recipes/org-rifle
+++ b/recipes/org-rifle
@@ -1,0 +1,2 @@
+(org-rifle :fetcher github :repo "alphapapa/org-rifle"
+           :files ("org-rifle.el"))


### PR DESCRIPTION
`helm-org-rifle` is being split into separate packages, `org-rifle` and `helm-org-rifle`.  Both are built from the same repo.  

I have a branch about ready to push to `master` at https://github.com/alphapapa/org-rifle/tree/wip/org-rifle.

What's the best way to coordinate the transition?  If the new `helm-org-rifle` recipe is merged to MELPA before I push the new branch to `master`, or if I push to `master` before the recipe is merged, users who try to upgrade it will get an error because the `org-rifle` package won't yet be buildable and won't be available for installation, which the new `helm-org-rifle` package depends on.

Thanks.