### PR TITLE
Add eldoc-stan

### DIFF
--- a/recipes/eldoc-stan
+++ b/recipes/eldoc-stan
@@ -3,4 +3,5 @@
  :repo "stan-dev/stan-mode"
  :files ("eldoc-stan/*.el"
 	 "eldoc-stan/eldoc-stan.json"
-         (:exclude "eldoc-stan/test-*.el")))
+         (:exclude "eldoc-stan/test-*.el"
+                   "eldoc-stan/eldoc-stan-create-json.el")))

--- a/recipes/eldoc-stan
+++ b/recipes/eldoc-stan
@@ -1,0 +1,6 @@
+(eldoc-stan
+ :fetcher github
+ :repo "stan-dev/stan-mode"
+ :files ("eldoc-stan/*.el"
+	 "eldoc-stan/eldoc-stan.json"
+         (:exclude "eldoc-stan/test-*.el")))


### PR DESCRIPTION
This is a split version of https://github.com/melpa/melpa/pull/6444

## Brief summary of what the package does

The `eldoc-stan` provides live help for function arguments via `eldoc` for all functions in Stan, a probabilistic programming language for Bayesian statistical inference.

This package was newly added in https://github.com/stan-dev/stan-mode/commit/d3c045c74cce32121e0e9c13a7222c537a14bbf7

### Direct link to the package repository

https://github.com/stan-dev/stan-mode
https://github.com/stan-dev/stan-mode/eldoc-stan

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them