### PR TITLE
Update shroud git url

### DIFF
--- a/recipes/shroud
+++ b/recipes/shroud
@@ -1,2 +1,2 @@
 (shroud :fetcher git
-              :repo "https://git.savannah.nongnu.org/git/emacs-shroud.git")
+              :url "https://git.savannah.nongnu.org/git/emacs-shroud.git")

--- a/recipes/shroud
+++ b/recipes/shroud
@@ -1,10 +1,10 @@
 (shroud :fetcher git
-              :url "https://git.savannah.nongnu.org/git/emacs-shroud.git"
-              :files ("src/shroud"
-                      "src/shroud*.el"
-                      "doc/emacs-shroud.texi"
-                      "README"
-                      "NEWS"
-                      "AUTHORS"
-                      "COPYING"
-                      (:exclude "make.el")))
+        :url "https://git.savannah.nongnu.org/git/emacs-shroud.git"
+        :files ("src/shroud"
+                "src/shroud*.el"
+                "doc/emacs-shroud.texi"
+                "README"
+                "NEWS"
+                "AUTHORS"
+                "COPYING"
+                (:exclude "make.el")))

--- a/recipes/shroud
+++ b/recipes/shroud
@@ -1,2 +1,2 @@
-(shroud :fetcher github
-              :repo "o-nly/emacs-shroud")
+(shroud :fetcher git
+              :repo "https://git.savannah.nongnu.org/git/emacs-shroud.git")

--- a/recipes/shroud
+++ b/recipes/shroud
@@ -1,2 +1,10 @@
 (shroud :fetcher git
-              :url "https://git.savannah.nongnu.org/git/emacs-shroud.git")
+              :url "https://git.savannah.nongnu.org/git/emacs-shroud.git"
+              :files ("src/shroud"
+                      "src/shroud*.el"
+                      "doc/emacs-shroud.texi"
+                      "README"
+                      "NEWS"
+                      "AUTHORS"
+                      "COPYING"
+                      (:exclude "make.el")))


### PR DESCRIPTION
Canonical home of emacs-shroud is https://nongnu.org.

### Brief summary of what the package does

A Lispy password manager.

### Direct link to the package repository

http://savannah.nongnu.org/projects/emacs-shroud

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

Nongnu.org is the canonical home for the package.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
