### PR TITLE
Add libbasecampel

### DIFF
--- a/recipes/libbasecampel
+++ b/recipes/libbasecampel
@@ -1,0 +1,1 @@
+(libbasecampel :fetcher github :repo "DamienCassou/libbasecampel")


### PR DESCRIPTION
### Brief summary of what the package does

The package is an Emacs library to interact with Basecamp
(https://basecamp.com), a project management web application. The
package depends on an external proxy implemented in JS (the same way
Indium is implemented https://melpa.org/#/indium).

### Direct link to the package repository

https://gitlab.petton.fr/basecampel/libbasecampel

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
