### PR TITLE
Add friendly-shell, friendly-shell-command, friendly-remote-shell

### DIFF
--- a/recipes/friendly-remote-shell
+++ b/recipes/friendly-remote-shell
@@ -1,0 +1,4 @@
+(friendly-remote-shell :repo "p3r7/friendly-remote-shell"
+                       :fetcher github
+                       :files (:defaults
+                               (:exclude "friendly-shell-command.el" "friendly-shell.el")))

--- a/recipes/friendly-remote-shell
+++ b/recipes/friendly-remote-shell
@@ -1,4 +1,4 @@
-(friendly-remote-shell :repo "p3r7/friendly-remote-shell"
+(friendly-remote-shell :repo "p3r7/friendly-shell"
                        :fetcher github
                        :files (:defaults
                                (:exclude "friendly-shell-command.el" "friendly-shell.el")))

--- a/recipes/friendly-shell
+++ b/recipes/friendly-shell
@@ -1,0 +1,4 @@
+(friendly-shell :repo "p3r7/friendly-shell"
+                :fetcher github
+                :files (:defaults
+                        (:exclude "friendly-shell-command.el" "friendly-remote-shell.el")))

--- a/recipes/friendly-shell-command
+++ b/recipes/friendly-shell-command
@@ -1,4 +1,4 @@
-(friendly-shell-command :repo "p3r7/friendly-shell-command"
+(friendly-shell-command :repo "p3r7/friendly-shell"
                         :fetcher github
                         :files (:defaults
                                 (:exclude "friendly-shell.el" "friendly-remote-shell.el")))

--- a/recipes/friendly-shell-command
+++ b/recipes/friendly-shell-command
@@ -1,0 +1,4 @@
+(friendly-shell-command :repo "p3r7/friendly-shell-command"
+                        :fetcher github
+                        :files (:defaults
+                                (:exclude "friendly-shell.el" "friendly-remote-shell.el")))


### PR DESCRIPTION
Cleaner attempt of https://github.com/melpa/melpa/pull/6834.

### Brief summary of what the package does

More user-friendly shell APIs for Emacs.

3 packages:
 - `friendly-shell-command.el` for single shell commands ([blog post](https://www.eigenbahn.com/2020/01/19/painless-emacs-shell-commands))
 - `friendly-shell.el` for interactive shells ([blog post](https://www.eigenbahn.com/2020/01/21/painless-emacs-interactive-shells))
 - `friendly-remote-shell.el` for interactive remote shells

### Direct link to the package repository

https://github.com/p3r7/friendly-shell

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
