### PR TITLE
Update stan-snippets

### DIFF
--- a/recipes/stan-snippets
+++ b/recipes/stan-snippets
@@ -2,4 +2,5 @@
  :fetcher github
  :repo "stan-dev/stan-mode"
  :files ("stan-snippets/stan-snippets.el"
-	 ("snippets/stan-mode" "stan-snippets/snippets/stan-mode/.yas-*")))
+	 ("snippets/stan-mode" "stan-snippets/snippets/stan-mode/*")
+         (:exclude "stan-snippets/test-*.el")))


### PR DESCRIPTION
This is a split version of https://github.com/melpa/melpa/pull/6444

## Brief summary of what the package does

The `stan-snippets` provides `yasnippet` templates for all statements and functions in Stan, a probabilistic programming language for Bayesian statistical inference.

The recipe has been updated to:
- Include all files under snippets/stan-mode to package original snippet files rather than just the compiled snippets file.
- Exclude `buttercup` test files

Actual changes to the package are in https://github.com/stan-dev/stan-mode/commit/f7ccceb91039dfcff45934326d0050f7e4d1713b

### Direct link to the package repository

https://github.com/stan-dev/stan-mode
https://github.com/stan-dev/stan-mode/stan-snippets

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them