### PR TITLE
Add cpu-sos

### DIFF
--- a/recipes/cpu-sos
+++ b/recipes/cpu-sos
@@ -1,0 +1,1 @@
+(cpu-sos :fetcher github :repo "oitofelix/cpu-sos")


### PR DESCRIPTION
----

### Brief summary of what the package does

‘cpu-sos’ is a buffer-local minor-mode designed to track the
visibility of buffers associated with sub-processes or EXWM managed
windows and send a SIGSTOP signal to those processes (and their
related ones) as soon as their buffers become buried, eventually
reverting this by sending a SIGCONT signal as soon as they become
visible again.  This has the effect of limiting CPU consumption of
processes managed by Emacs at the user’s discretion.  Useful for
programs whose background processing the user is not interested in.
For example, web-browsers running JavaScript aggressively on
background for no good reason.  Other legitimate use is to forcibly
disable background app notifications while one’s attention focus is
elsewhere.

CAVEATS: Notice that the concept of "visibility" used by this package
is defined by the semantics of the value ‘visible’ given to the
parameter ‘ALL-FRAMES’ of function ‘get-buffer-window’.  This is
necessary, but not sufficient for actual view of the buffer at hand.
For instance, if a buffer is in a window of a frame that is totally
occluded by another it still is regarded as "visible", although one
can’t actually see it.  Aside from imprecise detection of visual
interaction, there is no attempt to detect sound interaction.
Therefore, buffers running music players or recording programs should
not have this mode enabled.  The same is true if one wants to have
asynchronous processes delivering notifications at arrival.  Keep also
in mind that trying to yank selection from stopped processes is
problematic.

### Direct link to the package repository

https://github.com/oitofelix/cpu-sos

### Your association with the package

I’m the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them