### PR TITLE
Add rego mode

### DIFF
--- a/recipes/rego-mode
+++ b/recipes/rego-mode
@@ -1,0 +1,3 @@
+(rego-mode
+ :repo "psibi/rego-mode"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Rego mode is a major mode for Rego language. More details about rego here: https://www.openpolicyagent.org/docs/latest/policy-language/#what-is-rego

### Direct link to the package repository

https://github.com/psibi/rego-mode

### Your association with the package

Author 

### Relevant communications with the upstream package maintainer

** None Needed **

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
