### PR TITLE
Add gtk-variant recipe

### DIFF
--- a/recipes/gtk-variant
+++ b/recipes/gtk-variant
@@ -1,0 +1,1 @@
+(gtk-variant :fetcher github :repo "bepvte/gtk-variant.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package sets the theme variant (usually dark or light) of graphical Emacs' GTK theme. This is useful on desktop environments where the decorations are provided by GTK (like GNOME) to match Emacs' title bar with the rest of its window.

For example, if my GNOME desktop is on light theme, and I use a dark Emacs theme, running `gtk-variant-set-frame 'dark` will cause the windows title bar to match my Emacs theme.

### Direct link to the package repository

https://github.com/bepvte/gtk-variant.el

### Your association with the package

I maintain the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them