### PR TITLE
update location of minsk-theme

### DIFF
--- a/recipes/minsk-theme
+++ b/recipes/minsk-theme
@@ -1,1 +1,1 @@
-(minsk-theme :repo "jlpaca/minsk-theme" :fetcher github)
+(minsk-theme :fetcher github :repo "jlpaca/minsk-theme" :files ("theme/emacs/minsk-theme.el"))


### PR DESCRIPTION
recipe originally added in https://github.com/melpa/melpa/pull/6556.

the repository is expected soon also to contain implementations of the colour theme for other applications, so the recipe is updated to point to the files specific to emacs.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them