### PR TITLE
Renamed cpp-capf to clang-capf

### DIFF
--- a/recipes/clang-capf
+++ b/recipes/clang-capf
@@ -1,0 +1,3 @@
+(clang-capf :fetcher git
+            :url "https://git.sr.ht/~zge/clang-capf"
+            :old-names (cpp-capf))

--- a/recipes/cpp-capf
+++ b/recipes/cpp-capf
@@ -1,1 +1,0 @@
-(cpp-capf :url "https://git.sr.ht/~zge/cpp-capf" :fetcher git)


### PR DESCRIPTION
See #6214 for information on the package.

Hope this is ok/the right way to rename a package. I was dissatisfied with the name "cpp-capf", since it implies it might not be made of c. 