### PR TITLE
Added horizon-theme recipe

### DIFF
--- a/recipes/horizon-theme
+++ b/recipes/horizon-theme
@@ -1,0 +1,1 @@
+(horizon-theme :repo "aodhneine/horizon-theme.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package is port of Visual Studio Code theme of the same name, [Horizon](https://horizontheme.netlify.com).

### Direct link to the package repository

https://github.com/aodhneine/horizon-theme.el

### Your association with the package

I'm maintainer and author of the port. I really enjoyed the original theme, so I decided it would be nice to port it to Emacs.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
