### PR TITLE
Add posix-manual recipe

### DIFF
--- a/recipes/posix-manual
+++ b/recipes/posix-manual
@@ -1,0 +1,1 @@
+(posix-manual :fetcher github :repo "lassik/emacs-posix-manual")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a `posix-manual-entry` command with tab completion. It lets you easily call up POSIX manual pages in your web browser.

The package contains a database of all POSIX manual page names and their URLs. It's scraped from the Open Group website by a Racket script which is included in the repo.

### Direct link to the package repository

https://github.com/lassik/emacs-posix-manual

### Your association with the package

Just wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them