### PR TITLE
Add magit-vcsh

### DIFF
--- a/recipes/magit-vcsh
+++ b/recipes/magit-vcsh
@@ -1,0 +1,1 @@
+(magit-vcsh :fetcher gitlab :repo "stepnem/magit-vcsh-el")


### PR DESCRIPTION
[Cf. #6354]

Brief summary of what the package does

The package provides Magit integration with the vcsh CLI tool.

Direct link to the package repository

vcsh: https://github.com/RichiH/vcsh

This package (magit-vcsh.el): https://gitlab.com/stepnem/magit-vcsh-el

Your association with the package

I am the author.

Relevant communications with the upstream package maintainer

None needed

Checklist

Please confirm with x:

- [x] The package is released under a GPL-Compatible Free Software
      License.
- [x] I've read CONTRIBUTING.org
- [x] I've used the latest version of package-lint to check for
      packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] M-x checkdoc is happy with my docstrings
- [x] I've built and installed the package using the instructions in
      CONTRIBUTING.org
- [ ] I have confirmed some of these without doing them