### PR TITLE
Add lisp-local recipe

### DIFF
--- a/recipes/lisp-local
+++ b/recipes/lisp-local
@@ -1,0 +1,1 @@
+(lisp-local :fetcher github :repo "lispunion/emacs-lisp-local")


### PR DESCRIPTION
### Brief summary of what the package does

Allows different Lisp indentation in each buffer via a `lisp-indent-function` wrapper that temporarily replaces global indentation-related symbol properties with local values.

### Direct link to the package repository

https://github.com/lispunion/emacs-lisp-local

### Your association with the package

Wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
