### PR TITLE
Add ‘eterm-fn’ recipe.

### DIFF
--- a/recipes/eterm-fn
+++ b/recipes/eterm-fn
@@ -1,0 +1,1 @@
+(eterm-fn :fetcher github :repo "oitofelix/eterm-fn" :files (:defaults "*.ti"))


### PR DESCRIPTION
----

### Brief summary of what the package does

Function keys (F1--F12) for GNU Emacs terminal

This library provides the ‘eterm-fn-mode’: a global minor mode that
makes term mode capable of handling the keyboard function keys
(F1--F12).  This consists of detecting their presses and sending
their respective escape codes to the underlying process and also
providing a terminfo database to export such capabilities to
ncurses-based applications.  The X11R6 xterm’s escape codes are
used.

Both standard 16 colors and extended 256 colors terminals are
supported.  The latter is provided by package ‘eterm-256color’,
which is automatically detected in case it’s present.

Customize the variable ‘eterm-fn-mode’ to enable this mode globally.

### Direct link to the package repository

https://github.com/oitofelix/eterm-fn

### Your association with the package

I’m the original author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them