### PR TITLE
Add :files to org2blog.

### DIFF
--- a/recipes/org2blog
+++ b/recipes/org2blog
@@ -1,1 +1,1 @@
-(org2blog :repo "org2blog/org2blog" :fetcher github)
+(org2blog :repo "org2blog/org2blog" :fetcher github :files (:defaults "README.org"))


### PR DESCRIPTION
Now Org2Blog uses README.org in its package so add :files, specifying README.org.

Tested against Emacs 26.3 by building the package at the command line, inspecting the tar file, and then in Emacs installing the package using package-install-file and inspecting the directory under the elpa dir, and the package loaded successfully as expected.