### PR TITLE
Migrate lognav-mode and multi-project from BitBucket to OSDN

### DIFF
--- a/recipes/lognav-mode
+++ b/recipes/lognav-mode
@@ -1,1 +1,1 @@
-(lognav-mode :fetcher bitbucket :repo "ellisvelo/lognav-mode")
+(lognav-mode :fetcher hg :url "https://hg.osdn.net/view/lognav-mode/lognav-mode")

--- a/recipes/multi-project
+++ b/recipes/multi-project
@@ -1,1 +1,1 @@
-(multi-project :fetcher bitbucket :repo "ellisvelo/multi-project")
+(multi-project :fetcher hg :url "https://hg.osdn.net/view/multi-project/multi-project")


### PR DESCRIPTION
Please migrate my packages from Bitbucket to OSDN.

As @tarsius has requested in #N I have migrated my packages
from Bitbucket to OSDN.  The old repositories were:

* https://bitbucket.org/ellisvelo/multi-project
* https://bitbucket.org/ellisvelo/lognav-mode