### PR TITLE
fsharp-mode recipe: Use fsharp organisation repo

### DIFF
--- a/recipes/fsharp-mode
+++ b/recipes/fsharp-mode
@@ -1,8 +1,3 @@
 (fsharp-mode
  :fetcher github
- :repo "rneatherway/emacs-fsharp-mode-bin"
- :files ("*.el"
-         ("bin"
-          "*.exe"
-          "*.exe.config"
-          "*.dll")))
+ :repo "fsharp/emacs-fsharp-mode")


### PR DESCRIPTION
Previous versions of fsharp-mode (mis)used a second repository
(https://github.com/rneatherway/emacs-fsharp-mode-bin) to distribute
FsAutoComplete (language server) and fsharp-mode together.

The current version of fsharp-mode installs FsAutoComplete
automatically (download) via eglot-fsharp (part of fsharp-mode) or
lsp-mode (https://github.com/emacs-lsp/lsp-mode).

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

None needed: Same codebase (use original repo instead of fork)
