### PR TITLE
Add recipe for inform7

### DIFF
--- a/recipes/inform7
+++ b/recipes/inform7
@@ -1,0 +1,1 @@
+(inform7 :fetcher github :repo "GuiltyDolphin/inform7-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Inform7(-mode) is a package for working with [Inform7](http://inform7.com/) source files.

As of the first 'stable' release (0.1.0), the package supports basic syntax highlighting (headers, comments, strings, substitutions, some rule keywords), indentation (in strings/comments (free-form) as well as in rules), and header navigation via imenu. There was an [old inform7-mode](https://github.com/fred-o/inform7-mode) package that got removed from MELPA, but it hasn't seen any activity for 7+ years, and I think most (if not all) of the functionality (and more!) is covered in the new package.

### Direct link to the package repository

https://github.com/GuiltyDolphin/inform7-mode

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

~I seem to be having some issues installing `package-lint` at the moment, but will tick off as soon as that's sorted!~ Edit: I managed to get `package-lint` working (just loaded the Elisp directly)---needed a couple of changes, and these are in release 0.1.1.