### PR TITLE
add recipes/fit-text-scale

### DIFF
--- a/recipes/fit-text-scale
+++ b/recipes/fit-text-scale
@@ -1,0 +1,1 @@
+(fit-text-scale :repo "marcowahl/fit-text-scale" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

fit-text-scale is an automation to set the scale so that the text
uses the maximal space to fit in the window.


### Direct link to the package repository

https://gitlab.com/marcowahl/fit-text-scale

### Your association with the package

maintainer, contributor, enthusiastic user!

### Relevant communications with the upstream package maintainer
none.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

