### PR TITLE
Add json-process-client

### DIFF
--- a/recipes/json-process-client
+++ b/recipes/json-process-client
@@ -1,0 +1,3 @@
+(json-process-client
+ :fetcher git
+ :url "https://gitlab.petton.fr/nico/json-process-client.git")


### PR DESCRIPTION
## Summary

The package json-process-client is an Emacs library to
facilitate communicating with servers that read and write JSON. The
library is responsible for starting the server and connecting with
TCP. It is also responsible for converting to and from JSON.

The library was written by Nicolas Petton in the context of Indium and
later generalized by Damien Cassou who needed something similar to
integrate basecamp within Emacs.

## Direct link to the package repository

https://gitlab.petton.fr/nico/json-process-client

## Assocation

 With Nicolas Petton's permission, I extract part of Indium and created json-process-client.

### Relevant communications with the upstream package maintainer

None needded

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
