### PR TITLE
Jpkotta bitbucket migration

### DIFF
--- a/recipes/figlet
+++ b/recipes/figlet
@@ -1,3 +1,3 @@
 (figlet
- :fetcher bitbucket
+ :fetcher github
  :repo "jpkotta/figlet")

--- a/recipes/flex-isearch
+++ b/recipes/flex-isearch
@@ -1,3 +1,3 @@
 (flex-isearch
- :fetcher bitbucket
+ :fetcher github
  :repo "jpkotta/flex-isearch")

--- a/recipes/highlight-operators
+++ b/recipes/highlight-operators
@@ -1,3 +1,3 @@
 (highlight-operators
- :repo "jpkotta/highlight-operators"
- :fetcher bitbucket)
+ :fetcher github
+ :repo "jpkotta/highlight-operators")

--- a/recipes/immortal-scratch
+++ b/recipes/immortal-scratch
@@ -1,3 +1,3 @@
 (immortal-scratch
- :fetcher bitbucket
+ :fetcher github
  :repo "jpkotta/immortal-scratch")

--- a/recipes/openwith
+++ b/recipes/openwith
@@ -1,3 +1,3 @@
 (openwith
- :fetcher bitbucket
+ :fetcher github
  :repo "jpkotta/openwith")

--- a/recipes/syntax-subword
+++ b/recipes/syntax-subword
@@ -1,3 +1,3 @@
 (syntax-subword
- :fetcher bitbucket
+ :fetcher github
  :repo "jpkotta/syntax-subword")


### PR DESCRIPTION
Migrate jpkotta's packages from Bitbucket to Github

As @tarsius has requested in #6484 I have migrated my packages
from Bitbucket to Github.  The old repositories were located at:

* https://bitbucket.org/jpkotta/highlight-operators
* https://bitbucket.org/jpkotta/immortal-scratch
* https://bitbucket.org/jpkotta/syntax-subword/
* https://bitbucket.org/jpkotta/openwith
* https://bitbucket.org/jpkotta/flex-isearch
* https://bitbucket.org/jpkotta/figlet/

I accidentally didn't add a forwarding link for the immortal-scratch repo.