### PR TITLE
Add undo-fu

### DIFF
--- a/recipes/undo-fu
+++ b/recipes/undo-fu
@@ -1,0 +1,3 @@
+(undo-fu
+ :repo "ideasman42/emacs-undo-fu"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Helpers to expose undo/redo functionality on top of Emacs own undo commands
*(without modifying the internal undo data which tends to be buggy, [example](https://www.reddit.com/r/emacs/comments/85t95p/undo_tree_unrecognized_entry_in_undo_list/))*.

- Undo marks the initial step when activated.
- Redo will not redo past this initial undo action.
- Redo will not undo if the last action in the undo stack is not an undo.

These constraints can be disabled temporarily by pressing Ctrl-G.

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-undo-fu

### Your association with the package

Author/Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
