### PR TITLE
Adds nothing-theme

### DIFF
--- a/recipes/nothing-theme
+++ b/recipes/nothing-theme
@@ -1,0 +1,1 @@
+(nothing-theme :fetcher github :repo "jaredgorski/nothing.el" :files ("nothing-theme.el"))

--- a/recipes/nothing-theme
+++ b/recipes/nothing-theme
@@ -1,1 +1,1 @@
-(nothing-theme :fetcher github :repo "jaredgorski/nothing.el" :files ("nothing-theme.el"))
+(nothing-theme :fetcher github :repo "jaredgorski/nothing.el")


### PR DESCRIPTION
### Brief summary of what the package does

This theme provides a monochrome and rather default-style emacs experience. This helps some people focus on content over form and potentially minimizes effects of context-switching.

### Direct link to the package repository

https://github.com/jaredgorski/nothing.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
