### PR TITLE
Add ewal-doom-themes recipe.

### DIFF
--- a/recipes/ewal-doom-themes
+++ b/recipes/ewal-doom-themes
@@ -1,0 +1,4 @@
+(ewal-doom-themes
+ :fetcher gitlab
+ :repo "jjzmajic/ewal"
+ :files ("doom-themes/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

An ewal adapter for doom-themes discussed here https://github.com/hlissner/emacs-doom-themes/pull/327

### Direct link to the package repository

https://gitlab.com/jjzmajic/ewal

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly (`def-doom-theme` causes bytecode overflow even in the `doom-themes` package)
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
