### PR TITLE
Add awscli-capf, a completion at point function for the AWS CLI

### DIFF
--- a/recipes/awscli-capf
+++ b/recipes/awscli-capf
@@ -1,0 +1,1 @@
+(awscli-capf :repo "sebasmonia/awscli-capf" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A completion at point function, with company support, for commands and parameters form the AWS command line tool.

### Direct link to the package repository

https://github.com/sebasmonia/awscli-capf

### Your association with the package

Mantainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

package-lint and I disagree on the prefix for private functions. I am open to suggestions on

1. Changing the package name and thus the prefix
2. Changing the prefix only
3. Doing what package-lint suggests if you agree with its feedback.

Basically `awscli-capf--` vs `awscli--capf-` for internal functions.