### PR TITLE
added recipe for org-working-set

### DIFF
--- a/recipes/org-working-set
+++ b/recipes/org-working-set
@@ -1,0 +1,2 @@
+(org-working-set :fetcher github
+	   :repo "marcIhm/org-working-set")


### PR DESCRIPTION
### Brief summary of what the package does

Maintain a small and changing subset of your org-nodes to visit with ease.

### Direct link to the package repository

https://github.com/marcIhm/org-working-set

### Your association with the package

I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Remark: I use two prefixes for my package: org-working-set- and org-ws-- ; I do this for brevity although package-lint-current-buffer is complaining; I hope this is okay for you.