### PR TITLE
Remove amixer repository

### DIFF
--- a/recipes/amixer
+++ b/recipes/amixer
@@ -1,1 +1,0 @@
-(amixer :fetcher github :repo "remvee/amixer-el")


### PR DESCRIPTION
It has a conflicting name.  Others include a amixer.el in emacspeak and amixer.el by Ole Arndt.

See also https://github.com/melpa/melpa/pull/6433#issuecomment-535502711.
