### PR TITLE
Migrate packages from Bitbucket.

### DIFF
--- a/recipes/2048-game
+++ b/recipes/2048-game
@@ -1,1 +1,1 @@
-(2048-game :fetcher bitbucket :repo "zck/2048.el")
+(2048-game :fetcher hg :url "https://hg.sr.ht/~zck/game-2048")

--- a/recipes/minesweeper
+++ b/recipes/minesweeper
@@ -1,1 +1,1 @@
-(minesweeper :fetcher bitbucket :repo "zck/minesweeper.el")
+(minesweeper :fetcher hg :url "https://hg.sr.ht/~zck/minesweeper")

--- a/recipes/org-parser
+++ b/recipes/org-parser
@@ -1,1 +1,1 @@
-(org-parser :fetcher bitbucket :repo "zck/org-parser.el")
+(org-parser :fetcher hg :url "https://hg.sr.ht/~zck/org-parser")

--- a/recipes/zpresent
+++ b/recipes/zpresent
@@ -1,1 +1,1 @@
-(zpresent :fetcher bitbucket :repo "zck/zpresent.el")
+(zpresent :fetcher hg :url "https://hg.sr.ht/~zck/zpresent")


### PR DESCRIPTION
As @tarsius has requested in #6484 I have migrated my packages
from Bitbucket to Github.  The old repositories were located at:

* https://bitbucket.org/zck/2048.el/
* https://bitbucket.org/zck/minesweeper.el/
* https://bitbucket.org/zck/org-parser.el/
* https://bitbucket.org/zck/2048.el/
