### PR TITLE
Add flyspell-visible package

### DIFF
--- a/recipes/flyspell-visible-mode
+++ b/recipes/flyspell-visible-mode
@@ -1,0 +1,3 @@
+(flyspell-visible-mode
+ :repo "ideasman42/emacs-flyspell-visible-mode"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Use flyspell to show all incorrect spelling on the screen (instead of only the text just typed or any text the cursor moves over).

This means you can use flyspell _(a popular package which many users already have configured)_, displaying all visible errors (as most word processors & web browsers do for example).

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-flyspell-visible-mode

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
