### PR TITLE
Update location of company-quickhelp

### DIFF
--- a/recipes/company-quickhelp
+++ b/recipes/company-quickhelp
@@ -1,1 +1,1 @@
-(company-quickhelp :fetcher github :repo "expez/company-quickhelp")
+(company-quickhelp :fetcher github :repo "company-mode/company-quickhelp")


### PR DESCRIPTION
This repository has been moved over to the `company-mode` organization.

New home that this recipe now points to: https://github.com/company-mode/company-quickhelp

