### PR TITLE
Add OpenSearch descriptor

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -6,6 +6,7 @@
   <meta name="description" lang="en" content="The largest and most up-to-date repository of Emacs packages.">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <link rel="shortcut icon" href="favicon.ico">
+  <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Melpa" >
   <link href="/updates.rss" rel="alternate" title="MELPA updates" type="application/rss+xml">
   <!--[if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7/html5shiv.min.js" type="text/javascript"></script><![endif]-->
   <link href="https://netdna.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">

--- a/html/opensearch.xml
+++ b/html/opensearch.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>Melpa</ShortName>
+    <Description>Search Melpa</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/x-icon">https://melpa.org/favicon.ico</Image>
+    <Url type="text/html" method="get" template="https://melpa.org/#/?q={searchTerms}"/>
+    <moz:SearchForm>https://melpa.org/</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
This adds an [OpenSearch] descriptor to the site.

[OpenSearch]: https://developer.mozilla.org/en-US/docs/Web/OpenSearch

