### PR TITLE
Include examples

### DIFF
--- a/recipes/oer-reveal
+++ b/recipes/oer-reveal
@@ -1,4 +1,4 @@
 (oer-reveal
  :repo "oer/oer-reveal"
  :fetcher gitlab
- :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide"))
+ :files (:defaults "README*" "LICENSE*" "org" "css" "title-slide" "examples"))


### PR DESCRIPTION
This update of the recipe adds "examples" as subdirectory to help users.

### Brief summary of what the package does

Package oer-reveal bundles resources for the creation of reveal.js presentations as Open Educational Resources (OER) from Org source files. This package builds upon org-re-reveal for export from Org mode to HTML with reveal.js. It provides help in installing and configuring reveal.js and several of its plugins.

### Direct link to the package repository

https://gitlab.com/oer/oer-reveal

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
  Almost: I deprecated two functions, one calling the other. The byte compiler complains.
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
