### PR TITLE
Add recipe for `qtcreator-theme' package

### DIFF
--- a/recipes/qtcreator-theme
+++ b/recipes/qtcreator-theme
@@ -1,0 +1,1 @@
+(qtcreator-theme :fetcher github :repo "lesleylai/emacs-qtcreator-theme")


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs color theme that mimics the default theme of the Qt Creator IDE

### Direct link to the package repository

https://github.com/LesleyLai/emacs-qtcreator-theme

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
