### PR TITLE
Add weak-ref recipe

### DIFF
--- a/recipes/weak-ref
+++ b/recipes/weak-ref
@@ -1,0 +1,1 @@
+(weak-ref :fetcher github :repo "skeeto/elisp-weak-ref")


### PR DESCRIPTION
### Brief summary of what the package does

Exactly what it says on the box.  It contains a function for creating a single weak reference using a hash table with weak values and a function for dereferencing it.  Admittedly this is sugar, but standalone weak references are a feature missing from elisp and this package makes for better code.

### Direct link to the package repository

https://github.com/skeeto/elisp-weak-ref

### Your association with the package

An enthusiastic user.

### Relevant communications with the upstream package maintainer

I exchanged emails with @skeeto asking if he minded my submitting it to Melpa.  He added the version header, version tag, and adjusted the name to follow the feature namespace.  Additional checkdoc docstring complaints were recently addressed.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
