### PR TITLE
Add random-idle-quote to mepla

### DIFF
--- a/recipes/random-idle-quote
+++ b/recipes/random-idle-quote
@@ -1,0 +1,2 @@
+(random-idle-quote :repo "jcowgar/random-idle-quote"
+		   :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

When Emacs goes into idle mode, a random quote will appear in your echo window. I use it to help me memorize keyboard shortcuts I am working on in Emacs. You can use it for the same, to memorize any random text you may be working on, or fill it with quotes to brighten your day.

### Direct link to the package repository

https://github.com/jcowgar/random-idle-quote

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
