### PR TITLE
Move some repositories from bitbucket to gitlab

### DIFF
--- a/recipes/achievements
+++ b/recipes/achievements
@@ -1,1 +1,1 @@
-(achievements :fetcher bitbucket :repo "gvol/emacs-achievements")
+(achievements :fetcher gitlab :repo "gvol/emacs-achievements")

--- a/recipes/gap-mode
+++ b/recipes/gap-mode
@@ -1,4 +1,4 @@
 (gap-mode
- :fetcher bitbucket
+ :fetcher gitlab
  :repo "gvol/gap-mode"
- :files ("*.el" "emacs.gaprc"))
+ :files (:defaults "emacs.gaprc"))

--- a/recipes/nanowrimo
+++ b/recipes/nanowrimo
@@ -1,1 +1,1 @@
-(nanowrimo :fetcher bitbucket :repo "gvol/nanowrimo.el")
+(nanowrimo :fetcher gitlab :repo "gvol/nanowrimo.el")


### PR DESCRIPTION
This was necessitated due to bitbucket's discontinuing of mercurial
support.

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

I admit to not checking everything since they are pre-existing packages, but I can if it's really necessary.  @tarsius, what do you think?  I did build the packages with MELPA's make to ensure that works.  