### PR TITLE
add flycheck-indent recipe

### DIFF
--- a/recipes/flycheck-indent
+++ b/recipes/flycheck-indent
@@ -1,0 +1,2 @@
+(flycheck-indent :fetcher github :repo "conao3/indent-lint.el"
+                 :files ("flycheck-indent.el"))


### PR DESCRIPTION
### Brief summary of what the package does
Flycheck `indent-lint` (#6611) frontend

### Direct link to the package repository
https://github.com/conao3/indent-lint.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Warnings
There are warnings related to `eval-after-load`.
But `eval-after-load` is needed for package related to flycheck checker. Ref: https://github.com/alexmurray/flycheck-clang-analyzer/blob/223faa244502150d08a34898858a0b4806c92d4c/flycheck-clang-analyzer.el#L250-L264