### PR TITLE
Recipe/friendly tramp path

### DIFF
--- a/recipes/friendly-tramp-path
+++ b/recipes/friendly-tramp-path
@@ -1,0 +1,2 @@
+(friendly-tramp-path :repo "p3r7/friendly-tramp-path"
+                     :fetcher github)

--- a/recipes/space-theming
+++ b/recipes/space-theming
@@ -1,2 +1,0 @@
-(space-theming :repo "p3r7/space-theming"
-               :fetcher github)

--- a/recipes/space-theming
+++ b/recipes/space-theming
@@ -1,0 +1,2 @@
+(space-theming :repo "p3r7/space-theming"
+               :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides helper function `friendly-tramp-path-disect`, a drop-in replacement for `tramp-dissect-file-name` but that allows a more permissive syntax.

It is particularly suited for commands prompting the user for a remote path. 

Lib dependency for package [prf-remote-shell](https://github.com/p3r7/prf-shell) that allows spawning remote shells quickly.

### Direct link to the package repository

https://github.com/p3r7/friendly-tramp-path

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
