### PR TITLE
Add wallpaper package

### DIFF
--- a/recipes/wallpaper
+++ b/recipes/wallpaper
@@ -1,0 +1,1 @@
+(wallpaper :fetcher github :repo "farlado/emacs-wallpaper")


### PR DESCRIPTION
### Brief summary of what the package does

Wallpaper management within Emacs, including:

- Choosing a static wallpaper or set of wallpapers
- Cycling randomly through wallpapers in a directory
- Setting specific wallpapers for given workspaces (e.g. in EXWM or i3wm)

Currently depends on feh, but I am open to expanding it to try to work with other wallpaper-setting programs.

### Direct link to the package repository

https://github.com/farlado/emacs-wallpaper

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly (on Emacs 27)
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them