### PR TITLE
Ensure HTTP to HTTPS redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ read on for details.
 
 ## Usage
 
-To use the MELPA repository, you'll need an Emacs with
-`package.el`, ie. Emacs 24.1 or greater.
+To use the MELPA repository, you'll need an Emacs with `package.el`,
+ie. Emacs 24.1 or greater. To test TLS support you can visit a HTTPS
+URL, for example with `M-x eww RET https://wikipedia.org RET`.
 
 Enable installation of packages from MELPA by adding an entry to
 `package-archives` after `(require 'package)` and before the call to
@@ -38,20 +39,10 @@ Enable installation of packages from MELPA by adding an entry to
 
 ```elisp
 (require 'package)
-(let* ((no-ssl (and (memq system-type '(windows-nt ms-dos))
-                    (not (gnutls-available-p))))
-       (proto (if no-ssl "http" "https")))
-  (when no-ssl (warn "\
-Your version of Emacs does not support SSL connections,
-which is unsafe because it allows man-in-the-middle attacks.
-There are two things you can do about this warning:
-1. Install an Emacs version that does support SSL and be safe.
-2. Remove this warning from your init file so you won't see it again."))
-  (add-to-list 'package-archives (cons "melpa" (concat proto "://melpa.org/packages/")) t)
-  ;; Comment/uncomment this line to enable MELPA Stable if desired.  See `package-archive-priorities`
-  ;; and `package-pinned-packages`. Most users will not need or want to do this.
-  ;;(add-to-list 'package-archives (cons "melpa-stable" (concat proto "://stable.melpa.org/packages/")) t)
-  )
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+;; Comment/uncomment this line to enable MELPA Stable if desired.  See `package-archive-priorities`
+;; and `package-pinned-packages`. Most users will not need or want to do this.
+;;(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/packages/") t)
 (package-initialize)
 ```
 
@@ -62,22 +53,6 @@ Note that you'll need to run `M-x package-refresh-contents` or `M-x
 package-list-packages` to ensure that Emacs has fetched the MELPA
 package list before you can install packages with `M-x
 package-install` or similar.
-
-Instead of the messy code above, you can of course use something like
-the following instead:
-
-```elisp
-(require 'package)
-(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
-(package-initialize)
-```
-
-Before doing so you should understand what it does though.  To make
-sure of that, you should read the official
-[documentation](https://www.gnu.org/software/emacs/manual/html_node/emacs/Packages.html)
-from the Emacs manual.  Also note that the calls to `require` and
-`package-initialize` may be unnecessary depending on the Emacs version
-you use.
 
 ### MELPA Stable
 

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -40,6 +40,20 @@ server {
 
 server {
 	listen  80;
+
+	server_name melpa.org www.melpa.org test.melpa.org;
+
+	location /.well-known/acme-challenge/ {
+		default_type "text/plain";
+		root /tmp/letsencrypt-auto;
+	}
+
+	location / {
+		 return 301 https://$host$request_uri;
+	}
+}
+
+server {
 	listen	443 ssl;
 
         server_name melpa.org www.melpa.org test.melpa.org;
@@ -64,11 +78,6 @@ server {
         ssl_stapling_verify on;
         add_header Strict-Transport-Security max-age=15768000;
 
-        location ~ /.well-known {
-                allow all;
-		root /usr/share/nginx/html;
-        }
-
 	error_page   500 502 503 504  /50x.html;
 	location = /50x.html {
 		root   /var/www/nginx-default;
@@ -82,19 +91,24 @@ server {
 	location ~ ^/packages/.*\.svg {
 		add_header Cache-Control no-cache;
 	}
-	location ^~ /.well-known/acme-challenge/ {
-		default_type "text/plain";
-		root /tmp/letsencrypt-auto;
-	}
-
-	### Hide /acme-challenge subdirectory and return 404 on all requests.
-	location = /.well-known/acme-challenge/ {
-		return 404;
-	}
 }
 
 server {
 	listen  80;
+
+	server_name stable.melpa.org stable-test.melpa.org;
+
+	location /.well-known/acme-challenge/ {
+		default_type "text/plain";
+		root /tmp/letsencrypt-auto;
+	}
+
+	location / {
+		 return 301 https://$host$request_uri;
+	}
+}
+
+server {
 	listen	443 ssl;
 
         server_name stable.melpa.org stable-test.melpa.org;
@@ -119,11 +133,6 @@ server {
 	ssl_stapling_verify on;
 	add_header Strict-Transport-Security max-age=15768000;
 
-        location ~ /.well-known {
-                allow all;
-		root /usr/share/nginx/html;
-        }
-
 	error_page   500 502 503 504  /50x.html;
 	location = /50x.html {
 		root   /var/www/nginx-default;
@@ -137,16 +146,4 @@ server {
 	location ~ ^/packages/.*\.svg {
 		add_header Cache-Control no-cache;
 	}
-
-	location ^~ /.well-known/acme-challenge/ {
-		default_type "text/plain";
-		root /tmp/letsencrypt-auto;
-	}
-	### Hide /acme-challenge subdirectory and return 404 on all requests.
-	location = /.well-known/acme-challenge/ {
-		return 404;
-	}
 }
-
-
-

--- a/html/partials/getting-started.html
+++ b/html/partials/getting-started.html
@@ -4,7 +4,9 @@
       <h2>Installing</h2>
 
       <p>To use the MELPA repository, you'll need an Emacs with
-        <code>package.el</code>, ie. Emacs 24.1 or greater.
+        <code>package.el</code> and TLS support, ie. Emacs 24.1 or
+        greater. To test TLS support you can visit a HTTPS URL, for
+        example with <code>M-x eww RET https://wikipedia.org RET</code>.
       </p>
 
       <p>
@@ -16,20 +18,10 @@
       </p>
 
       <pre><code>(require 'package)
-(let* ((no-ssl (and (memq system-type '(windows-nt ms-dos))
-                    (not (gnutls-available-p))))
-       (proto (if no-ssl "http" "https")))
-  (when no-ssl (warn "\
-Your version of Emacs does not support SSL connections,
-which is unsafe because it allows man-in-the-middle attacks.
-There are two things you can do about this warning:
-1. Install an Emacs version that does support SSL and be safe.
-2. Remove this warning from your init file so you won't see it again."))
-  (add-to-list 'package-archives (cons "melpa" (concat proto "://melpa.org/packages/")) t)
-  ;; Comment/uncomment this line to enable MELPA Stable if desired.  See `package-archive-priorities`
-  ;; and `package-pinned-packages`. Most users will not need or want to do this.
-  ;;(add-to-list 'package-archives (cons "melpa-stable" (concat proto "://stable.melpa.org/packages/")) t)
-  )
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+;; Comment/uncomment this line to enable MELPA Stable if desired.  See `package-archive-priorities`
+;; and `package-pinned-packages`. Most users will not need or want to do this.
+;;(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/packages/") t)
 (package-initialize)</code></pre>
 
       <p>


### PR DESCRIPTION
See #3731. Untested for obvious reasons, but it should hopefully work. Rationale:

It has been almost five years since HTTPS URLs were added to the "Getting Started" page. The biggest issue were Windows builds of Emacs, but even these come in a flavor providing all dependencies, including GnuTLS. So that should no longer be an issue.

HSTS helps browser to always use the HTTPS versions, but programs like Curl and url.el don't honor that header. So a server-side redirect is required in any case.

Finally, Marmalade enforced this for years. If that doesn't convince you, I don't know what else will :>