### PR TITLE
Add recipe for lsp-ivy

### DIFF
--- a/recipes/lsp-ivy
+++ b/recipes/lsp-ivy
@@ -1,0 +1,1 @@
+(lsp-ivy :repo "emacs-lsp/lsp-ivy" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`lsp-ivy` is the ivy counterpart to `helm-lsp`. It allows the user to interactively search for, and jump to, symbols offered by the underlying `lsp-mode` workspace

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-ivy

### Your association with the package

maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback ~~(mostly, but package-lint keeps complaining about the empty Commentary section. May add some content if and when I can come up with something interesting to say)~~
- [x] My elisp byte-compiles cleanly ~~(mostly; there is one unused lexical argument within a lambda passed to `ivy-read` but I don't want to remove that without further testing and I won't do that today. If you wish to hold the PR until that is resolved, that's completely fine with me)~~ Edit: this has been fixed by a PR submitted by @abo-abo
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)