### PR TITLE
Add ac-stan

### DIFF
--- a/recipes/ac-stan
+++ b/recipes/ac-stan
@@ -1,0 +1,6 @@
+(ac-stan
+ :fetcher github
+ :repo "stan-dev/stan-mode"
+ :files ("ac-stan/*.el"
+         ("ac-dict" "ac-stan/ac-dict/stan-mode")
+         (:exclude "ac-stan/test-*.el")))


### PR DESCRIPTION
This is a split version of https://github.com/melpa/melpa/pull/6444

## Brief summary of what the package does

The `ac-stan` provides completion via `auto-complete` for all statements and functions in Stan, a probabilistic programming language for Bayesian statistical inference.

Actual changes to the package are in https://github.com/stan-dev/stan-mode/commit/05b63a22dace043e8d52519fc44028bb4bd725f1. This package existed but had never been submitted to MELPA.

### Direct link to the package repository

https://github.com/stan-dev/stan-mode
https://github.com/stan-dev/stan-mode/ac-stan

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them