### PR TITLE
Add origami-predef.el

### DIFF
--- a/recipes/origami-predef
+++ b/recipes/origami-predef
@@ -1,0 +1,1 @@
+(origami-predef :repo "alvarogonzalezsotillo/origami-predef" :fetcher github)

--- a/recipes/origami-predef
+++ b/recipes/origami-predef
@@ -1,1 +1,1 @@
-(origami-predef :repo "alvarogonzalezsotillo/origami-predef" :fetcher github)
+(origami-predef :repo "alvarogonzalezsotillo/origami-predef" :branch "melpa-stable" :fetcher github)

--- a/recipes/origami-predef
+++ b/recipes/origami-predef
@@ -1,1 +1,1 @@
-(origami-predef :repo "alvarogonzalezsotillo/origami-predef" :branch "melpa-stable" :fetcher github)
+(origami-predef :repo "alvarogonzalezsotillo/origami-predef" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This emacs package extends the origami package to apply some initial foldings when opening a file, based on tags in the file contents.
I tried to contact the author of the origami package (see https://github.com/gregsexton/origami.el/issues/95), in order to integrate ths functionality in his package, but I got no response.

### Direct link to the package repository

https://github.com/alvarogonzalezsotillo/origami-predef

### Your association with the package
I am the author and the maintainer.

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
