### PR TITLE
Add owcmd package

### DIFF
--- a/recipes/owcmd
+++ b/recipes/owcmd
@@ -1,0 +1,1 @@
+(owcmd :fetcher github :repo "fishyfriend/owcmd")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a command to switch to the next window, run a command, then switch back to the original window automatically. Use it to save keystrokes when you need to do just one thing in the other window, like scroll the buffer, jump to a definition, paste some text, or quit a temporary buffer. It is a sort of generalization of the built-in commands `scroll-other-window` and `scroll-other-window-down`.

### Direct link to the package repository

https://github.com/fishyfriend/execute-other-window

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Note on prior art

There is an existing package, [owdriver](https://github.com/aki2o/owdriver), that provides similar functionality. I believe execute-other-window provides unique value and should stand on its own. **TLDR:** execute-other-window avoids owdriver's keymap-driven approach and this offers better compatibility and convenience for some use cases.

#### Details

owdriver maintains a keymap of bindings the user wants available in the other window, where each key (outside of some defaults) must be configured individually. This offers some finer control over what keys are available in the other window, but has several disadvantages:
* labor-intensive if all you want is for all keys to work by default.
* would require extra dispatch code to set up keybindings for multiple modes that bind the same keys.
* hard to integrate with tools like Evil that override existing keymaps.

The keymap-driven approach does not seem ideal for these cases; there are probably solutions but they would require adding a lot of code complexity. Moreover, even with solutions to these problems, as a user of both Evil and God Mode, my life is greatly simplified if I can avoid adding yet another "weird" keymap to an already challenging keymap scheme. Thus, for me anyway, execute-other-window makes sense as an alternative.