### PR TITLE
Include images for sly info manual

### DIFF
--- a/recipes/sly
+++ b/recipes/sly
@@ -4,4 +4,5 @@
              "lib"
              "slynk"
              "contrib"
+             "doc/images"
              (:exclude "sly-autoloads.el")))


### PR DESCRIPTION
Fix #6870.
### Brief summary of what the package does

Include `doc/images/` since they're used in the sly info manual (for instance [here](https://github.com/joaotavora/sly/blob/master/doc/sly.texi#L644)).

(I tested installing the package before and after updating the recipe, and they were indeed absent before and present after.)

The gif files in `doc/animations/` do not seem to be referenced in the info manual, so I'm not including them.

### Direct link to the package repository

https://github.com/joaotavora/sly/

### Your association with the package

### Relevant communications with the upstream package maintainer

The issue was mentioned upstream [here](https://github.com/joaotavora/sly/issues/316), though obviously it was out of scope there.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them