### PR TITLE
Delete recipes/jsx-mode

### DIFF
--- a/recipes/jsx-mode
+++ b/recipes/jsx-mode
@@ -1,3 +1,0 @@
-(jsx-mode :repo "jsx/jsx-mode.el"
-          :fetcher github
-          :files ("src/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

jsx-mode.el had been created for JSX, an AltJS provided by DeNA, before JSX, an XML-like syntax extension, provided by Facebook was released, and I added its recipe by https://github.com/melpa/melpa/pull/1013.
However many people misunderstand that jsx-mode.el is for the XML-like syntax.
cf. https://github.com/jsx/jsx-mode.el/issues/13

In addition, the AltJS seems to be no longer maintained, so I think it is better to delete its recipe to avoid misunderstanding.


### Direct link to the package repository

https://github.com/jsx/jsx-mode.el

### Your association with the package

The maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them
    - I think I don't need to check these items to delete an existing package.