### PR TITLE
Migrate latex-pretty-symbols.el from Bitbucket to Github

### DIFF
--- a/recipes/latex-pretty-symbols
+++ b/recipes/latex-pretty-symbols
@@ -1,3 +1,3 @@
 (latex-pretty-symbols
- :repo "mortiferus/latex-pretty-symbols.el"
- :fetcher bitbucket)
+ :repo "epa095/latex-pretty-symbols.el"
+ :fetcher github)


### PR DESCRIPTION
Migrate existing package latex-pretty-symbols.el away from Bitbucket as requested in #6484.

### Brief summary of what the package does

latex-pretty-symbols.el makes emacs display unicode characters instead of latex commands for a lot of the most usual symbols.

### Direct link to the package repository

https://github.com/epa095/latex-pretty-symbols.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
