### PR TITLE
Revert "Yatemplate cleanup"

### DIFF
--- a/recipes/yatemplate
+++ b/recipes/yatemplate
@@ -1,4 +1,3 @@
 (yatemplate
  :fetcher github
- :repo "mineo/yatemplate"
- :files (:defaults (:exclude "test-*.el")))
+ :repo "mineo/yatemplate")


### PR DESCRIPTION
Reverts melpa/melpa#6631

See https://github.com/mineo/yatemplate/issues/20#issuecomment-572745421 - the file `test-yatemplate.el` has been renamed to `yatemplate-tests.el` (matching the default value of `:exclude`) in https://github.com/mineo/yatemplate/commit/e1a0bd215d9b86f3f7d09e6802e6fbb53efab779 already, but no release had been tagged with that commit. I've just tagged a new release, so neither MELPA nor MELPA stable need an explicit `:exclude` value anymore.