### PR TITLE
Add org-taskforecast recipe

### DIFF
--- a/recipes/org-taskforecast
+++ b/recipes/org-taskforecast
@@ -1,0 +1,1 @@
+(org-taskforecast :fetcher github :repo "HKey/org-taskforecast")


### PR DESCRIPTION
### Brief summary of what the package does

Time management tool for today's tasks showing them with estimated start/end time.

This package is based on the time management method TaskChute (https://taskchute.net/).
However this package implements only a few features, not all of the original TaskChute.

Make a list of tasks for today and show the list with todo state, estimated start and end time of task.  
User can see what task user is working on, what tasks user have done today with time log and rest tasks for today with estimated start and end time.  
And user can also manipulate tasks in the list like org-agenda.

### Direct link to the package repository

https://github.com/HKey/org-taskforecast

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
  - checkdoc reports some errors but I think they are not problem, please see below 
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

----

`M-x checkdoc` reports some errors.
The error messages and why I think they are not problem are below.

```
Probably "starts" should be imperative "start" (C-h,f,e,n,p,q)
```

The pointed string is "Get the date of TIME when the day starts at DAY-START.".
I think this is false positive because "starts" is not the first verb of docstring.
It intends to warn a docstring like "Return**s** processed value.", doesn't it?

```
You should convert this comment to documentation (C-h,f,e,n,p,q)
All variables and subroutines might as well have a documentation string (C-h,e,n,p,q)
```

I think these errors about missing docstring are not problem.
Because they point docstrings of `cl-defmethod` but I wrote the docstrings in `cl-defgeneric`.

```
Some lines are over 80 columns wide (C-h,f,e,n,p,q)
```

The first line of a docstring is a summary so I don't want to break the line.

```
Disambiguate org-taskforecast--clock by preceding w/ function,command,variable,option or symbol. (C-h,f,e,n,p,q)
Disambiguate org-taskforecast--eclock by preceding w/ function,command,variable,option or symbol. (C-h,f,e,n,p,q)
Disambiguate org-taskforecast--section by preceding w/ function,command,variable,option or symbol. (C-h,f,e,n,p,q)
Disambiguate org-taskforecast--task by preceding w/ function,command,variable,option or symbol. (C-h,f,e,n,p,q)
Disambiguate org-taskforecast--timestamp by preceding w/ function,command,variable,option or symbol. (C-h,f,e,n,p,q)
Disambiguate org-taskforecast--tlink by preceding w/ function,command,variable,option or symbol. (C-h,f,e,n,p,q)
Disambiguate org-taskforecast-cache-mode by preceding w/ function,command,variable,option or symbol. (C-h,f,e,n,p,q)
```

These symbols mean class name or minor mode name.
So I think the suggested words are not appropriate for them.