### PR TITLE
Add 'rivet-mode' recipe

### DIFF
--- a/recipes/rivet-mode
+++ b/recipes/rivet-mode
@@ -1,0 +1,1 @@
+(rivet-mode :fetcher gitlab :repo "thornjad/rivet-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Rivet mode is a minor mode for editing [Apache Rivet](https://github.com/apache/tcl-rivet) files, which blend HTML and TCL. It switches between Web and TCL major modes when appropriate.

### Direct link to the package repository

https://gitlab.com/thornjad/rivet-mode

### Your association with the package

Creator, maintainer and daily user

### Relevant communications with the upstream package maintainer

**None**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
  - ISC
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
