### PR TITLE
Add recipe for learn-ocaml

### DIFF
--- a/recipes/learn-ocaml
+++ b/recipes/learn-ocaml
@@ -1,0 +1,4 @@
+(learn-ocaml
+ :fetcher github
+ :repo "pfitaxel/learn-ocaml.el"
+ :files (:defaults "LICENSE"))

--- a/recipes/learn-ocaml
+++ b/recipes/learn-ocaml
@@ -1,4 +1,3 @@
 (learn-ocaml
  :fetcher github
- :repo "pfitaxel/learn-ocaml.el"
- :files (:defaults "LICENSE"))
+ :repo "pfitaxel/learn-ocaml.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package is a minor mode to interact directly from Emacs (`>= 25.1`) with the [learn-ocaml](http://ocaml-sf.org/learn-ocaml/) platform, developed by the OCaml software foundation to provide students with automated feedback in OCaml laboratory sessions.

(in particular, we plan to start using this mode on next week in Toulouse :)

### Direct link to the package repository

https://github.com/pfitaxel/learn-ocaml.el

### Your association with the package

I am the maintainer of `learn-ocaml.el`.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (→ [done](https://github.com/pfitaxel/learn-ocaml.el/commit/099a539ead361f03784de0c421ee4a6ab85df328))
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (→ 0 error)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Cc @yurug @leunam217 FYI