### PR TITLE
replace yafolding with my updated fork

### DIFF
--- a/recipes/yafolding
+++ b/recipes/yafolding
@@ -1,1 +1,1 @@
-(yafolding :fetcher github :repo "zenozeng/yafolding.el")
+(yafolding :fetcher github :repo "vindarel/yafolding.el")


### PR DESCRIPTION
We change the source of an abandoned package to our's with fixes.

### Brief summary of what the package does

yafolding is a code folding tool based on indentation.

It is already in MELPA.

### Direct link to the package repository

my updated fork: https://github.com/vindarel/yafolding.el

### Your association with the package

I am a minor contributor and a user, and I want to fix a feature.

### Relevant communications with the upstream package maintainer

This issue was raised 2 years ago (may 2017): https://github.com/zenozeng/yafolding.el/issues/34

My PR is unanswered for one year: https://github.com/zenozeng/yafolding.el/pull/38

My simple change is: replace the un-developed discover mode by a hydra.

### Checklist

Please confirm with `x`:

(yafolding is already in MELPA)

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
