### PR TITLE
Add swift-helpful recipe

### DIFF
--- a/recipes/swift-helpful
+++ b/recipes/swift-helpful
@@ -1,0 +1,3 @@
+(swift-helpful :repo "danielmartin/swift-helpful"
+               :fetcher github
+               :files ("*.el" "swift-info/*.info"))

--- a/recipes/swift-helpful
+++ b/recipes/swift-helpful
@@ -1,3 +1,3 @@
 (swift-helpful :repo "danielmartin/swift-helpful"
                :fetcher github
-               :files ("*.el" "swift-info/*.info"))
+               :files ("*.el" "swift-info/*.info" ("images" "swift-info/images/*.png")))


### PR DESCRIPTION
### Brief summary of what the package does

swift-helpful is a package that includes curated Swift documentation from Apple in GNU Info format
(original license is Creative Commons: https://swift.org/documentation/).

Invoke `M-x swift-helpful-configure-manuals` first to make sure Emacs can search the installed GNU Info manuals using `info-look`.

After that, if you open a `.swift` file, place the point on a keyword and invoke `M-x swift-helpful`, you will see a documentation snippet explaining the programming concept represented by that keyword.

If lsp-mode is configured, API documentation is also shown.

### Direct link to the package repository

https://github.com/danielmartin/swift-helpful

### Your association with the package

I created the package.

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them