### PR TITLE
Add ascii-table recipe

### DIFF
--- a/recipes/ascii-table
+++ b/recipes/ascii-table
@@ -1,0 +1,1 @@
+(ascii-table :fetcher github :repo "lassik/emacs-ascii-table")


### PR DESCRIPTION
### Brief summary of what the package does

Interactive ASCII table

Show a character map of the ubiquitous 7-bit ASCII character set (128 characters in total).

Do `M-x ascii-table` to bring up a window with the ASCII table.  Press 'b' for binary, 'o' for octal, 'd' for decimal and 'x' for hexadecimal. Press TAB to change the way control characters are shown.

### Direct link to the package repository

https://github.com/lassik/emacs-ascii-table

### Your association with the package

Wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them