### PR TITLE
Log processor rewrite

### DIFF
--- a/docker/logprocessor/process_log.py
+++ b/docker/logprocessor/process_log.py
@@ -2,20 +2,19 @@
 
 
 import argparse
-from datetime import datetime
+from datetime import datetime, timedelta
+from timeit import default_timer as timer
 import gzip
 import json
-import os
 import re
 import sys
 import time
-import tempfile
 import sqlite3
 from operator import or_
 
 LOGREGEX = r'^(?P<ip>[\d.]+) [ -]+ \[(?P<date>[\w/: +-]+)\] ' \
            r'"GET /+packages/+(?P<package>[^ ]+)-(?P<version>[0-9.]+).(?:el|tar) ' \
-           r'HTTP/\d.\d" 200'
+           r'HTTP/\d.\d" 200 \d+ "[^"]*?" "(?P<agent>[^"]*)'
 
 
 def json_handler(obj):
@@ -30,7 +29,7 @@ def json_handler(obj):
 
 def json_dump(data, jsonfile, indent=None):
     """
-    jsonfiy `data`
+    jsonify `data`
     """
     return json.dump(data, jsonfile, default=json_handler, indent=indent, encoding='utf-8')
 
@@ -57,6 +56,22 @@ def ip_to_number(ip):
     return reduce(or_, ((int(n) << (i*8)) for i, n in enumerate(
         reversed(ip.split('.')))), 0)
 
