### PR TITLE
update repo vhdl-tools, moved to gitlab

### DIFF
--- a/recipes/vhdl-tools
+++ b/recipes/vhdl-tools
@@ -1,1 +1,1 @@
-(vhdl-tools :repo "csantosb/vhdl-tools" :fetcher github)
+(vhdl-tools :repo "csantosb/vhdl-tools" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

VHDL-tools provides an extra layer in the form of a minor mode intended to be
used along with emacs vhdl-mode. 

### Direct link to the package repository

https://gitlab.com/csantosb/vhdl-tools

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer



### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
