### PR TITLE
add recipe for lsp-julia

### DIFF
--- a/recipes/lsp-julia
+++ b/recipes/lsp-julia
@@ -1,0 +1,5 @@
+(lsp-julia :fetcher github
+           :repo "gdkrmr/lsp-julia"
+           :files ("*.el"
+                   "README.org"
+                   "languageserver"))

--- a/recipes/lsp-julia
+++ b/recipes/lsp-julia
@@ -1,5 +1,3 @@
 (lsp-julia :fetcher github
            :repo "non-Jedi/lsp-julia"
-           :files ("*.el"
-                   "README.org"
-                   "languageserver"))
+           :files (:defaults "languageserver"))

--- a/recipes/lsp-julia
+++ b/recipes/lsp-julia
@@ -1,5 +1,5 @@
 (lsp-julia :fetcher github
-           :repo "gdkrmr/lsp-julia"
+           :repo "non-Jedi/lsp-julia"
            :files ("*.el"
                    "README.org"
                    "languageserver"))


### PR DESCRIPTION
### Brief summary of what the package does

Julia support for `lsp-mode`.

### Direct link to the package repository

https://github.com/non-jedi/lsp-julia

### Your association with the package

Maintainer of the package

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
