### PR TITLE
add recipe for ksm-window

### DIFF
--- a/recipes/ksm-window
+++ b/recipes/ksm-window
@@ -1,0 +1,3 @@
+(ksm-window :repo "karrick/ksm-window"
+            :fetcher github
+            :files ("ksm-window.el"))

--- a/recipes/ksm-window
+++ b/recipes/ksm-window
@@ -1,3 +1,1 @@
-(ksm-window :repo "karrick/ksm-window"
-            :fetcher github
-            :files ("ksm-window.el"))
+(ksm-window :repo "karrick/ksm-window" :fetcher github)


### PR DESCRIPTION
# ksm-window

provides handy window management functions

## Why

I frequently find myself in a situation where I have half a dozen
Emacs windows in a frame, and I want to focus on just one of those
windows for a few moments, and then later return my window state to
its present configuration.  Emacs already has facilities for
accomplishing such tasks, but I wanted a quick toggle function like
tmux' "C-b z" pane toggling feature.

I put this file somewhere Emacs will find it, then added the below to
my ~/.emacs/init.el file.

```Lisp
   (require 'ksm-window)
   (global-set-key (kbd "C-x w") #'ksm-window-zoom-out) ;; restore frame layout from stack
   (global-set-key (kbd "C-x z") #'ksm-window-zoom-in)  ;; save frame layout, then zoom in to buffer
```

I also frequently find myself working with half a dozen buffers in as
many windows when interrupted to help someone else. I want to save my
entire frame layout, associated with a key word, then go help the
person who asked for it, and afterwards, quickly restore my frame
layout.

To do this, I add the following two more lines to my
~/.emacs.d/init.el file:

```Lisp
   (global-set-key (kbd "C-x j") #'ksm-window-config-restore) ;; prompt for NAME and restore config
   (global-set-key (kbd "C-x p") #'ksm-window-config-save)    ;; prompt for NAME and save config
```

### Brief summary of what the package does

provides handy window management functions

### Direct link to the package repository

https://github.com/karrick/ksm-window

### Your association with the package

I am the package author.

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

I did all the steps, so I'm not sure what to put in the final task, "I have confirmed some of these without doing them".