### PR TITLE
add frecentf

### DIFF
--- a/recipes/frecentf
+++ b/recipes/frecentf
@@ -1,0 +1,3 @@
+(frecentf :fetcher git
+	  :url "https://git.launchpad.net/frecentf.el"
+	  :commit "origin/master")

--- a/recipes/frecentf
+++ b/recipes/frecentf
@@ -1,3 +1,2 @@
 (frecentf :fetcher git
-	  :url "https://git.launchpad.net/frecentf.el"
-	  :commit "origin/master")
+	  :url "https://git.launchpad.net/frecentf.el")


### PR DESCRIPTION
### Brief summary of what the package does

Pervasive recentf using frecency

### Direct link to the package repository

https://launchpad.net/frecentf.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

Versions of `persist` previous to 0.4 do not work (cannot persist a `hash-table`). I had real trouble trying to make sure this is the version that I was using (I have less trouble installing stuff from melpa than from elpa).

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback... although I use `straight` so I may have [missed something](https://github.com/purcell/package-lint/issues/108).
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
