### PR TITLE
Add fancy-dabbrev

### DIFF
--- a/recipes/fancy-dabbrev
+++ b/recipes/fancy-dabbrev
@@ -1,0 +1,1 @@
+(fancy-dabbrev :repo "jrosdahl/fancy-dabbrev" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

fancy-dabbrev essentially wraps the Emacs built-in dabbrev functionality, with two improvements:

1. **Preview**: The first expansion candidate will/can be shown when any text has been entered.
2. **Popup menu**: The first call to fancy-dabbrev-expand will expand the entered word prefix just like dabbrev-expand. But the second call will show a popup menu with other candidates (with the second candidate selected). The third call will advance to the third candidate, etc. It is also possible to go back to a previous candidate with fancy-dabbrev-backward. Selection from the menu can be canceled with C-g. Any cursor movement or typing will hide the menu again.

### Direct link to the package repository

https://github.com/jrosdahl/fancy-dabbrev

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
    - **I chose to ignore some suggestions about writing documentation for internal functions, though.**
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
    - **Installed using straight.el, not package.el.**
- [ ] I have confirmed some of these without doing them
