### PR TITLE
Update stan-mode

### DIFF
--- a/recipes/stan-mode
+++ b/recipes/stan-mode
@@ -1,4 +1,5 @@
 (stan-mode
  :fetcher github
  :repo "stan-dev/stan-mode"
- :files ("stan-mode/*.el"))
+ :files ("stan-mode/*.el"
+         (:exclude "stan-mode/test-*.el")))


### PR DESCRIPTION
This is a split version of https://github.com/melpa/melpa/pull/6444

### Brief summary of what the package does

The `stan-mode` provides indentation and syntax highlighting for the Stan, a probabilistic programming language for Bayesian statistical inference. This recipe update excludes newly included `test-*.el` `buttercup` test files. 

Actual changes to the package are in https://github.com/stan-dev/stan-mode/commit/a6104ecf33e134192a42a62c0912e72c5bc64019

### Direct link to the package repository

https://github.com/stan-dev/stan-mode
https://github.com/stan-dev/stan-mode/stan-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them