### PR TITLE
Add recipe for zetteldeft

### DIFF
--- a/recipes/zetteldeft
+++ b/recipes/zetteldeft
@@ -1,0 +1,1 @@
+(zetteldeft :fetcher github :repo "efls/zetteldeft" :files (:defaults "zetteldeft.org"))


### PR DESCRIPTION
### Brief summary of what the package does

Zetteldeft is an extension of the deft package for Emacs. It generates unique IDs to create stable links between notes, which allows the user to make an interconnected system of notes.
Zetteldeft uses deft to find and follow links to notes.
For more information, see zetteldeft.org or [https://efls.github.io/zetteldeft](https://efls.github.io/zetteldeft)

### Direct link to the package repository

https://github.com/EFLS/zetteldeft

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
