### PR TITLE
Revert removal of fountain-mode

### DIFF
--- a/recipes/fountain-mode
+++ b/recipes/fountain-mode
@@ -1,0 +1,1 @@
+(fountain-mode :fetcher github :repo "rnkn/fountain-mode")


### PR DESCRIPTION
I'm moving fountain-mode back off GNU ELPA and distributing via MELPA again.

This reverts commit ef4118814506db4dbdeaa15a6258ff28c9461748.

### Brief summary of what the package does

Fountain Mode is a scriptwriting program for GNU Emacs using the fountain plain text markup format.

### Direct link to the package repository

https://github.com/rnkn/fountain-mode

### Your association with the package

author/maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - Ignored some false positives: I've included aliases for `outline-` commands for backwards compatibility with Emacs < 25.1 when these lacked the prefix.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
