### PR TITLE
Add center-layout.

### DIFF
--- a/recipes/center-layout
+++ b/recipes/center-layout
@@ -1,0 +1,4 @@
+(center-layout
+ :fetcher gitlab
+ :repo "lae/emacs-center-layout"
+ :branch "stable")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a global minor mode center-layout-mode for centering
windows by applying left and optionally right margins.

### Direct link to the package repository

https://gitlab.com/lae/emacs-center-layout

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
