### PR TITLE
Add 'diff-at-point' package

### DIFF
--- a/recipes/diff-at-point
+++ b/recipes/diff-at-point
@@ -1,0 +1,3 @@
+(diff-at-point
+ :repo "ideasman42/emacs-diff-at-point"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Improved diff navigation, using the current context when diffing the current repository.

Demo video: https://youtu.be/bR4czpEqah8

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-diff-at-point

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
