### PR TITLE
Migrate elpher from github to own server.

### DIFF
--- a/recipes/elpher
+++ b/recipes/elpher
@@ -1,3 +1,3 @@
 (elpher
- :repo "tgvaughan/elpher"
- :fetcher github)
+ :url "git://thelambdalab.xyz/elpher.git"
+ :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

Elpher is a gopher browser.  This pull request moves upstream from GitHub to my own server. 

### Direct link to the package repository

git://thelambdalab.xyz/elpher.git

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
