### PR TITLE
Include changelog file in treemacs recipe.

### DIFF
--- a/recipes/treemacs
+++ b/recipes/treemacs
@@ -2,6 +2,7 @@
  :fetcher github
  :repo "Alexander-Miller/treemacs"
  :files (:defaults
+         "Changelog.org"
          "icons"
          "src/elisp/treemacs*.el"
          "src/scripts/treemacs*.py"


### PR DESCRIPTION
### Brief summary of what the package does

The package is already on melpa. This change adds the changelog to the list of files included in the package.

### Direct link to the package repository

https://github.com/Alexander-Miller/treemacs/
https://github.com/Alexander-Miller/treemacs/blob/master/Changelog.org

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
