### PR TITLE
Flames of Freedom package's recipe

### DIFF
--- a/recipes/belgian-holidays
+++ b/recipes/belgian-holidays
@@ -1,1 +1,0 @@
-(flame :fetcher github :repo "wiz21b/belgian-holidays")

--- a/recipes/belgian-holidays
+++ b/recipes/belgian-holidays
@@ -1,0 +1,1 @@
+(flame :fetcher github :repo "wiz21b/belgian-holidays")

--- a/recipes/flames-of-freedom
+++ b/recipes/flames-of-freedom
@@ -1,0 +1,1 @@
+(flames-of-freedom :fetcher github :repo "wiz21b/FlamesOfFreedom")

--- a/recipes/flames-of-freedom
+++ b/recipes/flames-of-freedom
@@ -1,1 +1,1 @@
-(flames-of-freedom :fetcher github :repo "wiz21b/FlamesOfFreedom")
+(flames-of-freedom :fetcher github :repo "wiz21b/FlamesOfFreedom" :branch "melpa")

--- a/recipes/flames-of-freedom
+++ b/recipes/flames-of-freedom
@@ -1,1 +1,1 @@
-(flames-of-freedom :fetcher github :repo "wiz21b/FlamesOfFreedom" :branch "melpa")
+(flames-of-freedom :fetcher github :repo "wiz21b/FlamesOfFreedom")


### PR DESCRIPTION
### Brief summary of what the package does

Displays the Flames of Freedom.
These are the eternal flames of freedom (and an homage to RMS who
is having tough times in this year 2019).
A small poem of yours can be displayed.

Resemble the fireplace package, but a bit more animated. 


### Direct link to the package repository

https://github.com/wiz21b/FlamesOfFreedom

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

n/a

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ I guess so] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

The package install that happens when I hit C-c C-c complains about missing version tags (although there are there and checkdoc/package-lint don't complain). The command "package-install-from-buffer" works fine.
