### PR TITLE
Remove pyimpsort,docean,company-racer

### DIFF
--- a/recipes/company-racer
+++ b/recipes/company-racer
@@ -1,2 +1,0 @@
-(company-racer :fetcher github
-               :repo "emacs-pe/company-racer")

--- a/recipes/docean
+++ b/recipes/docean
@@ -1,1 +1,0 @@
-(docean :fetcher github :repo "emacs-pe/docean.el")

--- a/recipes/gh-md
+++ b/recipes/gh-md
@@ -1,1 +1,0 @@
-(gh-md :fetcher github :repo "emacs-pe/gh-md.el")

--- a/recipes/pyimpsort
+++ b/recipes/pyimpsort
@@ -1,4 +1,0 @@
-(pyimpsort
- :fetcher github
- :repo "emacs-pe/pyimpsort.el"
- :files ("pyimpsort.el" "pyimpsort.py"))


### PR DESCRIPTION
I don't maintain this packages anymore.
I've archived their repositories and eventually delete them.

### Brief summary of what the package does

### Direct link to the package repository


### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
