### PR TITLE
remove ensime and return scala-mode/sbt-mode to original author

### DIFF
--- a/recipes/ensime
+++ b/recipes/ensime
@@ -1,2 +1,0 @@
-(ensime :fetcher github
-	:repo "ensime/ensime-emacs")

--- a/recipes/sbt-mode
+++ b/recipes/sbt-mode
@@ -1,3 +1,3 @@
 (sbt-mode
- :repo "ensime/emacs-sbt-mode"
+ :repo "hvesalai/sbt-mode"
  :fetcher github)

--- a/recipes/scala-mode
+++ b/recipes/scala-mode
@@ -1,4 +1,4 @@
 (scala-mode
- :repo "ensime/emacs-scala-mode"
+ :repo "hvesalai/scala-mode2"
  :branch "master"
  :fetcher github)


### PR DESCRIPTION
The ENSIME project is shutting down, all repositories are now archived.

The `ensime` package is no longer maintained (and confirmed it no longer works for recent versions of Scala). This PR deletes the `ensime` package and returns ownership of `scala-mode` / `sbt-mode` to @hvesalai, the original and best author.

My conclusion is that community initiatives are a waste of time: individual contributors are the best way to advance free software. I apologise to Heikki Vesalainen for roping him into this and I encourage anybody who wants to contribute to Free Software to take the following hard-earned advice to heart: https://medium.com/@fommil/hide-your-real-name-in-open-source-3d67e74a8c56

Note to @hvesalai if you want to retain the issue tracker and PR history from the `ensime/` versions of this repository I can assign you the ownership of the repos but github says that you must delete your fork first (I tried it already). https://github.com/ensime/emacs-scala-mode/settings and https://github.com/ensime/emacs-sbt-mode/settings. Specifically it says "hvesalai already has a repository in the ensime/emacs-scala-mode network and You can only transfer a repository from an organization to yourself at this time "