### PR TITLE
Add helm-org-multi-wiki

### DIFF
--- a/recipes/helm-org-multi-wiki
+++ b/recipes/helm-org-multi-wiki
@@ -1,0 +1,2 @@
+(helm-org-multi-wiki :fetcher github :repo "akirak/org-multi-wiki"
+                     :files ("helm-org-multi-wiki.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Helm interface to org-multi-wiki, Org-based wiki system for multiple workgroups

### Direct link to the package repository

https://github.com/akirak/org-multi-wiki

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

This is a companion package to #6828 and depends on it. Please merge this PR only after it is merged. CI currently fails, but it's going to become green once org-multi-wiki.el is available in MELPA.