### PR TITLE
Add recipe for message-attachment-reminder

### DIFF
--- a/recipes/message-attachment-reminder
+++ b/recipes/message-attachment-reminder
@@ -1,0 +1,1 @@
+(message-attachment-reminder :fetcher github :repo "alexmurray/message-attachment-reminder")


### PR DESCRIPTION
### Brief summary of what the package does

Reminders user of possible forgotten attachments in message-mode

### Direct link to the package repository

https://github.com/alexmurray/message-attachment-reminder

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
