### PR TITLE
Add vdf-mode

### DIFF
--- a/recipes/vdf-mode
+++ b/recipes/vdf-mode
@@ -1,0 +1,1 @@
+(vdf-mode :repo "plapadoo/vdf-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The package adds highlighting and indentation for Valve's VDF files.

### Direct link to the package repository

https://github.com/plapadoo/vdf-mode

### Your association with the package

I am the sole author of the package.

### Relevant communications with the upstream package maintainer

Not sure?

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
