### PR TITLE
Point god-mode to YangZhao11's repository

### DIFF
--- a/recipes/god-mode
+++ b/recipes/god-mode
@@ -1,1 +1,1 @@
-(god-mode :fetcher github :repo "chrisdone/god-mode")
+(god-mode :fetcher github :repo "YangZhao11/god-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Update god-mode to point to my repo.

### Direct link to the package repository

New:
https://github.com/YangZhao11/god-mode
Previous repository:
https://github.com/chrisdone/god-mode

### Your association with the package

New maintainer

### Relevant communications with the upstream package maintainer

The previous repository has been archived by the original author, Chris Done. I asked him about making this change and his response is "Sure".

https://www.reddit.com/message/messages/ju4n5h

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

I fixed some checks from the old version, will gradually address them.
