### PR TITLE
add dash.info to dash package recipe

### DIFF
--- a/recipes/dash
+++ b/recipes/dash
@@ -1,1 +1,1 @@
-(dash :fetcher github :repo "magnars/dash.el" :files ("dash.el"))
+(dash :fetcher github :repo "magnars/dash.el" :files ("dash.el" "dash.texi"))


### PR DESCRIPTION
Add dash.texi to recipe of dash package so that dash.info would be built and included in the package.  I discussed this with author of dash who gave his blessing to this idea.