### PR TITLE
Add stock-tracker

### DIFF
--- a/recipes/stock-tracker
+++ b/recipes/stock-tracker
@@ -1,0 +1,1 @@
+(stock-tracker :repo "beacoder/stock-tracker" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
stock-tracker enable users to track chinese stocks prices in emacs with json-api provided by netease company.

### Direct link to the package repository

https://github.com/beacoder/stock-tracker

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [ x] `M-x checkdoc` is happy with my docstrings
- [ x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
