### PR TITLE
Add multi-libvterm recipe

### DIFF
--- a/recipes/multi-libvterm
+++ b/recipes/multi-libvterm
@@ -1,0 +1,1 @@
+(multi-libvterm :fetcher github :repo "suonlight/multi-libvterm")

--- a/recipes/multi-libvterm
+++ b/recipes/multi-libvterm
@@ -1,1 +1,1 @@
-(multi-libvterm :fetcher github :repo "suonlight/multi-libvterm")
+(multi-vterm :fetcher github :repo "suonlight/multi-libvterm")


### PR DESCRIPTION
### Brief summary of what the package does

This is similiar with multi-term.el but it integrates with emacs-libvterm

### Direct link to the package repository

https://github.com/suonlight/multi-libvterm

### Your association with the package

I am the creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them
