### PR TITLE
[fix_codcut] fix missed recipe name in #6406

### DIFF
--- a/recipes/codcut
+++ b/recipes/codcut
@@ -1,0 +1,1 @@
+(codcut :repo "codcut/codcut-emacs" :fetcher github)

--- a/recipes/codcut-emacs
+++ b/recipes/codcut-emacs
@@ -1,1 +1,0 @@
-(codcut-emacs :repo "codcut/codcut-emacs" :fetcher github)


### PR DESCRIPTION
fyi @dgopsq, I made a mistake when I merged the recipe - the build expects the package to have the same name as the elisp file.  I should have rebuilt your PR after the name change.