### PR TITLE
Add counsel-test recipe

### DIFF
--- a/recipes/counsel-test
+++ b/recipes/counsel-test
@@ -1,0 +1,4 @@
+(counsel-test
+ :repo "xmagpie/counsel-test"
+ :fetcher github
+ :files (:defaults "counsel-test.el"))


### PR DESCRIPTION
### Brief summary of what the package does

An emacs package that integrates ivy/counsel with different testing frameworks and allows interactive test discovery and execution.

### Direct link to the package repository

https://github.com/xmagpie/counsel-test

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings. There are several false positive warnings about the *tests* word in several docstrings. I beleive these can be ignored.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
