### PR TITLE
Revert removal of olivetti

### DIFF
--- a/recipes/olivetti
+++ b/recipes/olivetti
@@ -1,0 +1,2 @@
+(olivetti :fetcher github
+          :repo "rnkn/olivetti")


### PR DESCRIPTION
Moving olivetti back from GNU ELPA to the MELPA mothership.

This reverts commit b4c165259030aa03affad3e7fd39c8ec9125668f.

### Brief summary of what the package does

Sets and balances window margin widths interactively to allow for a nicer writing environment.

### Direct link to the package repository

https://github.com/rnkn/olivetti

### Your association with the package

author/maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
