### PR TITLE
Add auctex-cluttex recipe

### DIFF
--- a/recipes/auctex-cluttex
+++ b/recipes/auctex-cluttex
@@ -1,0 +1,1 @@
+(auctex-cluttex :fetcher github :repo "tsuu32/auctex-cluttex")


### PR DESCRIPTION
### Brief summary of what the package does

Add [ClutTeX](https://www.ctan.org/pkg/cluttex) support for [AUCTeX](https://www.gnu.org/software/auctex/) package.

### Direct link to the package repository

https://github.com/tsuu32/auctex-cluttex

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Note
package-lint warns about function prefix such as `TeX-run-ClutTeX`, but this follows AUCTeX package's naming convention. Is this acceptable?