### PR TITLE
Add Verb package.

### DIFF
--- a/recipes/verb
+++ b/recipes/verb
@@ -1,0 +1,1 @@
+(verb :repo "federicotdn/verb" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Verb is a new HTTP client for emacs, based on Outline mode. It allows users to organize and send HTTP requests from Emacs.

### Direct link to the package repository

https://github.com/federicotdn/verb

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
