### PR TITLE
Add emacs-bazel-mode recipe

### DIFF
--- a/recipes/emacs-bazel-mode
+++ b/recipes/emacs-bazel-mode
@@ -1,0 +1,3 @@
+
+(emacs-bazel-mode :repo "bazelbuild/emacs-bazel-mode" :fetcher github
+  :files ("lisp/*.el" (:exclude "lisp/*-test.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Provides "official" support for the Bazel build system within Emacs.

### Direct link to the package repository

https://github.com/bazelbuild/emacs-bazel-mode

### Your association with the package

A user. 

### Relevant communications with the upstream package maintainer

https://github.com/bazelbuild/emacs-bazel-mode/issues/13 - the package maintainer is aware of this and is in support of it.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (I was unable to get this installed on my machine because I do not use ELPA and it appears to carry a dependency there)
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (there are 5 total errors. 4 are disambiguations that do not seem to make sense in the context of the documentation, and one is that some lines are over 80 columns. Everything else is fine)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
