### PR TITLE
Point 'undohist' to ideasman42's repository

### DIFF
--- a/recipes/undohist
+++ b/recipes/undohist
@@ -1,1 +1,1 @@
-(undohist :repo "m2ym/undohist-el" :fetcher github)
+(undohist :repo "ideasman42/emacs-undohist" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Store the undo history on disk.

This is an upgrade to the existing `undohist` package as the current repository has been archived by it's author and not updated since 2015, see: https://github.com/m2ym/undohist-el

The following improvements have been made.

- Store full undo/redo history, allowing `undo-only` to work as expected (this is the main improvement).
- Use a minor-mode<br>`(undohist-mode)` for a buffer-local mode.<br>`(global-undohist-mode)` to enable globally - to replace `(undohist-initialize)` which couldn't be disabled.
- Store history compressed (default to gz).
- Don't save history for ignored files.

See [changelog](https://gitlab.com/ideasman42/emacs-undohist/blob/master/changelog.rst) for a full list.

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-undohist

### Your association with the package

New maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
