### PR TITLE
add flyspell-correct-avy-menu recipe

### DIFF
--- a/recipes/flyspell-correct-avy-menu
+++ b/recipes/flyspell-correct-avy-menu
@@ -1,0 +1,3 @@
+(flyspell-correct-avy-menu :repo "d12frosted/flyspell-correct"
+                           :fetcher github
+                           :files ("flyspell-correct-avy-menu.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds `avy-menu` interface to the `flyspell-correct` package.

### Direct link to the package repository

https://github.com/d12frosted/flyspell-correct

### Your association with the package

I am the maintainer of this package. Didn't plan to add it to the MELPA until user communicated with me (https://github.com/d12frosted/flyspell-correct/issues/53). 

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (https://github.com/d12frosted/flyspell-correct/commit/4c32d3ccea82f8625362cadcef0fbccc953e4f47)
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them :smile_cat:  
