### PR TITLE
recipes(flycheck-grammalecte): Add missing python script in :files list

### DIFF
--- a/recipes/flycheck-grammalecte
+++ b/recipes/flycheck-grammalecte
@@ -1,4 +1,4 @@
 (flycheck-grammalecte
  :fetcher git
  :url "https://git.deparis.io/flycheck-grammalecte/"
- :files (:defaults "flycheck-grammalecte.py"))
+ :files (:defaults "flycheck-grammalecte.py" "conjugueur.py"))


### PR DESCRIPTION
This PR fix an already existing package: flycheck-grammalecte

### Brief summary of what the PR does

The last flycheck-grammalecte release add a new external python script, which should be embed in the package.

### Direct link to the package repository

https://git.deparis.io/flycheck-grammalecte/

### Your association with the package

Current maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I have confirmed some of these without doing them
