### PR TITLE
Add recipe: clipetty

### DIFF
--- a/recipes/clipetty
+++ b/recipes/clipetty
@@ -1,0 +1,1 @@
+(clipetty :repo "spudlyo/clipetty" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Clipetty is a minor mode for terminal (TTY) users that sends text that you kill in Emacs to your Operating System's clipboard.

### Direct link to the package repository

https://github.com/spudlyo/clipetty

### Your association with the package

I am the author, maintainer, and enthusiastic user.

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
