### PR TITLE
Do not apt-get update: too costly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     - texinfo
 
 before_install:
-  - sudo apt-get -yq update
   - sudo apt-get -yq install git mercurial texinfo
 
   - git clone https://github.com/rejeep/evm.git $HOME/.evm


### PR DESCRIPTION
You should not apt-get update from TravisCI.
https://docs.travis-ci.com/user/installing-dependencies#installing-packages-on-standard-infrastructure

So that line is removed.