### PR TITLE
Add recipe for keypression (redo #6630)

### DIFF
--- a/recipes/keypression
+++ b/recipes/keypression
@@ -1,0 +1,1 @@
+(keypression :repo "chuntaro/emacs-keypression" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package is a keystroke visualizer for GUI version Emacs.
This allows you to display keystrokes without relying on external tools when creating screencasts.
There are screencasts in the repositories below to see how this works.

(Sorry, I restarted https://github.com/melpa/melpa/pull/6630)

### Direct link to the package repository

https://github.com/chuntaro/emacs-keypression

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them