### PR TITLE
Rename libbasecampel to libbcel

### DIFF
--- a/recipes/libbasecampel
+++ b/recipes/libbasecampel
@@ -1,1 +1,0 @@
-(libbasecampel :fetcher github :repo "DamienCassou/libbasecampel")

--- a/recipes/libbcel
+++ b/recipes/libbcel
@@ -1,0 +1,4 @@
+(libbcel
+ :fetcher github
+ :repo "DamienCassou/libbcel"
+ :old-names (libbasecampel))


### PR DESCRIPTION
This renames libbasecampel to libbcel to comply with Basecamp guidelines: https://github.com/basecamp/api/blob/master/sections/brand_guidelines.md.