### PR TITLE
Add recipie for metapost-png-preview

### DIFF
--- a/recipes/metapost-png-preview
+++ b/recipes/metapost-png-preview
@@ -1,0 +1,1 @@
+(metapost-png-preview :fetcher github :repo "johanvts/metapost-png-preview")


### PR DESCRIPTION
A mode for previewing metapost figures using the png backend.

### Brief summary of what the package does

Allow viewing a png image of the current metapost buffer.

### Direct link to the package repository

https://github.com/johanvts/metapost-png-preview/

### Your association with the package

Author/maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
