### PR TITLE
Add geiser-kawa

### DIFF
--- a/recipes/geiser-kawa
+++ b/recipes/geiser-kawa
@@ -1,0 +1,7 @@
+(geiser-kawa
+ :fetcher gitlab
+ :repo "spellcard199/geiser-kawa"
+ :files ("elisp/*.el"
+         "pom.xml"
+         ".mvn" "mvnw" "mvnw.cmd"
+         "src"))


### PR DESCRIPTION
### Brief summary of what the package does

`geiser-kawa` extends the `geiser` package with support for the Kawa Scheme language [1] [2]. 

[1] https://www.gnu.org/software/kawa/index.html
[2] https://gitlab.com/kashell/Kawa

### Direct link to the package repository

https://gitlab.com/spellcard199/geiser-kawa

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

I'm the maintainer of `geiser-kawa`, but since `geiser-kawa` is an extension of the `geiser` package there has been a discussion with its maintainers about making `geiser-kawa` a separate package [1]. In summary, the `geiser` team is considering moving to an organization where there is a core `geiser` package and a `geiser-...` package for each scheme implementation so that they can focus and make more frequent updates/releases.

[1] https://gitlab.com/jaor/geiser/-/merge_requests/260

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### About byte-compile warnings

Result of `cask; cask build`:

```
In toplevel form:
geiser-kawa-arglist.el:110:1:Warning: Unused lexical argument ‘remote’
Compiling /home/doreen/IdeaProjects/geiser-kawa/elisp/geiser-kawa-deps.el...

In toplevel form:
geiser-kawa-deps.el:82:1:Warning: Unused lexical argument ‘desc’
geiser-kawa-deps.el:82:1:Warning: Unused lexical argument ‘buf’
Compiling /home/doreen/IdeaProjects/geiser-kawa/elisp/geiser-kawa-devutil-complete.el...
Compiling /home/doreen/IdeaProjects/geiser-kawa/elisp/geiser-kawa-devutil-exprtree.el...
Compiling /home/doreen/IdeaProjects/geiser-kawa/elisp/geiser-kawa-ext-help.el...

In toplevel form:
geiser-kawa-ext-help.el:126:1:Warning: Unused lexical argument ‘mod’
Compiling /home/doreen/IdeaProjects/geiser-kawa/elisp/geiser-kawa-globals.el...
Compiling /home/doreen/IdeaProjects/geiser-kawa/elisp/geiser-kawa-util.el...
Compiling /home/doreen/IdeaProjects/geiser-kawa/elisp/geiser-kawa.el...

In toplevel form:
geiser-kawa.el:104:1:Warning: Unused lexical argument ‘module’
```

The reason why I can't solve these "Unused lexical argument" warnings is that the culprit functions are registered to be called by `geiser` depending on the scheme implementation. In particular, this `geiser-kawa` implementation does not use those parameters, but geiser would still call those functions with that number of arguments.

### About TODOs

The reason why there are still TODOs in the code is because I don't know Kawa enough to implement them.

### About java dependencies

`geiser-kawa` is the elisp side, but the Kawa Scheme side depends on:
1. `kawa-geiser`
    - url: same repository of `geiser-kawa`
    - Takes care of wrapping required data in geiser's protocol
2. `kawa-devutil` (I'm the maintainer)
    - url: https://gitlab.com/spellcard199/kawa-devutil
    - Takes care of getting the actual data
3. `Kawa` (the actual language)
    - url: https://gitlab.com/kashell/Kawa
    - Provides the api that `kawa-devutil` uses
4. `ClassGraph`
    - url: https://github.com/classgraph/classgraph
    - Used by `kawa-devutil` for getting completion data about Java Packages and Classes

Each of these uses a GPL-Compatible Free Software License.
