### PR TITLE
Add company-org-roam package

### DIFF
--- a/recipes/company-org-roam
+++ b/recipes/company-org-roam
@@ -1,0 +1,2 @@
+(company-org-roam :fetcher github
+                   :repo "jethrokuan/company-org-roam")


### PR DESCRIPTION
### Brief summary of what the package does

`company-org-roam` is a [company][company] backend for use with [org-roam]. In
Org-roam buffers.

Related to #6738 .

### Direct link to the package repository
https://github.com/jethrokuan/company-org-roam

### Your association with the package
Maintainer.

### Relevant communications with the upstream package maintainer
None-needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

[company]: https://company-mode.github.io/
[org-roam]: https://github.com/jethrokuan/org-roam