### PR TITLE
add multistate package

### DIFF
--- a/recipes/multistate
+++ b/recipes/multistate
@@ -1,0 +1,1 @@
+(multistate :repo "matsievskiysv/multistate" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides `multistate-mode` minor mode. This mode allows modal editing and may be described as `evil-mode` without vi. It does not predefine any states, key bindings, does not use hooks, so it's very useful when user wants to configure modal editing but does not Emacs to emulate Vim (or spend time removing Vim out of `evil-mode`).

### Direct link to the package repository

<https://gitlab.com/matsievskiysv/multistate>

### Your association with the package

I'm an author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
