### PR TITLE
Added ivy-backup

### DIFF
--- a/recipes/git-backup-ivy
+++ b/recipes/git-backup-ivy
@@ -1,0 +1,1 @@
+(git-backup-ivy :fetcher github :repo "walseb/git-backup-ivy")


### PR DESCRIPTION
### Brief summary of what the package does

This allows the package helm-backup to be used with ivy

EDIT:
This allows the package provides an interface for git-backup using ivy

### Direct link to the package repository

https://github.com/walseb/git-backup-ivy

~https://github.com/walseb/ivy-backup~

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**
(I attempted to get this into helm-backup itself here https://github.com/antham/helm-backup/pull/35
But I think the extra modularity is good)

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
