### PR TITLE
Add org-pdftools

### DIFF
--- a/recipes/org-pdftools
+++ b/recipes/org-pdftools
@@ -1,0 +1,1 @@
+(org-pdftools :repo "fuxialexander/org-pdftools" :fetcher github)

--- a/recipes/org-pdftools
+++ b/recipes/org-pdftools
@@ -1,1 +1,2 @@
-(org-pdftools :repo "fuxialexander/org-pdftools" :fetcher github)
+(org-pdftools :repo "fuxialexander/org-pdftools" :fetcher github
+              :files ("org-pdftools.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Add support for org links from pdftools buffers with more precise location control.

### Direct link to the package repository

https://github.com/fuxialexander/org-pdftools

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
