### PR TITLE
Recipe: Add sbuffer

### DIFF
--- a/recipes/sbuffer
+++ b/recipes/sbuffer
@@ -1,0 +1,1 @@
+(sbuffer :fetcher github :repo "alphapapa/sbuffer.el")


### PR DESCRIPTION
### Brief summary of what the package does

Sbuffer is like Ibuffer, but using magit-section to group buffers in a very flexible way.

### Direct link to the package repository

https://github.com/alphapapa/sbuffer.el

### Your association with the package

Author and maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Notes

* Sbuffer is named like Ibuffer, with an "S" for "sections."  However, there is an unrelated package on MELPA named `s-buffer`, which I just discovered.  It is not depended on by any other MELPA package, and it doesn't have very many installs, so I'm not sure if the similar name is a problem.

  I'm willing to consider renaming this package, but naming things is hard...  :)  I thought about `mbuffer`, since it uses Magit sections, but there is also an `m-buffer` package, which is similar to `s-buffer` (!).  So I'm open to suggestions here.

Thanks.