### PR TITLE
Add recipe for ebuku.

### DIFF
--- a/recipes/ebuku
+++ b/recipes/ebuku
@@ -1,0 +1,3 @@
+(ebuku
+ :fetcher github
+ :repo "flexibeast/ebuku")


### PR DESCRIPTION
### Brief summary of what the package does

EBuku provides a basic interface to the Buku Web bookmark manager.

### Direct link to the package repository

https://github.com/flexibeast/ebuku

### Your association with the package

Creator.

### Relevant communications with the upstream package maintainer

n/a

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly (originally with one exception, described below; now addressed)
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Byte-compiling produces:

    ebuku.el:242:1:Warning: Unused lexical argument ‘proc’

which is indeed correct - the `proc` argument is not needed by that function, but Emacs calls sentinels with `proc event` as arguments.