### PR TITLE
Add fira-code-mode

### DIFF
--- a/recipes/fira-code-mode
+++ b/recipes/fira-code-mode
@@ -1,0 +1,1 @@
+(fira-code-mode :fetcher github :repo "jming422/fira-code-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a minor mode that enables Fira Code-style font ligatures using the Fira Code Symbol font and `prettify-symbols-mode`

### Direct link to the package repository

https://github.com/jming422/fira-code-mode

### Your association with the package

I am the author of the package (it's my very first!)

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). **(It's under GNU GPL v3)**
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
