### PR TITLE
add display-buffer-control (dbc) package

### DIFF
--- a/recipes/dbc
+++ b/recipes/dbc
@@ -1,0 +1,1 @@
+(dbc :fetcher gitlab :repo "matsievskiysv/display-buffer-control")


### PR DESCRIPTION
### Brief summary of what the package does

This package is a wrapper around emacs `display-buffer-alist` facility. It allows to write declarative style rules about how to open (new/old frame, window position etc) specified buffers, matched by name, major/minor modes.

### Direct link to the package repository

https://gitlab.com/matsievskiysv/display-buffer-control

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
