### PR TITLE
update edts

### DIFF
--- a/recipes/edts
+++ b/recipes/edts
@@ -1,40 +1,31 @@
 (edts
  :fetcher github
- :repo   "tjarvstrand/edts"
+ :repo   "sebastiw/edts"
  :files  ("*.el"
           "COPYING"
           "COPYING.LESSER"
           "Makefile"
           "README.md"
           "start"
+          "start.bat"
+          "rebar.config"
+          ("config"                     "config/*")
 
           ("elisp/edts"                 "elisp/edts/*.el")
           (:exclude                     "elisp/edts/*-test.el")
 
-          ("lib/edts"                   "lib/edts/Makefile")
-          ("lib/edts"                   "lib/edts/rebar")
-          ("lib/edts"                   "lib/edts/rebar.config")
-          ("lib/edts/priv"              "lib/edts/priv/app.config")
+          ("lib/edts/include"           "lib/edts/include/*")
           ("lib/edts/priv"              "lib/edts/priv/dispatch.conf")
           ("lib/edts/src"               "lib/edts/src/*")
 
-          ("plugins/edts_debug"         "plugins/edts_debug/*.el")
-          (:exclude                     "plugins/edts_debug/*-test.el")
-          ("plugins/edts_debug"         "plugins/edts_debug/Makefile")
-          ("plugins/edts_debug"         "plugins/edts_debug/rebar")
-          ("plugins/edts_debug"         "plugins/edts_debug/rebar.config")
-          ("plugins/edts_debug/src"     "plugins/edts_debug/src/*")
+          ("lib/edts_debug"             "lib/edts_debug/*.el")
+          (:exclude                     "lib/edts_debug/*-test.el")
+          ("lib/edts_debug/src"         "lib/edts_debug/src/*")
 
-          ("plugins/edts_dialyzer"      "plugins/edts_dialyzer/*.el")
-          (:exclude                     "plugins/edts_dialyzer/*-test.el")
-          ("plugins/edts_dialyzer"      "plugins/edts_dialyzer/Makefile")
-          ("plugins/edts_dialyzer"      "plugins/edts_dialyzer/rebar")
-          ("plugins/edts_dialyzer"      "plugins/edts_dialyzer/rebar.config")
-          ("plugins/edts_dialyzer/src"  "plugins/edts_dialyzer/src/*")
+          ("lib/edts_dialyzer"          "lib/edts_dialyzer/*.el")
+          (:exclude                     "lib/edts_dialyzer/*-test.el")
+          ("lib/edts_dialyzer/src"      "lib/edts_dialyzer/src/*")
 
-          ("plugins/edts_xref"          "plugins/edts_xref/*.el")
-          (:exclude                     "plugins/edts_xref/*-test.el")
-          ("plugins/edts_xref"          "plugins/edts_xref/Makefile")
-          ("plugins/edts_xref"          "plugins/edts_xref/rebar")
-          ("plugins/edts_xref"          "plugins/edts_xref/rebar.config")
-          ("plugins/edts_xref/src"      "plugins/edts_xref/src/*")))
+          ("lib/edts_xref"              "lib/edts_xref/*.el")
+          (:exclude                     "lib/edts_xref/*-test.el")
+          ("lib/edts_xref/src"          "lib/edts_xref/src/*")))


### PR DESCRIPTION
The edts has moved to https://github.com/sebastiw/edts .
And this has changed to use rebar3 to compile.