### PR TITLE
added recipie for modern-fringes

### DIFF
--- a/recipes/modern-fringes
+++ b/recipes/modern-fringes
@@ -1,0 +1,1 @@
+(modern-fringes :repo "specialbomb/emacs-modern-fringes" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

modern-fringes is meant to replace the existing emacs fringe bitmaps to what I feel are better looking ones.

### Direct link to the package repository

https://github.com/SpecialBomb/emacs-modern-fringes

### Your association with the package

I am the author, and the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
