### PR TITLE
Add company-native-complete recipe

### DIFF
--- a/recipes/company-native-complete
+++ b/recipes/company-native-complete
@@ -1,0 +1,3 @@
+(company-native-complete :fetcher github
+                         :repo "CeleritasCelery/emacs-native-shell-complete"
+                         :files ("company-native-complete.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a company backend for use with `native-complete` (The other package I just submitted). I decided to split them into two packages so that people who were not interested int the company completion don't need to install the dependency for it. I hope that was the right call. 

### Direct link to the package repository

https://github.com/CeleritasCelery/emacs-native-shell-complete

### Your association with the package

I am the maintainer 

### Relevant communications with the upstream package maintainer

none needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
