### PR TITLE
Add lsp-metals recipe.

### DIFF
--- a/recipes/lsp-metals
+++ b/recipes/lsp-metals
@@ -1,0 +1,1 @@
+(lsp-metals :repo "emacs-lsp/lsp-metals" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

We are moving `lsp-metals` from `lsp-mode` to a separate repo because it has too many features and need more dependencies.

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-metals

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them


Also what do you think, maybe it's time to remove long deprecated `lsp-scala` package?