### PR TITLE
Update location of smart-tab repo

### DIFF
--- a/recipes/smart-tab
+++ b/recipes/smart-tab
@@ -1,1 +1,3 @@
-(smart-tab :repo "genehack/smart-tab" :fetcher github)
+(smart-tab
+ :fetcher git
+ :url "https://git.genehack.net/genehack/smart-tab.git")


### PR DESCRIPTION
I'm migrating my content away from Github to my own self-hosted Gitea
instance.

### Brief summary of what the package does

Intelligent tab completion and indentation

### Direct link to the package repository

https://git.genehack.net/genehack/smart-tab

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

** None needed **

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
