### PR TITLE
Add xwidget-plus recipe.

### DIFF
--- a/recipes/xwwp
+++ b/recipes/xwwp
@@ -1,0 +1,1 @@
+(xwwp :fetcher github :repo "canatella/xwwp" :files ("xwwp.el" "xwwp-follow-link.el" "xwwp-follow-link-ido.el"))

--- a/recipes/xwwp-follow-link-helm
+++ b/recipes/xwwp-follow-link-helm
@@ -1,0 +1,1 @@
+(xwwp-follow-link-helm :fetcher github :repo "canatella/xwwp" :files ("xwwp-follow-link-helm.el"))

--- a/recipes/xwwp-follow-link-ivy
+++ b/recipes/xwwp-follow-link-ivy
@@ -1,0 +1,1 @@
+(xwwp-follow-link-ivy :fetcher github :repo "canatella/xwwp" :files ("xwwp-follow-link-ivy.el"))


### PR DESCRIPTION
Enhance xwidget-webkit navigation.
See https://github.com/canatella/xwidget-plus

### Brief summary of what the package does

This package provides enhancements to the xwidget-webkit browser. It provides an easy way to navigate a web page links using the keyboard. It also provides helper functions. I intend to add other features here.

### Direct link to the package repository

https://github.com/canatella/xwidget-plus

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
