### PR TITLE
Add ‘tramp-auto-auth’ recipe.

### DIFF
--- a/recipes/tramp-auto-auth
+++ b/recipes/tramp-auto-auth
@@ -1,0 +1,1 @@
+(tramp-auto-auth :fetcher github :repo "oitofelix/tramp-auto-auth")


### PR DESCRIPTION
----

### Brief summary of what the package does

TRAMP automatic authentication library

This library provides `tramp-auto-auth-mode`: a global minor mode
whose purpose is to automatically feed TRAMP sub-processes with
passwords for paths matching regexps.  This is useful in situations
where interactive user input is not desirable or feasible.  For
instance, in sub-nets with large number of hosts or whose hosts have
dynamic IPs assigned to them.  In those cases it’s not practical to
query passwords using the `auth-source` library directly, since this
would require each host to be listed explicitly and immutably in a
Netrc file.  Another scenario where this mode is useful are
non-interactive Emacs sessions (like those used for batch processing
or by evaluating `:async` Org Babel source blocks) in which it’s
impossible for the user to answer a password-asking prompt.

When a TRAMP prompt is encountered, `tramp-auto-auth-mode` queries the
alist `tramp-auto-auth-alist` for the auth-source spec value whose
regexp key matches the correspondent TRAMP path.  This spec is then
used to query the auth-source library for a presumably phony entry
exclusively dedicated to the whole class of TRAMP paths matching that
regexp.

To make use of the automatic authentication feature, on the Lisp side
the variable `tramp-auto-auth-alist` must be customized to hold the
path regexps and their respective auth-source specs, and then
`tramp-auto-auth-mode` must be enabled.  For example:

#### **`~/.emacs.el`**
```elisp
(require 'tramp-auto-auth)

(add-to-list
 'tramp-auto-auth-alist
 '("root@10\\.0\\." .
   (:host "Funny-Machines" :user "root" :port "ssh")))

(tramp-auto-auth-mode)
```

After this, just put the respective sacred secret in an
authentication source supported by auth-source library.  For
instance:

#### **`~/.authinfo.gpg`**
```elisp
machine Funny-Machines login root password "$r00tP#sWD!" port ssh
```

In case you are feeling lazy or the secret is not so secret (nor so
sacred) -- or for any reason you need to do it all from Lisp --
it’s enough to:

```elisp
(auth-source-remember '(:host "Funny-Machines" :user "root" :port "ssh")
		         '((:secret "$r00tP#sWD!")))
```

And happy TRAMPing!

### Direct link to the package repository

https://github.com/oitofelix/tramp-auto-auth

### Your association with the package

I’m the original author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them