### PR TITLE
Add recipe for git-invoke

### DIFF
--- a/recipes/git-invoke
+++ b/recipes/git-invoke
@@ -1,0 +1,4 @@
+(git-invoke
+ :repo "oer/git-invoke"
+ :fetcher gitlab
+ :files (:defaults "LICENSES"))


### PR DESCRIPTION
### Brief summary of what the package does

This project offers a small Emacs Lisp package with functions to invoke Git commands (clone, pull, update of submodules).  Some commands invoke Git and direct output into an output buffer, others return a string; see doc strings of contained functions.  This is not meant for end users but for programmers.

I refactored the functionality contained in this proposed package from [oer-reveal](https://melpa.org/#/oer-reveal) as I also need this for another project.

### Direct link to the package repository

https://gitlab.com/oer/git-invoke

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
