### PR TITLE
Add ‘info-rename-buffer’ recipe.

### DIFF
--- a/recipes/info-rename-buffer
+++ b/recipes/info-rename-buffer
@@ -1,0 +1,1 @@
+(info-rename-buffer :fetcher github :repo "oitofelix/info-rename-buffer")


### PR DESCRIPTION
----

### Brief summary of what the package does

Rename Info buffers to match manuals

`info-rename-buffer-mode` is a global minor-mode that automatically
renames Info buffers to match their visiting manual.

That’s a useful feature when consulting several Info manuals
simultaneously, because it frees the user from the burden of renaming
Info buffers to descriptive names manually before visiting another
manual, thus avoiding accidentally overriding the currently visited
node in case the user tries to open a new Info buffer.

### Direct link to the package repository

https://github.com/oitofelix/info-rename-buffer

### Your association with the package

I’m the original author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them