### PR TITLE
add eshell-eldoc

### DIFF
--- a/recipes/eshell-eldoc
+++ b/recipes/eshell-eldoc
@@ -1,0 +1,1 @@
+(eshell-eldoc :fetcher github :repo "defaultxr/eshell-eldoc")


### PR DESCRIPTION
### Brief summary of what the package does

Eshell-eldoc provides Eldoc functionality for Eshell. It provides the normal Eldoc for Elisp code when Elisp functionality is being called, or a summary of the command from `whatis` when an external command is being called.

### Direct link to the package repository

https://github.com/defaultxr/eshell-eldoc

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
