### PR TITLE
Rename edwin to edwina

### DIFF
--- a/recipes/edwin
+++ b/recipes/edwin
@@ -1,3 +1,0 @@
-(edwin
- :fetcher github
- :repo "ajgrf/edwin")

--- a/recipes/edwina
+++ b/recipes/edwina
@@ -1,0 +1,4 @@
+(edwina
+ :fetcher github
+ :repo "ajgrf/edwina"
+ :old-names (edwin))


### PR DESCRIPTION
Edwin was accepted into MELPA yesterday, and shortly after sharing it on reddit I became aware of a problem with the name. See ajgrf/edwina#1. Apparently there is already an Emacs-like text editor named [Edwin](https://www.gnu.org/software/mit-scheme/documentation/mit-scheme-user/Edwin.html) associated with the GNU project.

This PR renames the package. Apologies, I should have just waited another day to submit it to MELPA.