### PR TITLE
Update ink-mode recipe to include snippets

### DIFF
--- a/recipes/ink-mode
+++ b/recipes/ink-mode
@@ -1,1 +1,4 @@
-(ink-mode :repo "Kungsgeten/ink-mode" :fetcher github)
+(ink-mode
+ :repo "Kungsgeten/ink-mode"
+ :fetcher github
+ :files (:defaults "snippets"))


### PR DESCRIPTION
### Brief summary of what the package does

ink-mode is a major mode for [Ink](https://www.inklestudios.com/ink/), an open-source scripting language for writing interactive fiction developed by [Inkle Studios](https://www.inklestudios.com/). 
It has been on MELPA since commit [e3276b8](https://github.com/melpa/melpa/commit/e3276b823cf03455083929599e1d47aea894ad5c).

I am the new maintainer of this package and have expanded it a lot, adding YASnippet snippets in particular, which I would like to have included in MELPA.

### Direct link to the package repository

https://github.com/Kungsgeten/ink-mode

### Your association with the package

I am its new maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings → It complains about a word (_gathers_) which is more often a verb, but is definitely a noun in this context. I believe this is ok.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