+# In Python 2.7, strptime doesn't understand "%z", so we have to work around it
+OFFSET_RE = re.compile(" ([-+])([01]\d)([0-5]\d)$")
+def parse_log_datetime(s):
+    "Parse string t and return a datetime object with offset timezone."
+    m = OFFSET_RE.search(s)
+    if not m:
+        raise Exception("Bad date: {}".format(s))
+    # Eg. "16/Apr/2013:07:45:09 -0500"
+    dt = datetime.strptime(s[:-6],'%d/%b/%Y:%H:%M:%S')
+    delta = timedelta(hours=int(m.group(2)),minutes=int(m.group(3)))
+    if m.group(1) == "+":
+        return dt - delta
+    else:
+        return dt + delta
+
+EPOCH = datetime(1970,1,1)
 
 def parse_logfile(logfilename, curs):
     """
@@ -78,8 +93,19 @@ def parse_logfile(logfilename, curs):
         # Convert ips to four character strings.
         ip = match.group('ip')
         pkg = match.group('package')
+        date = int((parse_log_datetime(match.group('date')) - EPOCH).total_seconds())
+        version = match.group('version')
+        agent = match.group('agent')
 
-        curs.execute("INSERT OR IGNORE INTO pkg_ip VALUES (?, ?)", (pkg, ip))
+        curs.execute("INSERT OR IGNORE INTO packages VALUES (?)", (pkg,))
+        package_id, = curs.execute("SELECT rowid FROM packages WHERE name = ?", (pkg,)).fetchone()
+        curs.execute("INSERT OR IGNORE INTO versions VALUES (?)", (version,))
+        version_id, = curs.execute("SELECT rowid FROM versions WHERE version = ?", (version,)).fetchone()
+        curs.execute("INSERT OR IGNORE INTO agents VALUES (?)", (agent,))
+        agent_id, = curs.execute("SELECT rowid FROM agents WHERE agent = ?;", (agent,)).fetchone()
+        curs.execute("INSERT OR IGNORE INTO clients VALUES (?, ?)", (ip, agent_id))
+        client_id, = curs.execute("SELECT rowid FROM clients WHERE ip = ? AND agent_id = ?", (ip, agent_id)).fetchone()
+        curs.execute("INSERT OR IGNORE INTO downloads VALUES (?, ?, ?, ?)", (package_id, version_id, date, client_id))
         count += 1
 
     return count
@@ -98,23 +124,47 @@ def main():
     conn = sqlite3.connect(args.db)
     curs = conn.cursor()
 
-    sys.stdout.write("ensuring database setup...\n")
-    curs.execute(
-        '''CREATE TABLE IF NOT EXISTS pkg_ip (package, ip, PRIMARY KEY (package, ip)) WITHOUT ROWID''')
+    print("Ensuring database setup")
+    # We normalise common strings into separate tables along semantic lines
+    # so that the "downloads" table is a compact set of ints.
+    #
+    # As of end Jan 2020, the approximate cardinality of data is as follows:
+    #
+    # Packages: 4950
+    # Distinct agents: 12.5k
+    # Distinct version strings: 74k
+    # Distinct IPs 1.75M
+    # Distinct clients: 2.2M
+    # Downloads: 174M
+    curs.execute("CREATE TABLE IF NOT EXISTS versions (version TEXT, PRIMARY KEY (version))")
+    curs.execute("CREATE TABLE IF NOT EXISTS packages (name TEXT, PRIMARY KEY (name))")
+    curs.execute("CREATE TABLE IF NOT EXISTS agents (agent TEXT, PRIMARY KEY (agent))")
+    curs.execute("CREATE TABLE IF NOT EXISTS clients (ip TEXT, agent_id INT, PRIMARY KEY (ip, agent_id))")
+    curs.execute("CREATE TABLE IF NOT EXISTS downloads (pkg_id INT, version_id INT, date INT, client_id INT, PRIMARY KEY (pkg_id, version_id, date, client_id)) WITHOUT ROWID")
+    curs.execute('''
+      CREATE VIEW IF NOT EXISTS download_totals AS
+        SELECT p.name AS package, counts.count
+         FROM (SELECT pkg_id, COUNT(1) AS count FROM downloads GROUP BY pkg_id) counts
+         JOIN packages p ON p.rowid = pkg_id
+    ''')
     conn.commit()
 
     # parse each parameter
     for logfile in args.logs:
-        sys.stdout.write("processing logfile {0}... ".format(logfile))
-        sys.stdout.flush()
-
+        print("Processing logfile {0}".format(logfile))
+        start = timer()
         count = parse_logfile(logfile, curs)
-        sys.stdout.write("{0}\n".format(count))
+        print("-> {0} records processed in {1}s".format(count, timer() - start))
         conn.commit()
 
     # calculate current package totals
+
+    print("Querying totals")
+    start = timer()
     pkgcount = {p: c for p, c in curs.execute(
-        "SELECT package, count(ip) FROM pkg_ip GROUP BY 1")}
+        "SELECT package, count FROM download_totals")}
+    print("-> Done in {}s".format(timer() - start))
+
     json_dump(pkgcount, open(args.jsondir + "/download_counts.json", 'w'), indent=1)
 
     return 0

--- a/docker/logprocessor/run.sh
+++ b/docker/logprocessor/run.sh
@@ -5,12 +5,12 @@ cd "${MELPA_REPO}"
 
 # Unstable
 /usr/bin/python ${MELPA_REPO}/docker/logprocessor/process_log.py \
-  --db /mnt/db/download_log.db \
+  --db /mnt/db/download_log_full.db \
   --jsondir html \
   /mnt/store/log/melpa.access.log
 
 # Stable
 /usr/bin/python ${MELPA_REPO}/docker/logprocessor/process_log.py \
-   --db /mnt/db/download_log_stable.db \
+   --db /mnt/db/download_log_stable_full.db \
    --jsondir html-stable \
    /mnt/store/log-stable/melpa.access.log


### PR DESCRIPTION
See #3493. Filing as a pull request for visibility with @milkypostman. Will merge soon unless there's a blocker.

---

Okay, so I've aggressively reworked the log processor, and I have backfilled a pair of databases from the historical logs ready to switch over (which took ages!).

The new schema stores user agents, downloaded package versions and individual download times: basically all the interesting stuff in the log files. This will let us do all manner of per-package, per-time-period, per-version reporting, as well as continue to get the current per-package download counts.

Here's how it compares...

### Total number of downloads

```
Old: 107624260
New: 173760968
```

Our methodology has changed, in this regard: a download is now a successful GET of a specific versioned package file by a distinct IP / user agent pair. Previously it was unique `(package-root-name, ip)` pairs over all time. Some packages are heavily affected, e.g. `dash` will jump from around 1.05M downloads to around 2.5M.

### Space usage

```
Old: 3659710464 bytes
New: 3978551296 bytes
```
Surprisingly, the result is still half the size of the "old old" `WITH ROWID` table file, and only slightly larger than the "Old" `WITHOUT ROWID` version. This is achieved by aggressively moving strings out of the downloads tables into separate tables and referencing them by ID.

#### Query time for package totals to create JSON

```
Old: 215s
New: 232s
```

### Ingestion speed

```
Old: Unknown
New: Around 5000 (matching) log lines per second
```

I believe the speed to be comparable, though.
