### PR TITLE
Update to the magma-mode recipe

### DIFF
--- a/recipes/magma-mode
+++ b/recipes/magma-mode
@@ -3,4 +3,5 @@
  :repo "ThibautVerron/magma-mode"
  :files ("*.el"
          "snippets"
+	 "data/magma_symbols.txt"
          ("bin" "bin/build_completion_table.sh")))

--- a/recipes/magma-mode
+++ b/recipes/magma-mode
@@ -3,5 +3,5 @@
  :repo "ThibautVerron/magma-mode"
  :files ("*.el"
          "snippets"
-	 "data/magma_symbols.txt"
+	 ("data" "data/magma_symbols.txt")
          ("bin" "bin/build_completion_table.sh")))


### PR DESCRIPTION
### Brief summary of what the package does

Support for editing magma source code files. Updated with a list of symbols for completion.

### Direct link to the package repository

https://github.com/ThibautVerron/magma-mode

Original PR: https://github.com/melpa/melpa/pull/2059

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
  _(In progress. But the package is already on melpa in its current state, and the new files added in the recipe are not elisp.)_
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
