### PR TITLE
Add trashed recipe

### DIFF
--- a/recipes/trashed
+++ b/recipes/trashed
@@ -1,0 +1,2 @@
+(trashed :repo "shingo256/trashed"
+         :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Viewing/editing system trash can -- open, view, restore or permanently delete trashed files or directories in trash can with Dired-like look and feel.  The trash can has to be compliant with freedesktop.org spec in <http://freedesktop.org/wiki/Specifications/trash-spec/>

### Direct link to the package repository

https://github.com/shingo256/trashed

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
