### PR TITLE
add VFL mode

### DIFF
--- a/recipes/vfl-mode
+++ b/recipes/vfl-mode
@@ -1,4 +1,4 @@
 (vfl-mode
  :fetcher gitlab
  :repo "val314159/python-mode"
- :files ("vfl-mode.el" ("completion" "completion/pycomplete.*")))
+ :files ("vfl-mode.el"))

--- a/recipes/vfl-mode
+++ b/recipes/vfl-mode
@@ -1,0 +1,4 @@
+(python-mode
+ :fetcher gitlab
+ :repo "val314159/vfl-mode"
+ :files ("vfl-mode.el" ("completion" "completion/pycomplete.*")))

--- a/recipes/vfl-mode
+++ b/recipes/vfl-mode
@@ -1,4 +1,1 @@
-(vfl-mode
- :fetcher gitlab
- :repo "val314159/vfl-mode"
- :files ("vfl-mode.el"))
+(vfl-mode :fetcher gitlab :repo "val314159/vfl-mode")

--- a/recipes/vfl-mode
+++ b/recipes/vfl-mode
@@ -1,4 +1,4 @@
-(python-mode
+(vfl-mode
  :fetcher gitlab
  :repo "val314159/vfl-mode"
  :files ("vfl-mode.el" ("completion" "completion/pycomplete.*")))

--- a/recipes/vfl-mode
+++ b/recipes/vfl-mode
@@ -1,4 +1,4 @@
 (vfl-mode
  :fetcher gitlab
- :repo "val314159/python-mode"
+ :repo "val314159/vfl-mode"
  :files ("vfl-mode.el"))

--- a/recipes/vfl-mode
+++ b/recipes/vfl-mode
@@ -1,4 +1,4 @@
 (vfl-mode
  :fetcher gitlab
- :repo "val314159/vfl-mode"
+ :repo "val314159/python-mode"
  :files ("vfl-mode.el" ("completion" "completion/pycomplete.*")))


### PR DESCRIPTION
### Brief summary of what the package does

VFL-mode: a new emacs mode for VFL (derived from python mode)

### Direct link to the package repository

https://gitlab.com/val314159/vfl-mode

### Your association with the package

maintainer, author of VFL

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x ] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
