### PR TITLE
add org-linkotron recipe

### DIFF
--- a/recipes/org-linkotron
+++ b/recipes/org-linkotron
@@ -1,0 +1,1 @@
+(org-linkotron :fetcher gitlab :repo "perweij/org-linkotron")


### PR DESCRIPTION
### Brief summary of what the package does

The purpose of this package is to provide a way to open a group of org-links at once. This makes it easier to switch between work tasks that each require a number of links opened (in the web browser). 

Upon activation, the program locates all org-links in the current text block, then it calls `org-open-at-point` on each of them, with a configurable pause between each call (to allow Firefox to handle the load, in case they are browser links).

This is my first attempt at creating an Emacs package.

### Direct link to the package repository

https://gitlab.com/perweij/org-linkotron

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
