### PR TITLE
New recipe for etc-sudoers-mode.

### DIFF
--- a/recipes/etc-sudoers-mode
+++ b/recipes/etc-sudoers-mode
@@ -1,0 +1,3 @@
+(etc-sudoers-mode
+ :fetcher gitlab
+ :repo "mavit/etc-sudoers-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This [Emacs](https://www.gnu.org/software/emacs/) package provides syntax highlighting for the [Sudo](https://www.sudo.ws/) security policy file, `/etc/sudoers`.

### Direct link to the package repository

https://gitlab.com/mavit/etc-sudoers-mode

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them