### PR TITLE
Add recipe for speedbar-git-respect

### DIFF
--- a/recipes/speedbar-git-respect
+++ b/recipes/speedbar-git-respect
@@ -1,1 +1,1 @@
-(speedbar-git-respect :repo "ukari/speedbar-git-respect" :fetcher github)
+(speedbar-git-respect :repo "ukari/speedbar-git-respect" :fetcher github :files ("speedbar-git-respect.el"))

--- a/recipes/speedbar-git-respect
+++ b/recipes/speedbar-git-respect
@@ -1,0 +1,1 @@
+(speedbar-git-respect :repo "ukari/speedbar-git-respect" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
This package will override the Emacs builtin `speedbar-file-lists` function and change its behaviour when the directory is a git repo.

The file list will show the following stuffs:
1. All directorys and files tracked by git
2. All directorys and files untracked by git but not matched in `.gitignore`

### Direct link to the package repository

https://github.com/ukari/speedbar-git-respect

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### flycheck warnings
```
13:23: error: Package f is not installable.
47:0: error: "speedbar-file-lists" doesn't start with package's prefix "speedbar-git-respect".
```
- I' not sure why package f is not installable. It seems to be `Package f`'s fault
- This package is designed to override builtin function `speedbar-file-lists` to change speedbar behavior, so prefix is not need