### PR TITLE
Preparation for `kubel-evil`: ignoring the future `kubel-evil.el` file

### DIFF
--- a/recipes/kubel
+++ b/recipes/kubel
@@ -1,1 +1,4 @@
-(kubel :repo "abrochard/kubel" :fetcher github)
+(kubel :repo "abrochard/kubel" :fetcher github
+       :files
+       (:defaults
+        (:exclude "kubel-evil.el")))


### PR DESCRIPTION
### Brief summary of what the package does

This is just an update to the kubel recipe to exclude the `kubel-evil.el` file which will add evil keybindings as a separate package. This is copying the method that the current `kuberenetes` and `kubernetes-evil` recipes use.

### Direct link to the package repository

https://github.com/abrochard/kubel/pull/4/files

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [ X I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
