### PR TITLE
Add annalist.el

### DIFF
--- a/recipes/annalist
+++ b/recipes/annalist
@@ -1,0 +1,2 @@
+(annalist :fetcher github
+          :repo "noctuid/annalist.el")


### PR DESCRIPTION
### Brief summary of what the package does
`annalist` is a package for recording information and later printing it using org-mode headings and tables. Both general.el and evil-collection use org-mode for displaying recorded keybindings. `annalist` generalizes and extracts this functionality into a library that can be used by both (and other packages).

### Direct link to the package repository

https://github.com/noctuid/annalist.el

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist
- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

(`package-lint` and also `elisp-lint` checks pass and I've tested it in the sandbox)