### PR TITLE
New recipe: space-theming

### DIFF
--- a/recipes/space-theming
+++ b/recipes/space-theming
@@ -1,0 +1,2 @@
+(space-theming :repo "p3r7/space-theming"
+               :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Straightforward port of the [Spacemacs theming layer](https://www.spacemacs.org/layers/+themes/theming/README.html) ([code](https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Bthemes/theming)) to vanilla Emacs.

Allows overriding theme faces with the same syntax / utils as what Spacemacs provides.

For more details, see the package README and/or this [blog post](https://www.eigenbahn.com/2020/04/06/emacs-theme-override).

### Direct link to the package repository

https://github.com/p3r7/space-theming

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
