### PR TITLE
Add edit-chrome-textarea recipe

### DIFF
--- a/recipes/edit-chrome-textarea
+++ b/recipes/edit-chrome-textarea
@@ -1,0 +1,1 @@
+(edit-chrome-textarea :fetcher github :repo "xuchunyang/edit-chrome-textarea.el")


### PR DESCRIPTION
### Brief summary of what the package does

Edit Chrome Textarea similar to [atomic-chrome](https://github.com/alpha22jp/atomic-chrome), because they uses different approach, atomic-chrome needs a running websocket server insider Emacs and a Chrome extension to work, edit-chrome-textarea needs launching Chrome with `--remote-debugging-port` to work. However, edit-chrome-textarea is less powerful for lacking bidirectional sync and customized editable div such as the CodeMirror editor.

### Direct link to the package repository

https://github.com/xuchunyang/edit-chrome-textarea.el

### Your association with the package

[Are you the maintainer? A contributor? An enthusiastic user?]

I'm the maintainer

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
