### PR TITLE
Added recipe for brf-mode.

### DIFF
--- a/recipes/b
+++ b/recipes/b
@@ -1,0 +1,1 @@
+(b :fetcher git :url "https://bitbucket.org/MikeWoolley/b-mode")

--- a/recipes/b
+++ b/recipes/b
@@ -1,1 +1,0 @@
-(b :fetcher git :url "https://bitbucket.org/MikeWoolley/b-mode")

--- a/recipes/brf
+++ b/recipes/brf
@@ -1,0 +1,1 @@
+(brf :fetcher git :url "https://bitbucket.org/MikeWoolley/brf-mode")

--- a/recipes/brf
+++ b/recipes/brf
@@ -1,1 +1,1 @@
-(brf :fetcher git :url "https://bitbucket.org/MikeWoolley/brf-mode")
+(brf :fetcher bitbucket :repo "MikeWoolley/brf-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`brf-mode` adds functionality from the editor Brief to Emacs.

This package is not an emulation of Brief (there are plenty of those already), but rather provides an implementation in Emacs of specific features that I miss from Brief. 

They have been implemented in an Emacs-style. This means the functions respond to prefix args and where they override Emacs functions, they live on the Emacs key bindings as well as the original Brief keys. The emphasis is also on accurately implementing these specific features in Emacs, rather than doing what Brief emulations tend to do, which is just mapping all the Brief key-sequences to similar functions in Emacs. 

Principally the features are:

* Line-mode cut and paste
* Column-mode cut and paste
* Fully reversible paging and scrolling
* Temporary bookmarks
* Cursor motion undo
* Easy window management

Further details at:
https://bitbucket.org/MikeWoolley/brf-mode/

### Direct link to the package repository

https://bitbucket.org/MikeWoolley/brf-mode/

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
