### PR TITLE
Add recipe for blackout

### DIFF
--- a/recipes/blackout
+++ b/recipes/blackout
@@ -1,0 +1,1 @@
+(blackout :fetcher github :repo "raxod502/blackout")


### PR DESCRIPTION
### Brief summary of what the package does

Blackout is a package which allows you to hide or customize the display of major and minor modes in the mode line. It can replace diminish.el, delight.el, and dim.el.

The reason that Blackout is a better alternative to all three of the listed existing packages [is documented in the README](https://github.com/raxod502/blackout/tree/34adf3d4ea03010861fe6b2b3f28966784a75416#comparison).

### Direct link to the package repository

https://github.com/raxod502/blackout

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Note: `package-lint` complains about the `use-package` handlers and the associated `with-eval-after-load`. However, both of these things are necessary for `use-package` integration, so the warnings are erroneous.
