### PR TITLE
Add recipe for virtual-auto-fill

### DIFF
--- a/recipes/virtual-auto-fill
+++ b/recipes/virtual-auto-fill
@@ -1,0 +1,1 @@
+(virtual-auto-fill :repo "luisgerhorst/virtual-auto-fill" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`virtual-auto-fill` is a package to [display unfilled text in a readable way](https://github.com/luisgerhorst/virtual-auto-fill/blob/master/README.md#screenshots).  It wraps the text as if you had inserted line breaks (e.g. using [`fill-paragraph`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Fill-Commands.html) or `auto-fill-mode`) without actually modifying the underlying buffer.  It also indents paragraphs in bullet lists properly.

Internally, [Adaptive Wrap Prefix mode](http://elpa.gnu.org/packages/adaptive-wrap.html) mode, [Visual Fill Column mode](https://github.com/joostkremers/visual-fill-column), and [Visual Line mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Visual-Line-Mode.html) are employed to wrap paragraphs and bullet lists between the wrap prefix and the fill column. If you don't need all of the features provided by Virtual Auto Fill mode, it may be better for you to use a subset of these modes directly. However, if you often switch between filled and unfilled text, Virtual Auto Fill mode catches you when you accidentally invoke `fill-paragraph` (by default bound to `M-q`) out of habit in a virtually filled buffer. To prevent you from breaking the formatting convention without noticing it, you are asked whether you actually meant to fill the paragraph and if you want to be warned again next time.

### Direct link to the package repository

https://github.com/luisgerhorst/virtual-auto-fill

### Your association with the package

I'm the original author and current maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
