### PR TITLE
update recipe for org-roam

### DIFF
--- a/recipes/org-roam
+++ b/recipes/org-roam
@@ -1,3 +1,2 @@
 (org-roam :fetcher github
-          :repo "jethrokuan/org-roam"
-          :files ("org-roam.el" "org-roam-protocol.el"))
+          :repo "jethrokuan/org-roam")


### PR DESCRIPTION
After splitting up the files in https://github.com/jethrokuan/org-roam/pull/363, the MELPA recipe is no longer sufficient for building org-roam (https://github.com/jethrokuan/org-roam/issues/367)

Now, after removing company-org-roam, using the default recipe should work.
