### PR TITLE
add nndiscourse

### DIFF
--- a/recipes/nndiscourse
+++ b/recipes/nndiscourse
@@ -1,3 +1,3 @@
 nndiscourse :repo "dickmao/nndiscourse"
             :fetcher github
-            :files ("nndiscourse.el" ("nndiscourse" "nndiscourse/Gemfile" "nndiscourse/Gemfile.lock" "nndiscourse/nndiscourse.gemspec" "nndiscourse/nndiscourse.thor" "nndiscourse/lib"))
+            :files ("nndiscourse.el" ("nndiscourse" ("nndiscourse/Gemfile" "nndiscourse/Gemfile.lock" "nndiscourse/nndiscourse.gemspec" "nndiscourse/nndiscourse.thor" "nndiscourse/lib")))

--- a/recipes/nndiscourse
+++ b/recipes/nndiscourse
@@ -1,3 +1,3 @@
-nndiscourse :repo "dickmao/nndiscourse"
-            :fetcher github
-            :files ("nndiscourse.el" ("nndiscourse" ("nndiscourse/Gemfile" "nndiscourse/Gemfile.lock" "nndiscourse/nndiscourse.gemspec" "nndiscourse/nndiscourse.thor" "nndiscourse/lib")))
+(nndiscourse :repo "dickmao/nndiscourse"
+             :fetcher github
+             :files ("nndiscourse.el" ("nndiscourse" ("nndiscourse/Gemfile" "nndiscourse/Gemfile.lock" "nndiscourse/nndiscourse.gemspec" "nndiscourse/nndiscourse.thor" "nndiscourse/lib"))))

--- a/recipes/nndiscourse
+++ b/recipes/nndiscourse
@@ -1,0 +1,3 @@
+nndiscourse :repo "dickmao/nndiscourse"
+            :fetcher github
+            :files ("nndiscourse.el" ("nndiscourse" "nndiscourse/Gemfile" "nndiscourse/Gemfile.lock" "nndiscourse/nndiscourse.gemspec" "nndiscourse/nndiscourse.thor" "nndiscourse/lib"))


### PR DESCRIPTION
### Brief summary of what the package does

A Gnus backend for Discourse

### Direct link to the package repository

https://github.com/dickmao/nndiscourse

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
