### PR TITLE
Add cl-font-lock recipe

### DIFF
--- a/recipes/cl-font-lock
+++ b/recipes/cl-font-lock
@@ -1,0 +1,1 @@
+(cl-font-lock :repo "equwal/cl-font-lock" :fetcher github)


### PR DESCRIPTION
Adds pretty font locking for lots of common lisp symbols.

### Brief summary of what the package does

Adds font highlighting to a large number of symbols for Common Lisp (generated from the specification).

### Direct link to the package repository

https://github.com/equwal/cl-font-lock

### Your association with the package

I pulled the code from [emacs-settings](https://github.com/sheepduke/emacs-settings) so it could be a stand-alone package.

So that makes me a maintainer I guess.

### Relevant communications with the upstream package maintainer

None needed; the project has an open license.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org).
