### PR TITLE
Add spell-fu package

### DIFF
--- a/recipes/spell-fu
+++ b/recipes/spell-fu
@@ -1,0 +1,3 @@
+(spell-fu
+ :repo "ideasman42/emacs-spell-fu"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Use show all incorrect spelling on the screen (unlike flyspell which only highlights text as you type).

Unlike other spell-checkers I've tried, this loads the dictionary into memory, making it fast enough to run as part of syntax highlighting, although by default it uses an idle timer at 1/4 of a second, as spell checking all words as you type can become irritating, and this means it doesn't add overhead (however small) when performing edits.

This package has been posted to reddit, see: [RFC](https://www.reddit.com/r/emacs/comments/futthm/rfc_spellfu_fast_elisp_highlighter_for_misspelled/).

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-spell-fu

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
