### PR TITLE
Add ob-svgbob recipe

### DIFF
--- a/recipes/ob-svgbob
+++ b/recipes/ob-svgbob
@@ -1,0 +1,3 @@
+(ob-svgbob
+  :fetcher github
+  :repo "mgxm/ob-svgbob")


### PR DESCRIPTION
### Brief summary of what the package does

Org-babel support for [svgbob](https://github.com/ivanceras/svgbob).

### Direct link to the package repository

https://github.com/mgxm/ob-svgbob

### Your association with the package

An enthusiastic user. Tracking publishing to MELPA in this issue https://github.com/mgxm/ob-svgbob/issues/1

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

`package-lint` and `checkdoc` have some warnings, fixing them in https://github.com/mgxm/ob-svgbob/pull/2