### PR TITLE
Add auto-clang-format

### DIFF
--- a/recipes/auto-clang-format
+++ b/recipes/auto-clang-format
@@ -1,0 +1,1 @@
+(auto-clang-format :repo "jrosdahl/auto-clang-format" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

auto-clang-format provides is a minor mode (auto-clang-format-mode) that runs clang-format-buffer before the buffer is saved to its file.

### Direct link to the package repository

https://github.com/jrosdahl/auto-clang-format

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
