### PR TITLE
Add mc-calc

### DIFF
--- a/recipes/mc-calc
+++ b/recipes/mc-calc
@@ -1,0 +1,1 @@
+(mc-calc :fetcher github :repo "hatheroldev/mc-calc")


### PR DESCRIPTION
### Brief summary of what the package does

This package allows the use of calc in with multiple-cursors.

### Direct link to the package repository

https://github.com/hatheroldev/mc-calc

### Your association with the package

I am the maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly (despite a needed setting of calc variable var-mccursors)
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
