### PR TITLE
Add ob-graphql recipe

### DIFF
--- a/recipes/ob-graphql
+++ b/recipes/ob-graphql
@@ -1,0 +1,1 @@
+(ob-graphql :fetcher github :repo "jdormit/ob-graphql")


### PR DESCRIPTION
### Brief summary of what the package does

[`ob-graphql`](https://github.com/jdormit/ob-graphql) adds an org-babel execution backend for GraphQL snippets that allows users to execute GraphQL source blocks against their servers and see the results inline in their `.org` files.

### Direct link to the package repository

https://github.com/jdormit/ob-graphql

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
