### PR TITLE
Migration of my packages from GitHub to https://depp.brause.cc

### DIFF
--- a/recipes/eyebrowse
+++ b/recipes/eyebrowse
@@ -1,1 +1,1 @@
-(eyebrowse :fetcher github :repo "wasamasa/eyebrowse")
+(eyebrowse :fetcher git :url "https://depp.brause.cc/eyebrowse.git")

--- a/recipes/firestarter
+++ b/recipes/firestarter
@@ -1,1 +1,1 @@
-(firestarter :fetcher github :repo "wasamasa/firestarter")
+(firestarter :fetcher git :url "https://depp.brause.cc/firestarter.git")

--- a/recipes/form-feed
+++ b/recipes/form-feed
@@ -1,1 +1,1 @@
-(form-feed :fetcher github :repo "wasamasa/form-feed")
+(form-feed :fetcher git :url "https://depp.brause.cc/form-feed.git")

--- a/recipes/gotham-theme
+++ b/recipes/gotham-theme
@@ -1,1 +1,1 @@
-(gotham-theme :fetcher github :repo "wasamasa/gotham-theme")
+(gotham-theme :fetcher git :url "https://depp.brause.cc/gotham-theme.git")

--- a/recipes/jammer
+++ b/recipes/jammer
@@ -1,1 +1,1 @@
-(jammer :fetcher github :repo "wasamasa/jammer")
+(jammer :fetcher git :url "https://depp.brause.cc/jammer.git")

--- a/recipes/nov
+++ b/recipes/nov
@@ -1,1 +1,1 @@
-(nov :fetcher github :repo "wasamasa/nov.el")
+(nov :fetcher git :url "https://depp.brause.cc/nov.el.git")

--- a/recipes/punpun-theme
+++ b/recipes/punpun-theme
@@ -1,1 +1,1 @@
-(punpun-theme :fetcher github :repo "wasamasa/punpun-theme")
+(punpun-theme :fetcher git :url "https://depp.brause.cc/punpun-theme.git")

--- a/recipes/shackle
+++ b/recipes/shackle
@@ -1,1 +1,1 @@
-(shackle :fetcher github :repo "wasamasa/shackle")
+(shackle :fetcher git :url "https://depp.brause.cc/shackle.git")

--- a/recipes/xbm-life
+++ b/recipes/xbm-life
@@ -1,1 +1,1 @@
-(xbm-life :fetcher github :repo "wasamasa/xbm-life")
+(xbm-life :fetcher git :url "https://depp.brause.cc/xbm-life.git")

--- a/recipes/zone-nyan
+++ b/recipes/zone-nyan
@@ -1,1 +1,1 @@
-(zone-nyan :fetcher github :repo "wasamasa/zone-nyan")
+(zone-nyan :fetcher git :url "https://depp.brause.cc/zone-nyan.git")


### PR DESCRIPTION
I've completed moving my packages to my own Git hosting at https://depp.brause.cc/ and would like to update the recipes to point to the respective new locations.