### PR TITLE
Add global-tags

### DIFF
--- a/recipes/global-tags
+++ b/recipes/global-tags
@@ -1,0 +1,2 @@
+(global-tags :fetcher git
+             :url "https://git.launchpad.net/global-tags.el")


### PR DESCRIPTION
### Brief summary of what the package does


Tastable Emacs Lisp API that wraps around GNU global tag system

### Direct link to the package repository

https://launchpad.net/global-tags.el

### Your association with the package

An enthusiastic user?

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

cc @FelipeLema

When I'm testing the package built via `make recipes/global-tags`, I keep getting the error:

    package-buffer-info: Search failed: ";;; global.el ends here"

I have no idea how to fix this...