### PR TITLE
Add flycheck-pest

### DIFF
--- a/recipes/flycheck-pest
+++ b/recipes/flycheck-pest
@@ -1,0 +1,3 @@
+(flycheck-pest :repo "ksqsf/pest-mode"
+               :fetcher github
+               :files ("flycheck-pest.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides flycheck integration for pest-mode (#6707).

### Direct link to the package repository

https://github.com/ksqsf/pest-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
