### PR TITLE
Add auth-source-xoauth2

### DIFF
--- a/recipes/auth-source-xoauth2
+++ b/recipes/auth-source-xoauth2
@@ -1,0 +1,3 @@
+(auth-source-xoauth2
+ :fetcher github
+ :repo "ccrusius/auth-source-xoauth2")


### PR DESCRIPTION
### Brief summary of what the package does

Adds an OAUTH2 backend to auth-sources, enabling it to be used with services such as GMail.

### Direct link to the package repository

https://github.com/ccrusius/auth-source-xoauth2

### Your association with the package

Author and user.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly: There is a free variable warning that I'm not sure can be removed without unnecessarily (requre 'nnimap), which would bring all of Gnus with it.
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
