### PR TITLE
Make bibtex-completion a separate package

### DIFF
--- a/recipes/bibtex-completion
+++ b/recipes/bibtex-completion
@@ -1,0 +1,1 @@
+(bibtex-completion :fetcher github :repo "tmalsburg/helm-bibtex" :files ("bibtex-completion.el"))

--- a/recipes/helm-bibtex
+++ b/recipes/helm-bibtex
@@ -1,1 +1,1 @@
-(helm-bibtex :fetcher github :repo "tmalsburg/helm-bibtex" :files ("helm-bibtex.el" "bibtex-completion.el"))
+(helm-bibtex :fetcher github :repo "tmalsburg/helm-bibtex" :files ("helm-bibtex.el"))

--- a/recipes/ivy-bibtex
+++ b/recipes/ivy-bibtex
@@ -1,1 +1,1 @@
-(ivy-bibtex :fetcher github :repo "tmalsburg/helm-bibtex" :files ("ivy-bibtex.el" "bibtex-completion.el"))
+(ivy-bibtex :fetcher github :repo "tmalsburg/helm-bibtex" :files ("ivy-bibtex.el"))


### PR DESCRIPTION
Useful for org-roam-bibtex and generally cleaner.

### Brief summary of what the package does

bibtex-completion.el used to be part of packages helm-bibtex and ivy-bibtex. First this is redundant, second there are now other packages that need bibtex-completion but do not depend on helm-bibtex or ivy-bibtex.

### Direct link to the package repository

https://github.com/tmalsburg/helm-bibtex

This repo contains bibtex-completion, helm-bibtex, and ivy-bibtex since they are tightly related and developed in tandem.

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

I did not manage to make checkdoc 100% happy (some lines are too long).  Shame on me.  