### PR TITLE
Add the unobtrusive-magit-theme.

### DIFF
--- a/recipes/unobtrusive-magit-theme
+++ b/recipes/unobtrusive-magit-theme
@@ -1,0 +1,3 @@
+(unobtrusive-magit-theme
+ :fetcher github
+ :repo "tee3/unobtrusive-magit-theme")


### PR DESCRIPTION
### Brief summary of what the package does

This is an Emacs theme to improve the Magit faces in the case where a theme has not customized Magit faces.  It is unobtrusive in that Magit fits better within a theme.

### Direct link to the package repository

https://github.com/tee3/unobtrusive-magit-theme

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

The `package-lint` tool reports that the `provide` line is wrong, but this is a theme, so it uses `provide-theme`.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
