### PR TITLE
add presentation-mode recipe

### DIFF
--- a/recipes/presentation-mode
+++ b/recipes/presentation-mode
@@ -1,0 +1,1 @@
+(presentation-mode :fetcher github :repo "UwUnyaa/presentation-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A package that provides a way to temporarily enlarge all faces in Emacs to make it suitable for screencasts and presentations where it might be hard to read small text.

### Direct link to the package repository

https://github.com/UwUnyaa/presentation-mode

### Your association with the package

This is my package I maintain.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
