### PR TITLE
info-buffer: Move repo to gitlab

### DIFF
--- a/recipes/info-buffer
+++ b/recipes/info-buffer
@@ -1,3 +1,3 @@
 (info-buffer
- :fetcher github
+ :fetcher gitlab
  :repo "llvilanova/info-buffer")


### PR DESCRIPTION
~The repository is gone.~
Upstream moved to gitlab

### Relevant communications with the upstream package maintainer

cc @llvilanova 

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
