### PR TITLE
Add magit-delta recipe

### DIFF
--- a/recipes/magit-delta
+++ b/recipes/magit-delta
@@ -1,0 +1,1 @@
+(magit-delta :fetcher github :repo "dandavison/magit-delta")


### PR DESCRIPTION
This PR adds [magit-delta](https://github.com/dandavison/magit-delta) to MELPA.

`magit-delta` supplies a minor mode `magit-delta-mode` which integrates [Delta](https://github.com/dandavison/delta) with Magit, so that diffs in Magit are displayed with color syntax highlighting provided by Delta. A screenshot of the minor mode being used is below.

**There is one important outstanding issue regarding which I would like to ask for MELPA maintainers' advice**: `magit-delta` depends on a commit merged to magit master 20 days ago: https://github.com/magit/magit/commit/8de6ecf5c5c840f8a964c3e5bd4d7a1aedf04e10. What needs to happen in order for `magit-delta` to be able to declare this dependency in a way that will make it appropriate for inclusion in MELPA (unstable)?

<br>
<table><tr><td>
  <img width=500px src="https://user-images.githubusercontent.com/52205/80056404-23745500-84f2-11ea-9ecd-832376faf2f1.png" alt="image" />
</td></tr></table>


### Direct link to the package repository
https://github.com/dandavison/magit-delta

### Your association with the package

Author & maintainer

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
