### PR TITLE
add recipe for deno-fmt

### DIFF
--- a/recipes/deno-fmt
+++ b/recipes/deno-fmt
@@ -1,3 +1,1 @@
-(deno-fmt :repo "rclarey/deno-emacs"
-           :fetcher github
-           :files ("deno-fmt.el"))
+(deno-fmt :repo "rclarey/deno-emacs" :fetcher github)

--- a/recipes/deno-fmt
+++ b/recipes/deno-fmt
@@ -1,0 +1,3 @@
+(deno-fmt :repo "rclarey/deno-emacs"
+           :fetcher github
+           :files ("deno-fmt.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`deno-fmt` is function that formats the current buffer on save with [deno fmt](https://deno.land/manual/tools/formatter). The package also exports a minor mode that applies `(deno-fmt)` on save.

### Direct link to the package repository

https://github.com/rclarey/deno-emacs

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
