### PR TITLE
add zero-input package.

### DIFF
--- a/recipes/zero-input
+++ b/recipes/zero-input
@@ -1,0 +1,4 @@
+(zero-input
+ :fetcher git
+ :url "https://gitlab.emacsos.com/sylecn/zero-el"
+ :branch "pkg")


### PR DESCRIPTION
### Brief summary of what the package does

zero is a Chinese input method framework written as Emacs minor mode. A pinyin input method is included with zero.

### Direct link to the package repository

https://gitlab.emacsos.com/sylecn/zero-el/tree/pkg

### Your association with the package

I am maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
  Apache License Version 2.0
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

package-lint still reports two errors
```
206:38: error: You should depend on (emacs "25.1") if you need `window-absolute-pixel-position'.
211:11: error: You should depend on (emacs "25.1") if you need `frame-edges'.
```

These two functions are tested using functionp, a fallback
function will be used if they are not available.

- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
  zero-framework.el still have 5 Errors. Other files are clean.
  checkdoc doesn't like `zero-mode' in docstring, which I don't know how to fix. Adding function or symbol prefix would only make the docstring worse. For example
```emacs-lisp
(defvar zero-mode-map
  ;; content omitted for brevity
  nil
  "Keymap for `zero-mode'.")

(defun zero-on ()
  "Turn on `zero-mode'."
  ;; content omitted for brevity
  )
```
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
  nope :)

// edit: updated info on package-lint.
// eidt2: update git repo url to link to pkg branch.