### PR TITLE
Update to the new repo

### DIFF
--- a/recipes/hydandata-light-theme
+++ b/recipes/hydandata-light-theme
@@ -1,1 +1,1 @@
-(hydandata-light-theme :fetcher github :repo "hydandata/hydandata-light-theme")
+(hydandata-light-theme :fetcher github :repo "chkhd/hydandata-light-theme")


### PR DESCRIPTION
### Brief summary of what the package does

A light color theme that is easy on the eyes

NOTE: package-lint complains about package name not matching the provided theme, but I would like to avoid changing the theme-name since this is just repo change.

### Direct link to the package repository

https://github.com/chkhd/hydandata-light-theme

### Your association with the package

Author, original PR was #3456

### Relevant communications with the upstream package maintainer

nil

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them