### PR TITLE
Add recipe for `eldev' package.

### DIFF
--- a/recipes/eldev
+++ b/recipes/eldev
@@ -1,0 +1,2 @@
+(eldev :repo "doublep/eldev"
+       :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Eldev (Elisp Development Tool) is an Emacs-based build system, targeted solely at Elisp projects. It is an alternative to Cask. Unlike Cask, Eldev itself is fully written in Elisp and its configuration files are also Elisp programs. If you are familiar with Java world, Cask can be seen as a parallel to Maven — it uses project description, while Eldev is sort of a parallel to Gradle — its configuration is a program on its own.

Eldev doesn't have to be installed in user's Emacs, as it is a command-line tool, but its normal installation consists of 1) user copying a (relatively) small `emake` shell script to his machine (using `curl`, for example); 2) Emake bootstrapping itself from Melpa. The second step obviously requires the package being published on Melpa.

*Originally submitted as "Emake" (PR #6596), but as was pointed out in a comment to that PR, there is already a package with that name, even if not on Melpa. Therefore, I renamed my project to Eldev.*

### Direct link to the package repository

https://github.com/doublep/eldev

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings [*]
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

[*] Since Eldev uses docstrings on its own functions to provide help in batch mode, `M-x checkdoc` cannot be really happy. E.g. first line will usually not contain full sentence, etc.