### PR TITLE
add xml-format package

### DIFF
--- a/recipes/xml-format
+++ b/recipes/xml-format
@@ -1,0 +1,3 @@
+(xml-format
+ :fetcher github
+ :repo "wbolster/emacs-xml-format")


### PR DESCRIPTION
### Brief summary of what the package does

XML reformatter using xmllint

### Direct link to the package repository

https://github.com/wbolster/emacs-xml-format

### Your association with the package

author

### Relevant communications with the upstream package maintainer

not needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
