### PR TITLE
Remove picolisp-mode recipe.

### DIFF
--- a/recipes/picolisp-mode
+++ b/recipes/picolisp-mode
@@ -1,4 +1,0 @@
-(picolisp-mode
- :fetcher github
- :repo "flexibeast/plisp-mode"
- :files ("picolisp-mode.el" "inferior-picolisp.el"))


### PR DESCRIPTION
It has now been three months since the merging of https://github.com/melpa/melpa/pull/6396, which renamed my `picolisp-mode` to `plisp-mode`. i feel this is probably sufficient time for users to have transitioned to using the `plisp-mode` package rather than the `picolisp-mode` package. Thus, this PR deletes the recipe for the latter.

Once this PR is merged, i will remove the `picolisp-mode.el` and `inferior-picolisp.el` files from [the plisp-mode repo](https://github.com/flexibeast/plisp-mode/).

cc: @purcell @tarsius 