### PR TITLE
remove yahoo-weather

### DIFF
--- a/recipes/yahoo-weather
+++ b/recipes/yahoo-weather
@@ -1,1 +1,0 @@
-(yahoo-weather :fetcher github :repo "lujun9972/yahoo-weather-mode")


### PR DESCRIPTION
### Brief summary of what the package does

The YQL service at query.yahooapis.com has retired and I can't get the API request approval.

This package is not workable any more.

### Direct link to the package repository

https://github.com/lujun9972/yahoo-weather-mode

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
