### PR TITLE
Add recipe for smart-input-source

### DIFF
--- a/recipes/smart-input-source
+++ b/recipes/smart-input-source
@@ -1,0 +1,3 @@
+(smart-input-source
+  :fetcher github
+  :repo "laishulu/emacs-smart-input-source")


### PR DESCRIPTION
### Brief summary of what the package does

Switch input source smartly.

### Direct link to the package repository

https://github.com/laishulu/emacs-smart-input-source

### Your association with the package

maintainer
### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

---
1. Result of `package-lint`, the issues actually does not stand. Because I use [`names` ](https://github.com/Malabarba/names) package to wrap all the symbols in the name space of `smart-input-source
```
32 issues found:

37:0: error: "english-pattern" doesn't start with package's prefix "smart-input-source".
41:0: error: "other-pattern" doesn't start with package's prefix "smart-input-source".
45:0: error: "blank-pattern" doesn't start with package's prefix "smart-input-source".
49:0: error: "english-input-source" doesn't start with package's prefix "smart-input-source".
53:0: error: "other-input-source" doesn't start with package's prefix "smart-input-source".
57:0: error: "external-ism" doesn't start with package's prefix "smart-input-source".
61:0: error: "do-get-input-source" doesn't start with package's prefix "smart-input-source".
67:0: error: "do-set-input-source" doesn't start with package's prefix "smart-input-source".
77:0: error: "ENGLISH" doesn't start with package's prefix "smart-input-source".
78:0: error: "OTHER" doesn't start with package's prefix "smart-input-source".
81:0: error: "ISM-EMP" doesn't start with package's prefix "smart-input-source".
83:0: error: "-ism" doesn't start with package's prefix "smart-input-source".
86:0: error: "-string-match-p" doesn't start with package's prefix "smart-input-source".
101:0: error: "-back-detect-chars" doesn't start with package's prefix "smart-input-source".
122:0: error: "-fore-detect-chars" doesn't start with package's prefix "smart-input-source".
136:0: error: "-guess-context" doesn't start with package's prefix "smart-input-source".
175:0: error: "-prober" doesn't start with package's prefix "smart-input-source".
189:0: error: "-mk-get-input-source-fn" doesn't start with package's prefix "smart-input-source".
197:0: error: "-mk-set-input-source-fn" doesn't start with package's prefix "smart-input-source".
206:0: error: "-get-input-source" doesn't start with package's prefix "smart-input-source".
211:0: error: "-set-input-source" doesn't start with package's prefix "smart-input-source".
224:0: error: "adaptive-input-source" doesn't start with package's prefix "smart-input-source".
231:0: error: "set-input-source-english" doesn't start with package's prefix "smart-input-source".
236:0: error: "set-input-source-other" doesn't start with package's prefix "smart-input-source".
241:0: error: "mode" doesn't start with package's prefix "smart-input-source".
285:0: error: "-inline-overlay" doesn't start with package's prefix "smart-input-source".
289:0: error: "-last-inline-overlay-start-position" doesn't start with package's prefix "smart-input-source".
293:0: error: "-last-inline-overlay-end-position" doesn't start with package's prefix "smart-input-source".
297:0: error: "check-to-deactive-overlay" doesn't start with package's prefix "smart-input-source".
305:0: error: "activate-inline-overlay" doesn't start with package's prefix "smart-input-source".
324:0: error: "end-inline-overlay" doesn't start with package's prefix "smart-input-source".
330:0: error: "deactivate-inline-overlay" doesn't start with package's prefix "smart-input-source".
```
2. `byte-compile-file` gives no error
3. `checkdoc` result
```
Buffer comments and tags:  Not checked
Documentation style:       Ok
Message/Query text style:  Ok
Unwanted Spaces:           Ok
```