### PR TITLE
Add recipe for helm-treemacs-icons

### DIFF
--- a/recipes/helm-treemacs-icons
+++ b/recipes/helm-treemacs-icons
@@ -1,0 +1,1 @@
+(helm-treemacs-icons :repo "yyoncho/helm-treemacs-icons " :fetcher github)

--- a/recipes/helm-treemacs-icons
+++ b/recipes/helm-treemacs-icons
@@ -1,1 +1,1 @@
-(helm-treemacs-icons :repo "yyoncho/helm-treemacs-icons " :fetcher github)
+(helm-treemacs-icons :repo "yyoncho/helm-treemacs-icons" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Integration between treemacs icons and helm(++).

### Direct link to the package repository

https://github.com/yyoncho/helm-treemacs-icons

### Your association with the package

author

### Relevant communications with the upstream package maintainer

none needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
Note: I have used it - it has one false negative for the name of the package containing "emacs"
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
