### PR TITLE
Migrate own packages from github to gitlab

### DIFF
--- a/recipes/hl-block-mode
+++ b/recipes/hl-block-mode
@@ -1,3 +1,3 @@
 (hl-block-mode
  :repo "ideasman42/emacs-hl-block-mode"
-:fetcher github)
+ :fetcher gitlab)

--- a/recipes/inkpot-theme
+++ b/recipes/inkpot-theme
@@ -1,3 +1,3 @@
 (inkpot-theme
  :repo "ideasman42/emacs-inkpot-theme"
- :fetcher github)
+ :fetcher gitlab)

--- a/recipes/run-stuff
+++ b/recipes/run-stuff
@@ -1,3 +1,3 @@
 (run-stuff
  :repo "ideasman42/emacs-run-stuff"
- :fetcher github)
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Move packages I maintain to gitlab: `hl-block-mode`, `run-stuff`, `inkpot-theme`.

### Direct link to the package repository

New locations:

- https://gitlab.com/ideasman42/emacs-run-stuff
- https://gitlab.com/ideasman42/emacs-inkpot-theme
- https://gitlab.com/ideasman42/emacs-hl-block-mode

Old locations:

- https://github.com/ideasman42/emacs-run-stuff
- https://github.com/ideasman42/emacs-inkpot-theme
- https://github.com/ideasman42/emacs-hl-block-mode

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**
### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
