### PR TITLE
Change transfer-sh.el target repository

### DIFF
--- a/recipes/transfer-sh
+++ b/recipes/transfer-sh
@@ -1,1 +1,1 @@
-(transfer-sh :fetcher github :repo "SRoskamp/transfer-sh.el")
+(transfer-sh :fetcher gitlab :repo "tuedachu/transfer-sh.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides an interface to the transfer-sh website. This package was originally created by @SRoskamp.

### Direct link to the package repository

https://gitlab.com/tuedachu/transfer-sh.el

### Your association with the package

Contributor and maintainer

### Relevant communications with the upstream package maintainer

The main contributor is no longer maintaining the package (PR pending for 2 years now) and gave me the green lights to change the target repository on melpa: https://github.com/SRoskamp/transfer-sh.el/pull/8

Since I am more confortable with gitlab toolkit, I decide to migrate to gitlab. The original repository is referenced in the README file.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
