### PR TITLE
recipes/plain-org-wiki: Add plain-org-wiki

### DIFF
--- a/recipes/plain-org-wiki
+++ b/recipes/plain-org-wiki
@@ -1,0 +1,1 @@
+(plain-org-wiki :fetcher github :repo "abo-abo/plain-org-wiki")


### PR DESCRIPTION
### Brief summary of what the package does

Quickly browse or create Org files.

### Direct link to the package repository

https://github.com/abo-abo/plain-org-wiki

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
