### PR TITLE
Recipe: Add prism

### DIFF
--- a/recipes/prism
+++ b/recipes/prism
@@ -1,0 +1,1 @@
+(prism :fetcher github :repo "alphapapa/prism.el")


### PR DESCRIPTION
### Brief summary of what the package does

`prism` disperses lisp forms (and other syntax bounded by parentheses, brackets, and braces) into a spectrum of color by depth. It’s similar to `rainbow-blocks`, but it respects existing non-color face properties, and allows flexible configuration of faces and colors. It also optionally colorizes strings and/or comments by code depth in a similar, customizable way.

### Direct link to the package repository

https://github.com/alphapapa/prism.el

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Thanks.