### PR TITLE
Migrate project-root from Bitbucket to Github

### DIFF
--- a/recipes/project-root
+++ b/recipes/project-root
@@ -1,3 +1,3 @@
-(project-root :fetcher bitbucket
+(project-root :fetcher github
               :repo "piranha/project-root"
               :files ("project-root.el"))


### PR DESCRIPTION
As @tarsius has requested in #6484 I have migrated my packages
from Bitbucket to Github.  The old repositories were located at:

* https://bitbucket.org/piranha/project-root
