### PR TITLE
Add currency-convert recipe

### DIFF
--- a/recipes/currency-convert
+++ b/recipes/currency-convert
@@ -1,0 +1,1 @@
+(currency-convert :fetcher github :repo "lassik/emacs-currency-convert")


### PR DESCRIPTION
### Brief summary of what the package does

Convert amounts of money from one currency to another in Emacs.

Exchange rates are downloaded from exchangeratesapi.io. They ought to be accurate enough for everyday purposes. It goes without saying that you should not rely on this package for investment or business decisions.

### Direct link to the package repository

https://github.com/lassik/emacs-currency-convert

### Your association with the package

Just wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
