### PR TITLE
Add srfi recipe

### DIFF
--- a/recipes/srfi
+++ b/recipes/srfi
@@ -1,0 +1,1 @@
+(srfi :fetcher github :repo "srfi-explorations/emacs-srfi")


### PR DESCRIPTION
### Brief summary of what the package does

Provides quick access to Scheme Requests for Implementation (SRFI)
documents from within Emacs:

* `M-x srfi-list` brings up a `*SRFI*` buffer listing all SRFIs.

* `M-x srfi` does the same, but allows live-narrowing the list by
  typing numbers or words into the minibuffer.

* The `*SRFI*` buffer provides one-key commands to visit the SRFI
  document, its discussion archive (mailing list archive), and it
  version control repository. These commands open the right web
  pages in your web browser using `browse-url`.

### Direct link to the package repository

https://github.com/srfi-explorations/emacs-srfi

### Your association with the package

Wrote it.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them