### PR TITLE
Use github fetcher for github project

### DIFF
--- a/recipes/jabber
+++ b/recipes/jabber
@@ -1,4 +1,4 @@
 (jabber
- :url "https://github.com/legoscia/emacs-jabber.git"
- :fetcher git
+ :repo "legoscia/emacs-jabber"
+ :fetcher github
  :files ("*.el" "*.texi" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))


### PR DESCRIPTION
emacs-jabber is hosted on github, but used the git fetcher. This PR fixes this.