### PR TITLE
Add gnome-screencast recipe

### DIFF
--- a/recipes/gnome-screencast
+++ b/recipes/gnome-screencast
@@ -1,0 +1,3 @@
+(gnome-screencast
+ :fetcher github
+ :repo "juergenhoetzel/emacs-gnome-screencast")


### PR DESCRIPTION
### Brief summary of what the package does

Use Gnome shell’s screen recorder from within Emacs

### Direct link to the package repository

https://github.com/juergenhoetzel/emacs-gnome-screencast

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
