### PR TITLE
Migrate digit-groups from Bitbucket to Github

### DIFF
--- a/recipes/digit-groups
+++ b/recipes/digit-groups
@@ -1,1 +1,1 @@
-(digit-groups :fetcher bitbucket :repo "adamsmd/digit-groups")
+(digit-groups :fetcher github :repo "adamsmd/digit-groups")


### PR DESCRIPTION
Migrate my package(s) from Bitbucket to Github

As @tarsius has requested in #6484 I have migrated my packages
from Bitbucket to Github.  The old repositories were located at:

* https://bitbucket.org/adamsmd/digit-groups/