### PR TITLE
Add recipe for arduino-cli-mode

### DIFF
--- a/recipes/arduino-cli-mode
+++ b/recipes/arduino-cli-mode
@@ -1,0 +1,1 @@
+(arduino-cli-mode :fetcher github :repo "motform/arduino-cli-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`arduino-cli-mode` is an Emacs minor mode for using the excellent new [arduino command line interface](https://github.com/arduino/arduino-cli) in an Emacs-native fashion. The mode covers the full range of `arduino-cli` features in an Emacs native fashion. It even leverages the infinite power the GNU to provide fussy-finding of libraries and much improved support for handling multiple boards. The commands that originally require multiple steps (such as first searching for a library and then separately installing it) have been folded into one.

### Direct link to the package repository

https://github.com/motform/arduino-cli-mode

### Your association with the package

I am the maintainer and creator of the package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
