### PR TITLE
Replace the gdscript-mode package with GDQuest/emacs-gdscript-mode

### DIFF
--- a/recipes/gdscript-mode
+++ b/recipes/gdscript-mode
@@ -1,4 +1,2 @@
-(gdscript-mode
- :fetcher github
- :repo "AdamBark/gdscript-mode")
- 
+(gdscript-mode :fetcher github
+               :repo "GDQuest/emacs-gdscript-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This package brings support for the [Godot engine](https://godotengine.org/)'s GDScript programming language in Emacs.

### Direct link to the package repository

https://github.com/GDQuest/emacs-gdscript-mode

### Your association with the package

I'm the maintainer, actively working on the package, and would like

### Relevant communications with the upstream package maintainer

The gdscript-mode package currently available on MELPA is unmaintained and does not work well.

This new package, based on Emacs's built-in `python.el`, covers all the basics to write GDScript code in Godot.

Its largest files, `gdscript-fill-paragraph.el`, `gdscript-indent-and-nav.el`, and `gdscript-syntax.el`, and some more, reuse a lot of code from `python.el`. That is because GDScript has a syntax similar to Python. I just renamed and adapted the corresponding functions, trying to remove everything that was not relevant to GDScript.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
