### PR TITLE
Add awscli-capf recipe

### DIFF
--- a/recipes/awscli-capf
+++ b/recipes/awscli-capf
@@ -1,0 +1,1 @@
+(awscli-capf :repo "sebasmonia/awscli-capf" :fetcher github)

--- a/recipes/awscli-capf
+++ b/recipes/awscli-capf
@@ -1,1 +1,1 @@
-(awscli-capf :repo "sebasmonia/awscli-capf" :fetcher github)
+(awscli-capf :repo "sebasmonia/awscli-capf" :fetcher github :files (:defaults "*.data"))


### PR DESCRIPTION
### Brief summary of what the package does

Provide completion at point for the AWS CLI

### Direct link to the package repository

https://github.com/sebasmonia/awscli-capf.git

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ X `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them


NOTE: I found out some issues running the completion data refresh under Linux. I saw the pre-packaged data as optional but until I can work out the issue I prefer to include in the package for better usability, hence the change in the recipe.