### PR TITLE
Add clang-format+ recipe

### DIFF
--- a/recipes/clang-format+
+++ b/recipes/clang-format+
@@ -1,0 +1,3 @@
+(clang-format+
+ :repo "SavchenkoValeriy/emacs-clang-format-plus"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

*clang-format+* is a small package aimed at improving the user experience of using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) in Emacs. It defines a minor mode `clang-format+-mode`, which applies **clang-format** on save. It can also apply **clang-format** to the modified parts of the region only and try to be smart about it.

### Direct link to the package repository

https://github.com/SavchenkoValeriy/emacs-clang-format-plus

### Your association with the package

I am the author and the maintainer of the package

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
