### PR TITLE
add somafm recipe

### DIFF
--- a/recipes/somafm
+++ b/recipes/somafm
@@ -1,0 +1,1 @@
+(somafm :fetcher github :repo "artenator/somafm.el")


### PR DESCRIPTION
### Brief summary of what the package does

`somafm.el` is a simple interface to [soma.fm](https://somafm.com) radio stream channels. It allows you to easily browse the available channels and stream them from the comfort of emacs. The overall goal is to eventually have all of the functionality and aesthetic appeal of the [soma.fm popup player](https://somafm.com/player) but from within emacs.

### Direct link to the package repository

https://github.com/artenator/somafm.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
