### PR TITLE
Add company-ctags recipe

### DIFF
--- a/recipes/company-ctags
+++ b/recipes/company-ctags
@@ -1,0 +1,1 @@
+(company-ctags :fetcher github :repo "redguardtoo/company-ctags")


### PR DESCRIPTION
### Brief summary of what the package does

This library enables the completion using Company mode and Ctags for Emacs. It's simply fast because a new optimized algorithm is designed for Ctags.

### Direct link to the package repository

https://github.com/redguardtoo/company-ctags

### Your association with the package

I'm the developer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them
