### PR TITLE
Adding rms-quote package recipe

### DIFF
--- a/recipes/rms-quote
+++ b/recipes/rms-quote
@@ -1,0 +1,3 @@
+(rms-quote :fetcher github :repo "m0n73/rms-quote" 
+           :files (:defaults "rms-quotes.list"))
+ 


### PR DESCRIPTION
### Brief summary of what the package does
This package selects and messages out a random crazy thing RMS
has said in the past. The user can add to the quotes list directly from
emacs.

### Direct link to the package repository

https://github.com/m0n73/rms-quote

### Your association with the package

I am the maintainer and so far sole contributor. 

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
