### PR TITLE
Add new recipe apdl-mode

### DIFF
--- a/recipes/apdl-mode
+++ b/recipes/apdl-mode
@@ -1,0 +1,5 @@
+(apdl-mode
+:fetcher github
+:repo "dieter-wilhelm/apdl-mode"
+:files ("*.el" "*.org" "README" "/doc/*.org" "/matlib")
+)

--- a/recipes/apdl-mode
+++ b/recipes/apdl-mode
@@ -1,4 +1,4 @@
 (apdl-mode
 :fetcher github
 :repo "dieter-wilhelm/apdl-mode"
-:files ("*.el" "*.org" "apdl-mode-readme.txt" ("doc" "doc/*.org" "doc/example.*") "matlib" "template"))
+:files (:defaults "matlib" "template"))

--- a/recipes/apdl-mode
+++ b/recipes/apdl-mode
@@ -1,5 +1,4 @@
 (apdl-mode
 :fetcher github
 :repo "dieter-wilhelm/apdl-mode"
-:files ("*.el" "*.org" "apdl-mode-readme.txt" "doc/*.org" "matlib" "template")
-)
+:files ("*.el" "*.org" "apdl-mode-readme.txt" ("doc" "doc/*.org") "matlib" "template"))

--- a/recipes/apdl-mode
+++ b/recipes/apdl-mode
@@ -1,4 +1,4 @@
 (apdl-mode
 :fetcher github
 :repo "dieter-wilhelm/apdl-mode"
-:files ("*.el" "*.org" "apdl-mode-readme.txt" ("doc" "doc/*.org") "matlib" "template"))
+:files ("*.el" "*.org" "apdl-mode-readme.txt" ("doc" "doc/*.org" "doc/example.*") "matlib" "template"))

--- a/recipes/apdl-mode
+++ b/recipes/apdl-mode
@@ -1,5 +1,5 @@
 (apdl-mode
 :fetcher github
 :repo "dieter-wilhelm/apdl-mode"
-:files ("*.el" "*.org" "README" "/doc/*.org" "/matlib")
+:files ("*.el" "*.org" "apdl-mode-readme.txt" "doc/*.org" "matlib" "template")
 )


### PR DESCRIPTION
### Brief summary of what the package does

APDL-Mode is the GNU-Emacs major mode for the APDL scripting language of the ANSYS FEA suite.

APDL-Mode (formerly ANSYS-Mode) represents, in conjunction with the GNU-Emacs editor, an advanced APDL environment with features like solver communication (GNU-Linux only), manual browsing, license reporting, keyword completion, code templates, dedicated keybindings, etc. 
Over the years it has accumulated lots of features for writing and debugging FEA models in APDL code.

### Direct link to the package repository

https://github.com/dieter-wilhelm/apdl-mode

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback.

    But there remains a problem. I can't configure package-lint to observe my package prefix "apdl".
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
