### PR TITLE
Migrate instapaper from Bitbucket to self-hosted gitea

### DIFF
--- a/recipes/instapaper
+++ b/recipes/instapaper
@@ -1,3 +1,3 @@
 (instapaper
- :fetcher bitbucket
- :repo "jfm/emacs-instapaper")
+ :fetcher git
+ :url "https://git.carcosa.net/jmcbray/emacs-instapaper.git")


### PR DESCRIPTION
Migrate my package(s) from Bitbucket to Github

As @tarsius has requested in #6484 I have migrated my packages
from Bitbucket to self-hosted git.  The old repository was located at:

* https://bitbucket.org/jfm/emacs-instapaper

The new repository is on my own gitea at https://git.carcosa.net/jmcbray/emacs-instapaper.git/