### PR TITLE
Add recipe for vega-view

### DIFF
--- a/recipes/vega-view
+++ b/recipes/vega-view
@@ -1,0 +1,1 @@
+(vega-view :repo "applied-science/emacs-vega-view" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a package for viewing Vega visualizations in emacs. There's an extensive README at the repo in case this doesn't immediately make sense.

### Direct link to the package repository

https://github.com/applied-science/emacs-vega-view

### Your association with the package

Author/maintainer.

### Relevant communications with the upstream package maintainer

The Makefile fails on my recipe, but it also seems to fail on every other recipe that `require`s `cl-lib`, despite said packages already being in MELPA. Everything else is squeaky clean.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
