### PR TITLE
Add lsp-mssql

### DIFF
--- a/recipes/lsp-mssql
+++ b/recipes/lsp-mssql
@@ -1,0 +1,1 @@
+(lsp-mssql :repo "emacs-lsp/lsp-mssql" :files (:defaults "images" "snippets") :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

lsp-mode client for mssql language server.

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-mssql

### Your association with the package

Author/maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly 
**Does not compile cleanly due to treemacs macro which generates:**
```
Compiling file .../lsp-mssql/lsp-mssql.el at Wed Dec  4 13:53:31 2019
lsp-mssql.el:442:1:Warning: value returned from (aref theme 1) is unused
```
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

