### PR TITLE
Update evil recipe

### DIFF
--- a/recipes/evil
+++ b/recipes/evil
@@ -1,4 +1,5 @@
 (evil :repo "emacs-evil/evil"
       :fetcher github
       :files (:defaults
+              "doc/build/texinfo/evil.texi"
               (:exclude "evil-test-helpers.el")))


### PR DESCRIPTION
A documentation overhaul PR (https://github.com/emacs-evil/evil/pull/1218) is expected to move the location of the texinfo file to somewhere the default files setting will not find it. Therefore we need to update the recipe before merging.

This should be almost void of review burden.

### Your association with the package

i am the maintainer.

