### PR TITLE
Add ivy-fuz

### DIFF
--- a/recipes/ivy-fuz
+++ b/recipes/ivy-fuz
@@ -1,0 +1,1 @@
+(ivy-fuz :repo "Silex/ivy-fuz.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Fast and precise fuzzy scoring/matching utils for Emacs, powered by rust, for ivy.

### Direct link to the package repository

https://github.com/Silex/ivy-fuz.el

### Your association with the package

Maintainer.

@cireu I know you didn't want to make this because you feel ivy-fuz is not stable enough, but I find it silly having to copy-paste `ivy-fuz.el` in my installation and hoping it doesn't change often so I made this PR :-)

You of course have the latest word on this, if you feel it might create too much maintenance for you I'll just continue with my copy-paste solution.

### Relevant communications with the upstream package maintainer

**none needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them