### PR TITLE
Add recipe for elfeed-score (Gnus-style scoring for Elfeed)

### DIFF
--- a/recipes/elfeed-score
+++ b/recipes/elfeed-score
@@ -1,0 +1,3 @@
+(elfeed-score
+ :fetcher github
+ :repo "sp1ff/elfeed-score")


### PR DESCRIPTION
### Brief summary of what the package does

`elfeed-score` is an add-on for `elfeed`, an RSS reader for Emacs.  It brings Gnus-style scoring to your RSS feeds.  Elfeed, by default, displays feed entries by date.  This package allows you to setup rules for assigning numeric scores to entries, and sorting entries with higher scores ahead of those with lower, regardless of date.  The idea is to prioritize content important to you.

### Direct link to the package repository

https://github.com/sp1ff/elfeed-score

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
