### PR TITLE
Use explicit https for URLs in jslicense.html

### DIFF
--- a/html/jslicense.html
+++ b/html/jslicense.html
@@ -41,24 +41,24 @@
 	  </tr>
 	</thead>
 	<tr>
-          <td><a href="//cdnjs.cloudflare.com/ajax/libs/mithril/0.2.5/mithril.min.js">mithril.min.js</a></td>
+          <td><a href="https://cdnjs.cloudflare.com/ajax/libs/mithril/0.2.5/mithril.min.js">mithril.min.js</a></td>
           <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-          <td><a href="//cdnjs.cloudflare.com/ajax/libs/mithril/0.2.5/mithril.js">mithril.js</a></td>
+          <td><a href="https://cdnjs.cloudflare.com/ajax/libs/mithril/0.2.5/mithril.js">mithril.js</a></td>
 	</tr>
 	<tr>
-          <td><a href="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment.min.js">moment.min.js</a></td>
+          <td><a href="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment.min.js">moment.min.js</a></td>
           <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-          <td><a href="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment.js">moment.js</a></td>
+          <td><a href="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment.js">moment.js</a></td>
 	</tr>
 	<tr>
-          <td><a href="//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js">lodash.min.js</a></td>
+          <td><a href="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js">lodash.min.js</a></td>
           <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-          <td><a href="//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.js">lodash.js</a></td>
+          <td><a href="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.js">lodash.js</a></td>
 	</tr>
 	<tr>
-          <td><a href="//cdnjs.cloudflare.com/ajax/libs/Cookies.js/1.2.1/cookies.min.js">cookies.min.js</a></td>
+          <td><a href="https://cdnjs.cloudflare.com/ajax/libs/Cookies.js/1.2.1/cookies.min.js">cookies.min.js</a></td>
           <td><a href="http://unlicense.org/UNLICENSE">Unlicense</a></td>
-          <td><a href="//cdnjs.cloudflare.com/ajax/libs/Cookies.js/1.2.1/cookies.js">cookies.js</a></td>
+          <td><a href="https://cdnjs.cloudflare.com/ajax/libs/Cookies.js/1.2.1/cookies.js">cookies.js</a></td>
 	</tr>
 	<tr>
           <td><a href="/js/melpa.js">melpa.js</a></td>


### PR DESCRIPTION
Previously, the protocol was inherited (via `\\`) resulting in a mismatch with index.html (which uses strict `https` in its `<script>` `src`s to external libraries), which confused LibreJS.

Fix regression in #3731, where MELPA doesn't work with LibreJS, when accessed via `http://`.

The regression in #3731 could also be fixed by always redirecting from `http://` to `https://` in which case this pull request would be redundant (but not harmful).

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
