### PR TITLE
Add flycheck-stan

### DIFF
--- a/recipes/flycheck-stan
+++ b/recipes/flycheck-stan
@@ -3,4 +3,5 @@
  :repo "stan-dev/stan-mode"
  :files ("flycheck-stan/*.el"
 	 "flycheck-stan/error_msgs.txt"
-         (:exclude "flycheck-stan/test-*.el")))
+         (:exclude "flycheck-stan/test-*.el"
+                   "flycheck-stan/flycheck-stan-error-msgs.el")))

--- a/recipes/flycheck-stan
+++ b/recipes/flycheck-stan
@@ -1,0 +1,6 @@
+(flycheck-stan
+ :fetcher github
+ :repo "stan-dev/stan-mode"
+ :files ("flycheck-stan/*.el"
+	 "flycheck-stan/error_msgs.txt"
+         (:exclude "flycheck-stan/test-*.el")))


### PR DESCRIPTION
This is a split version of https://github.com/melpa/melpa/pull/6444

## Brief summary of what the package does

The `flycheck-stan` provides on-the-fly syntax check for Stan via its compiler `stanc`. Stan is a probabilistic programming language for Bayesian statistical inference.

This package was newly added in https://github.com/stan-dev/stan-mode/commit/0d875ad012d85c898fe6682b62df6182295b6871 based on a very early form that was never released.

### Direct link to the package repository

https://github.com/stan-dev/stan-mode
https://github.com/stan-dev/stan-mode/flycheck-stan

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them