### PR TITLE
remove recipe for readability

### DIFF
--- a/recipes/readability
+++ b/recipes/readability
@@ -1,1 +1,0 @@
-(readability :fetcher github :repo "emacsorphanage/readability")


### PR DESCRIPTION
The `readability` package provides an interface to a now defunct service. According to [Wikipedia](https://en.wikipedia.org/wiki/Readability_(service)) it closed down in 2016. The package is available in the [orphanage](https://github.com/emacsorphanage/readability) and appears abandoned.