### PR TITLE
Add recipe for remind-bindings

### DIFF
--- a/recipes/remind-bindings
+++ b/recipes/remind-bindings
@@ -1,0 +1,1 @@
+(remind-bindings :fetcher github :repo "mtekman/remind-bindings.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package parses your Emacs init file for `use-package` or `global-set-key` calls and summarises the bindings it detects on a package-by-package basis.

### Direct link to the package repository

https://github.com/mtekman/remind-bindings.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
