### PR TITLE
Add lavenderless-theme

### DIFF
--- a/recipes/lavenderless-theme
+++ b/recipes/lavenderless-theme
@@ -1,0 +1,4 @@
+(lavenderless-theme
+  :fetcher git
+  :url "https://git.sr.ht/~lthms/colorless-themes.el"
+  :files ("lavenderless-theme.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`lavenderless-theme` is inspired by [`lavender-theme`](https://github.com/emacsfodder/emacs-lavender-theme) and is based on the [`colorless-themes` macro](https://git.sr.ht/~lthms/colorless-themes.el), which has been added to melpa for quite some time now (#6075).

### Direct link to the package repository

All my “colorless themes” are located in the `colorless-themes` repository: https://git.sr.ht/~lthms/colorless-themes.el

### Your association with the package

I am the author and maintainer of both `lavenderless-theme` and `colorless-themes`.

### Relevant communications with the upstream package maintainer

The logic of this recipe is exactly the same as `nordless-theme` (see #6339 if interested).

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
