### PR TITLE
Add recipe for ctrlf

### DIFF
--- a/recipes/ctrlf
+++ b/recipes/ctrlf
@@ -1,0 +1,1 @@
+(ctrlf :fetcher github :repo "raxod502/ctrlf")


### PR DESCRIPTION
### Brief summary of what the package does

CTRLF (pronounced "control F) is an intuitive and efficient solution for single-buffer text search in Emacs, replacing packages such as Isearch, Swiper, and helm-swoop. Taking inspiration from the widely-adopted and battle-tested ctrl+F interfaces in programs such as web browsers, but following the flow and keybindings of Isearch, CTRLF improves on existing text search solutions in convenience, robustness, and consistency.

### Direct link to the package repository

https://github.com/raxod502/ctrlf

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**none needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

As documented in the README, the unusual autoloading conventions improve startup time by allowing the user to enable `ctrlf-mode` without loading CTRLF until a command is actually used. Thus the corresponding `package-lint` warnings are erroneous.
