### PR TITLE
Add aftersave package

### DIFF
--- a/recipes/aftersave
+++ b/recipes/aftersave
@@ -1,0 +1,1 @@
+(aftersave :repo "roman/aftersave.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
When developing software, I tend to notice sometimes that I do repetitive tasks
on my session; at some point, I stop and create a quick function on my
`*scratch*` that executes a bunch of steps in one go and add an
`after-save-hook` for it on my current buffer.

This package helps removing manual steps in the development cycle. If you
need to execute the same commands after a save (run tests, restart browser,
etc.), this package allows you to add an Emacs function in the
after-save-hook of the editor (or the local buffer).

### Direct link to the package repository

https://github.com/roman/aftersave.el

### Your association with the package

Author and Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them <= cute
