### PR TITLE
add recipe for osx-plist

### DIFF
--- a/recipes/osx-plist
+++ b/recipes/osx-plist
@@ -1,0 +1,1 @@
+(osx-plist :fetcher github :repo "gonewest818/osx-plist")


### PR DESCRIPTION
### Brief summary of what the package does

This library provides a parser for Apple property list (`.plist`) files.  

### Direct link to the package repository

https://github.com/gonewest818/osx-plist

### Your association with the package

The original package was implemented by @hober and described on [Emacswiki](https://www.emacswiki.org/emacs/MacOSXPlist).  However the source link has disappeared and there's now just a clone of the source [here](https://github.com/ferdy/osx-plist). I cloned that repo and updated it.

My intention is to get this published to MELPA and then soon after, tag a version 2.0.0 since the new version includes some breaking changes. The original is still tagged as 1.0.0 in this repo.

### Relevant communications with the upstream package maintainer

I've contacted @hober, the original author, and she has approved releasing this updated version to MELPA. See gonewest818/osx-plist#1.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
