### PR TITLE
Remove flycheck-mix package

### DIFF
--- a/recipes/flycheck-mix
+++ b/recipes/flycheck-mix
@@ -1,1 +1,0 @@
-(flycheck-mix :repo "tomekowal/flycheck-mix" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The package compiled elixir project to give errors on every save.
Now, it no longer works because of changes in Elixir.

### Direct link to the package repository

https://github.com/tomekowal/flycheck-mix
(it says in README and prints to messages buffer that it is deprecated)

### Your association with the package

I am maintainer but I am going to delete the repository.

### Relevant communications with the upstream package maintainer

### Checklist

Please confirm with `x`:

- ~[ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).~
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- ~[ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback~
- ~[ ] My elisp byte-compiles cleanly~
- ~[ ] `M-x checkdoc` is happy with my docstrings~
- ~[ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)~
- ~[ ] I have confirmed some of these without doing them~
