### PR TITLE
Add raku-mode recipe

### DIFF
--- a/recipes/raku-mode
+++ b/recipes/raku-mode
@@ -1,0 +1,1 @@
+(raku-mode :fetcher github :repo "Raku/raku-mode" :files (:defaults (:exclude "nqp-mode.el")))


### PR DESCRIPTION
Hello,

This adds the `raku-mode` recipe. It's the same recipe as [recipes/perl6-mode](https://github.com/melpa/melpa/blob/master/recipes/perl6-mode) since the language got renamed and https://github.com/perl6/perl6-mode/ redirects cleanly to https://github.com/Raku/raku-mode/.

Should I include the remove of `perl6-mode` in this PR? If so, what will happen with the users that have that package installed?

Some reference issues:

* https://github.com/melpa/melpa/issues/6475
* https://github.com/Raku/raku-mode/issues/22