### PR TITLE
recipes: added the soria theme

### DIFF
--- a/recipes/soria-theme
+++ b/recipes/soria-theme
@@ -1,0 +1,1 @@
+(soria-theme :repo "mssola/soria" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

**Soria** is a color theme which mixes:

- [xoria256](http://www.vim.org/scripts/script.php?script_id=2140): a color theme by Dmitry Zotikov, originally for Vim. I did not do the initial porting from Vim to Emacs, I took the initial code from [suxue](https://github.com/suxue/xoria256-emacs). That being said, [this](https://github.com/suxue/xoria256-emacs) project has not received any update in years and the project doesn't look maintained. Moreover, this theme does not want to be a port of xoria256 (since it also adds colors from the openSUSE guidelines). Considering all this, contributing directly to that port did not look like a good option.
- openSUSE: I took some colors from [openSUSE's Brand Guidelines](http://opensuse.github.io/branding-guidelines/).

### Direct link to the package repository

https://github.com/mssola/soria

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
