### PR TITLE
added nv-delete-forward recipe

### DIFF
--- a/recipes/nv-delete-forward
+++ b/recipes/nv-delete-forward
@@ -1,7 +1,1 @@
-<<<<<<< HEAD
-(nv-delete-forward :fetcher github
-  :repo "nivaca/nv-delete-forward"
-  :files ("*.el" ("doc/*.md" "doc/*.gif")))
-=======
 (nv-delete-forward :fetcher gitlab :repo "nivaca/nv-delete-forward")
->>>>>>> upstream/master

--- a/recipes/nv-delete-forward
+++ b/recipes/nv-delete-forward
@@ -1,0 +1,7 @@
+<<<<<<< HEAD
+(nv-delete-forward :fetcher github
+  :repo "nivaca/nv-delete-forward"
+  :files ("*.el" ("doc/*.md" "doc/*.gif")))
+=======
+(nv-delete-forward :fetcher gitlab :repo "nivaca/nv-delete-forward")
+>>>>>>> upstream/master


### PR DESCRIPTION
### Brief summary of what the package does

The package `nv-delete-forward` replicates the forward delete behavior of modern text editors like oXygen XML or Sublime Text. It implements the function `nv-delete-forward-all` which deletes all white space (including newlines) until, but not including, the following text. 

### Direct link to the package repository

https://gitlab.com/nivaca/nv-delete-forward

### Your association with the package

I am creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
