### PR TITLE
Add package jest-test-mode

### DIFF
--- a/recipes/jest-test-mode
+++ b/recipes/jest-test-mode
@@ -1,0 +1,1 @@
+(jest-test-mode :repo "rymndhng/jest-test-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This packages adds a mode for executing jest-tests. The design is inspired by ruby-test-mode and cider-test. 

It differs from an existing package named `jest`, specifically the way menus are presented to users. `jest-test-mode` also does not rely on any other packages.

### Direct link to the package repository

https://github.com/rymndhng/jest-test-mode

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

n/a

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
