### PR TITLE
Add mybigword

### DIFF
--- a/recipes/mybigword
+++ b/recipes/mybigword
@@ -1,0 +1,1 @@
+(mybigword :repo "redguardtoo/mybigword" :fetcher github :files ("mybigword.el" "eng.zipf"))


### PR DESCRIPTION
### Brief summary of what the package does

Use Zipf frequency of each word to extract English big words.

Zipf scale was proposed by Marc Brysbaert, who created the SUBTLEX lists. Zipf frequency of a word is the base-10 logarithm of the number of times it appears per billion words.

### Direct link to the package repository

https://github.com/redguardtoo/mybigword

### Your association with the package

the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
