### PR TITLE
Add package inform

### DIFF
--- a/recipes/inform
+++ b/recipes/inform
@@ -1,0 +1,3 @@
+(inform
+:fetcher github
+:repo "dieter-wilhelm/inform")

--- a/recipes/treemacs
+++ b/recipes/treemacs
@@ -2,6 +2,7 @@
  :fetcher github
  :repo "Alexander-Miller/treemacs"
  :files (:defaults
+         "Changelog.org"
          "icons"
          "src/elisp/treemacs*.el"
          "src/scripts/treemacs*.py"


### PR DESCRIPTION
Package inform: Symbol links in Info buffers to their help documentation

### Brief summary of what the package does

This library provides links of symbols (functions, variables,
faces) within Emacs' Info viewer to their help documentation.  This
linking is done, when the symbol names in texinfo documentations
(like the Emacs and Elisp manual) are `quoted', which is done
customarily.  And the quoted names must be known to Emacs i.e. the
definitions are loaded in its memory.

You can follow these additional links with the usual Info
keybindings.  The customisation variable
`mouse-1-click-follows-link' is influencing the clicking behaviour
(and the tooltips) of the links, the variable's default is 450
(milli seconds) setting it to nil means only clicking with mouse-2
is following the link .

### Direct link to the package repository

https://github.com/dieter-wilhelm/inform

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist


- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
