### PR TITLE
Add comint-hyperlink

### DIFF
--- a/recipes/comint-hyperlink
+++ b/recipes/comint-hyperlink
@@ -1,0 +1,1 @@
+(comint-hyperlink :fetcher github :repo "matthewbauer/comint-hyperlink")


### PR DESCRIPTION
### Brief summary of what the package does

A filter for comint to add terminal hyperlinks as detailed in https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda

### Direct link to the package repository

https://github.com/matthewbauer/comint-hyperlink

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
