### PR TITLE
Remove @proofit404's disappeared packages

### DIFF
--- a/recipes/company-edbi
+++ b/recipes/company-edbi
@@ -1,3 +1,0 @@
-(company-edbi
- :fetcher github
- :repo "proofit404/company-edbi")

--- a/recipes/company-tern
+++ b/recipes/company-tern
@@ -1,1 +1,0 @@
-(company-tern :fetcher github :repo "proofit404/company-tern")

--- a/recipes/edbi-database-url
+++ b/recipes/edbi-database-url
@@ -1,3 +1,0 @@
-(edbi-database-url
- :fetcher github
- :repo "proofit404/edbi-database-url")

--- a/recipes/edbi-django
+++ b/recipes/edbi-django
@@ -1,1 +1,0 @@
-(edbi-django :fetcher github :repo "proofit404/edbi-django")

--- a/recipes/edbi-minor-mode
+++ b/recipes/edbi-minor-mode
@@ -1,1 +1,0 @@
-(edbi-minor-mode :fetcher github :repo "proofit404/edbi-minor-mode")

--- a/recipes/edbi-sqlite
+++ b/recipes/edbi-sqlite
@@ -1,4 +1,0 @@
-(edbi-sqlite
- :fetcher github
- :repo "proofit404/edbi-sqlite"
- :old-names (edbi-sqlite3))

--- a/recipes/envdir
+++ b/recipes/envdir
@@ -1,1 +1,0 @@
-(envdir :fetcher github :repo "proofit404/envdir-mode")


### PR DESCRIPTION
These modes are gone from the authors github profile.
Discovered through the Nix emacs-overlay hydra: https://hydra.nix-community.org/eval/4237.

### Relevant communications with the upstream package maintainer

None. Hoping the author @proofit404 will chime in here.

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them