### PR TITLE
Add org-roam-server

### DIFF
--- a/recipes/org-roam-graph-server
+++ b/recipes/org-roam-graph-server
@@ -1,0 +1,4 @@
+(org-roam-graph-server
+ :repo "goktug97/org-roam-graph-server"
+ :fetcher github
+ :files ("*.el" "index.html" "assets"))

--- a/recipes/org-roam-graph-server
+++ b/recipes/org-roam-graph-server
@@ -1,4 +1,0 @@
-(org-roam-graph-server
- :repo "goktug97/org-roam-graph-server"
- :fetcher github
- :files ("*.el" "index.html" "assets"))

--- a/recipes/org-roam-server
+++ b/recipes/org-roam-server
@@ -1,0 +1,4 @@
+(org-roam-server
+ :repo "goktug97/org-roam-server"
+ :fetcher github
+ :files ("*.el" "index.html" "assets"))

--- a/recipes/org-roam-server
+++ b/recipes/org-roam-server
@@ -1,4 +1,4 @@
 (org-roam-server
- :repo "goktug97/org-roam-server"
+ :repo "org-roam/org-roam-server"
  :fetcher github
  :files ("*.el" "index.html" "assets"))


### PR DESCRIPTION
### Brief summary of what the package does

A Web Application to Visualize the [Org-Roam](https://github.com/org-roam/org-roam) Database

https://github.com/org-roam/org-roam-server

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

EDIT: Change direct github link because it is now part of org-roam
