### PR TITLE
Add native-complete recipe

### DIFF
--- a/recipes/native-complete
+++ b/recipes/native-complete
@@ -1,0 +1,3 @@
+(native-complete :fetcher github
+                 :repo "CeleritasCelery/emacs-native-shell-complete"
+                 :files ("native-complete.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package interacts with a shell's native completion functionality to provide the same completions in Emacs that you would get from the shell itself.

### Direct link to the package repository

https://github.com/CeleritasCelery/emacs-native-shell-complete

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
