### PR TITLE
Convert metaweblog recipe to be a multiple package in on repo recipe in org2blog's repo

### DIFF
--- a/recipes/metaweblog
+++ b/recipes/metaweblog
@@ -1,1 +1,1 @@
-(metaweblog :fetcher github :repo "org2blog/metaweblog")
+(metaweblog :fetcher github :repo "org2blog/org2blog" :files ("metaweblog.el"))

--- a/recipes/org2blog
+++ b/recipes/org2blog
@@ -1,1 +1,1 @@
-(org2blog :repo "org2blog/org2blog" :fetcher github :files (:defaults "README.org"))
+(org2blog :repo "org2blog/org2blog" :fetcher github :files (:defaults "README.org" (:exclude "metaweblog.el")))


### PR DESCRIPTION
When we moved `metaweblog` [to it's own repo](https://github.com/org2blog/org2blog/issues/52) we did it with the best of intentions: software engineering best practices and reuse and all of that. It was a great idea. In practice [8 years later](https://github.com/org2blog/metaweblog/issues/8) though no other packages were using it. Only `org2blog` uses it. 

The plan is to reintegrate the `metaweblog` package into `org2blog` by

1. Move `metaweblog.el` into the [org2blog repository](https://github.com/org2blog/org2blog)
2. Convert this recipe to a ["Multiple Packages in one Repository" recipe](https://github.com/melpa/melpa#example-multiple-packages-in-one-repository) to point at the `org2blog` repo
3. Archive the [metaweblog](https://github.com/org2blog/metaweblog) repository.

Reviewed with @tarsius and this is that recipe change.