### PR TITLE
Transition from 'picolisp-mode' to 'plisp-mode'.

### DIFF
--- a/recipes/picolisp-mode
+++ b/recipes/picolisp-mode
@@ -1,3 +1,4 @@
 (picolisp-mode
  :fetcher github
- :repo "flexibeast/picolisp-mode")
+ :repo "flexibeast/plisp-mode"
+ :files ("picolisp-mode.el" "inferior-picolisp.el"))

--- a/recipes/plisp-mode
+++ b/recipes/plisp-mode
@@ -1,0 +1,4 @@
+(plisp-mode
+ :fetcher github
+ :repo "flexibeast/plisp-mode"
+ :files ("plisp-mode.el" "inferior-plisp.el"))


### PR DESCRIPTION
Following private discussions with @purcell, this PR begins the transition for the renaming of `picolisp-mode` to `plisp-mode`. This renaming will remove the naming conflict with other `picolisp-mode` packages (e.g. https://github.com/tj64/picolisp-mode, which is not on MELPA).

Once this PR is merged, i will add code to the old `picolisp-mode.el` and `inferior-picolisp.el` packages in my repo to warn users that the `picolisp-mode` package on MELPA is obsolete, and that they should use `plisp-mode` instead.

cc: @tarsius 