### PR TITLE
Add stripes

### DIFF
--- a/recipes/stripes
+++ b/recipes/stripes
@@ -1,0 +1,1 @@
+(stripes :fetcher gitlab :repo "stepnem/stripes-el")


### PR DESCRIPTION
### Brief summary of what the package does

Highlight every other `stripes-unit' (3 by default) lines with an
alternative background color or font. Useful for buffers that display
lists of any kind, as a guide for your eyes to follow these lines.

### Direct link to the package repository

https://gitlab.com/stepnem/stripes-el

### Your association with the package

I am the maintainer and coauthor.

### Relevant communications with the upstream package maintainer

Originally I found the old version at https://www.emacswiki.org/emacs/stripes.el

Based on communication and agreement with Michael Schierl, the
original author, I have taken over the maintenance. He has also given
me permission to release it into the public domain.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

[with the exception of "1:0: warning: The package summary should start with an uppercase letter or a digit.", cf. purcell/package-lint#162]

- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them