### PR TITLE
defmaybe - maybe define well documented variables

### DIFF
--- a/recipes/defmaybe
+++ b/recipes/defmaybe
@@ -1,0 +1,1 @@
+(defmaybe :fetcher github :repo "mplscorwin/defmaybe")


### PR DESCRIPTION
I have a couple of features I may add eventually or if nudged.  Otherwise this should be fairly stable.

### Brief summary of what the package does

Drop in replacement for defvar (or defcustom) to make it really easy to use setq instead.  A buffer-local variable defmaybe-defvar controls the run-time behaviour.  A transformation function is provided to revert to source to using core functions and elimiate defmaybe as a dependancy when development is complete or for use during packaging.

### Direct link to the package repository

https://github.com/mplscorwin/defmaybe

### Your association with the package

Author and packager (e.g. MELPA pumpkiner.)

### Relevant communications with the upstream package maintainer

NA

### Checklist

Please confirm with `x`:

- [X ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ X] My elisp byte-compiles cleanly
- [ X] `M-x checkdoc` is happy with my docstrings
- [ X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [>_<] I have confirmed some of these without doing them
