### PR TITLE
Added recipe for with-shell-interpreter

### DIFF
--- a/recipes/with-shell-interpreter
+++ b/recipes/with-shell-interpreter
@@ -1,0 +1,2 @@
+(with-shell-interpreter :repo "p3r7/with-shell-interpreter"
+                        :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides helper function `with-shell-interpreter` to ease dealing with the few vars acting as implicit parameters for shell functions.

They can be set as explicit keyword argument instead of having to let-bind vars.

Lib dependency for packages in [p3r7/prf-shell](https://github.com/p3r7/prf-shell).

There is also an [accompanying blog post](https://www.eigenbahn.com/2020/01/19/painless-emacs-shell-commands) that walks through the implementation.

### Direct link to the package repository

https://github.com/p3r7/with-shell-interpreter

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
  **NB:** Except for macro `with-shell-interpreter` wich takes &rest args but maps them to keyword args, like use-package does.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
