### PR TITLE
Add org-noter-pdftools

### DIFF
--- a/recipes/org-noter-pdftools
+++ b/recipes/org-noter-pdftools
@@ -1,0 +1,2 @@
+(org-noter-pdftools :repo "fuxialexander/org-pdftools" :fetcher github
+            :files ("org-noter-pdftools.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Add integration between org-pdftools and org-noter.

### Direct link to the package repository

https://github.com/fuxialexander/org-pdftools

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
