### PR TITLE
Yatemplate cleanup

### DIFF
--- a/recipes/yatemplate
+++ b/recipes/yatemplate
@@ -1,3 +1,4 @@
 (yatemplate
  :fetcher github
- :repo "mineo/yatemplate")
+ :repo "mineo/yatemplate"
+ :files (:defaults (:exclude "test-*.el")))


### PR DESCRIPTION
adds an exclusion for the tests in the stable repo (fixed in unstable with https://github.com/mineo/yatemplate/issues/20 )