### PR TITLE
Add company-stan

### DIFF
--- a/recipes/company-stan
+++ b/recipes/company-stan
@@ -1,0 +1,5 @@
+(company-stan
+ :fetcher github
+ :repo "stan-dev/stan-mode"
+ :files ("company-stan/*.el"
+         (:exclude "company-stan/test-*.el")))


### PR DESCRIPTION
This is a split version of https://github.com/melpa/melpa/pull/6444

## Brief summary of what the package does

The `company-stan` provides completion via `company` for all statements and functions in Stan, a probabilistic programming language for Bayesian statistical inference.

This package was newly added in https://github.com/stan-dev/stan-mode/commit/1b1a537936422adb50a2b7677203ed8c37168875

### Direct link to the package repository

https://github.com/stan-dev/stan-mode
https://github.com/stan-dev/stan-mode/company-stan

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them