### PR TITLE
add evil keybindings to kubel

### DIFF
--- a/recipes/kubel-evil
+++ b/recipes/kubel-evil
@@ -1,0 +1,3 @@
+(kubel-evil :repo "abrochard/kubel"
+            :fetcher github
+            :files ("kubel-evil.el"))


### PR DESCRIPTION
### Brief summary of what the package does
This package provides evil bindings to the kubel package. This is added as an additional package similar to the kubernetes -> kubernetes-evil, so that people can decide whether they want to include evil bindings or not.

### Direct link to the package repository

https://github.com/abrochard/kubel

### Your association with the package

Contributor of the evil keybindings to kubel

### Relevant communications with the upstream package maintainer

**None needed**, because the preparations were already taken here: https://github.com/melpa/melpa/pull/6390

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (At least it's happy soon: https://github.com/abrochard/kubel/pull/6)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
