### PR TITLE
Change the repository of `fuz` and `helm-fuz`.

### DIFF
--- a/recipes/fuz
+++ b/recipes/fuz
@@ -1,2 +1,2 @@
-(fuz :repo "cireu/fuz.el" :fetcher github
+(fuz :repo "rustify-emacs/fuz.el" :fetcher github
      :files ("fuz*.el" "Cargo.toml" "Cargo.lock" "src"))

--- a/recipes/helm-fuz
+++ b/recipes/helm-fuz
@@ -1,2 +1,2 @@
-(helm-fuz :repo "cireu/fuz.el" :fetcher github
+(helm-fuz :repo "rustify-emacs/fuz.el" :fetcher github
           :files ("helm-fuz.el"))


### PR DESCRIPTION
I just transfer the repository fuz.el from my account to orginazation `rustify-emacs`

https://github.com/rustify-emacs/fuz.el

This repo contains two package `fuz` and `helm-fuz`. I also want to change the recipe of them.