### PR TITLE
Add org-treeusage recipe

### DIFF
--- a/recipes/org-treeusage
+++ b/recipes/org-treeusage
@@ -1,0 +1,1 @@
+(org-treeusage :fetcher github :repo "mtekman/org-treeusage.el")


### PR DESCRIPTION
### Brief summary of what the package does

This library provides a minor mode for peeking at the line or character usage of each heading with respect to the parent heading in an org-mode file, allowing users with large org files to see the distribution of heading content and make informed decisions on where to prune, refile, or archive.

### Direct link to the package repository

https://github.com/mtekman/org-treeusage.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
