### PR TITLE
Add Setup

### DIFF
--- a/recipes/setup
+++ b/recipes/setup
@@ -1,0 +1,1 @@
+(setup :url "https://git.sr.ht/~zge/setup.el" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides the `setup` macro that helps in configuring Emacs, and the `setup-define` that helps in configuring-configuring Emacs. The former is comparable in idea to `use-package`, but places more emphasis on user-extensibility via the latter.

### Direct link to the package repository

https://git.sr.ht/~zge/setup.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

**Note:** There are two `package-lint` complaints I cannot fix (`with-eval-after-load` usage), due to the nature of the package. I should note that both are in macros that only get used in real code after macro-expansion, not by the package itself.