### PR TITLE
Recipe: Add org-sidebar

### DIFF
--- a/recipes/org-sidebar
+++ b/recipes/org-sidebar
@@ -1,0 +1,1 @@
+(org-sidebar :fetcher github :repo "alphapapa/org-sidebar")


### PR DESCRIPTION
### Brief summary of what the package does

This package presents a helpful sidebar view for Org buffers. At the top is a chronological list of scheduled and deadlined tasks in the current buffer (similar to the Org agenda ,but without all its features), and below that is a list of all other non-done to-do items. If the buffer is narrowed, the sidebar only shows items in the narrowed portion; this allows seeing an overview of tasks in a subtree.

### Direct link to the package repository

https://github.com/alphapapa/org-sidebar

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Thanks.