### PR TITLE
Add recipe for rtags-xref

### DIFF
--- a/recipes/rtags-xref
+++ b/recipes/rtags-xref
@@ -1,0 +1,3 @@
+(rtags-xref :repo "Andersbakken/rtags"
+            :fetcher github
+            :files ("src/rtags-xref.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Backend for xref (Jump to definition, references...)

### Direct link to the package repository

https://github.com/Andersbakken/rtags

### Your association with the package

Maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
