### PR TITLE
Add Ayu-theme, the port of original Ayu for Sublime Text

### DIFF
--- a/recipes/ayu-theme
+++ b/recipes/ayu-theme
@@ -1,0 +1,3 @@
+(ayu-theme
+ :repo "vutran1710/Ayu-Theme-Emacs"
+ :fetcher github)


### PR DESCRIPTION
Aye-theme for Emacs

### Brief summary of what the package does

Refer to the original Ayu-theme. It’s truly an amazing set of theme and someone has to port it to Emacs eventually.

### Direct link to the package repository

https://github.com/vutran1710/Ayu-Theme-Emacs
https://github.com/dempfi/ayu

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
