### PR TITLE
Add rbtagger

### DIFF
--- a/recipes/rbtagger
+++ b/recipes/rbtagger
@@ -1,0 +1,4 @@
+(rbtagger
+ :fetcher github
+ :repo "thiagoa/rbtagger"
+ :files (:defaults "bin"))


### PR DESCRIPTION
### Brief summary of what the package does

A ctags-based Emacs utility to index Ruby projects along with gems. It aims to provide context-aware, accurate tag lookup by parsing the current Ruby file and an easy-to-use tags solution that works out of the box.

### Direct link to the package repository

https://github.com/thiagoa/rbtagger

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them