### PR TITLE
add python-black

### DIFF
--- a/recipes/python-black
+++ b/recipes/python-black
@@ -1,3 +1,3 @@
-(gsettings
+(python-black
  :fetcher github
  :repo "wbolster/emacs-python-black")

--- a/recipes/python-black
+++ b/recipes/python-black
@@ -1,0 +1,3 @@
+(gsettings
+ :fetcher github
+ :repo "wbolster/emacs-python-black")


### PR DESCRIPTION
### Brief summary of what the package does

This is an Emacs package to make it easy to reformat Python code using black, the uncompromising Python code formatter.

### Direct link to the package repository

https://github.com/wbolster/emacs-python-black

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
