### PR TITLE
Add recipe org-fragtog

### DIFF
--- a/recipes/org-fragtog
+++ b/recipes/org-fragtog
@@ -1,0 +1,1 @@
+(org-fragtog :fetcher github :repo "io12/org-fragtog")


### PR DESCRIPTION
### Brief summary of what the package does

This package automates toggling org-mode latex fragment previews. Fragment previews are disabled for editing when your cursor steps onto them, and re-enabled when the cursor leaves.

### Direct link to the package repository

https://github.com/io12/org-fragtog

### Your association with the package

I'm the maintainer. This is my first Emacs package so I hope I did everything right.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
