### PR TITLE
Add astyle

### DIFF
--- a/recipes/astyle
+++ b/recipes/astyle
@@ -1,0 +1,2 @@
+(astyle :repo "storvik/emacs-astyle"
+        :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides functions for running astyle, C / C++ formatting tool, on buffer. 

### Direct link to the package repository

https://github.com/storvik/emacs-astyle

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Note

I had some problems with `Package reformatter is unavailable` when building from within Emacs, but `make recipes/astyle` is working as intended.
