### PR TITLE
Add company-tern recipe

### DIFF
--- a/recipes/company-tern
+++ b/recipes/company-tern
@@ -1,0 +1,1 @@
+(company-tern :fetcher github :repo "kocubinski/company-tern")


### PR DESCRIPTION
### Brief summary of what the package does

Tern backend for company-mode

### Direct link to the package repository

https://github.com/kocubinski/company-tern

### Your association with the package

This package was removed in https://github.com/melpa/melpa/pull/6854 subsequently breaking my Emacs configs.  Since I use this package for at least an hour or so each week, I reached out to the package's author @proofit404, offering to maintain it on his behalf.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
