### PR TITLE
add lsp-pascal

### DIFF
--- a/recipes/lsp-pascal
+++ b/recipes/lsp-pascal
@@ -1,0 +1,3 @@
+(lsp-pascal
+ :fetcher github
+ :repo "arjanadriaanse/lsp-pascal")


### PR DESCRIPTION
### Brief summary of what the package does

LSP client to support Pascal through the `lsp-mode` package using the
[Pascal Language Server](https://github.com/arjanadriaanse/pascal-language-server).

### Direct link to the package repository

https://github.com/arjanadriaanse/lsp-pascal

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
