### PR TITLE
Add pest-mode recipe

### DIFF
--- a/recipes/pest-mode
+++ b/recipes/pest-mode
@@ -1,0 +1,2 @@
+(pest-mode :repo "ksqsf/pest-mode"
+           :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a major mode for editing Pest files.

### Direct link to the package repository

https://github.com/ksqsf/pest-mode

### Your association with the package

Author & Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
  - I should mention checkdoc is unhappy with the docstrings of `-flymake` because `report-fn` is not mentioned, but they are private, no?
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
