### PR TITLE
Add recipe for ivy-clipmenu.el

### DIFF
--- a/recipes/ivy-clipmenu
+++ b/recipes/ivy-clipmenu
@@ -1,0 +1,3 @@
+(ivy-clipmenu
+ :repo "wpcarro/ivy-clipmenu.el"
+ :fetcher github)


### PR DESCRIPTION
Publishing github.com/wpcarro/ivy-clipmenu.el to Melpa.

### Brief summary of what the package does

[Ivy](https://github.com/abo-abo/swiper#ivy) integration with the clipboard manager, [clipmenu](https://github.com/cdown/clipmenu).

### Direct link to the package repository

https://github.com/wpcarro/ivy-clipmenu.el

### Your association with the package

I'm the project creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
