### PR TITLE
Add org-multi-wiki

### DIFF
--- a/recipes/org-multi-wiki
+++ b/recipes/org-multi-wiki
@@ -1,0 +1,2 @@
+(org-multi-wiki :fetcher github :repo "akirak/org-multi-wiki"
+                :files ("org-multi-wiki.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Org-based wiki system for multiple workgroups with namespace support.

### Direct link to the package repository

https://github.com/akirak/org-multi-wiki

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
