### PR TITLE
Added php-quickhelp recipe

### DIFF
--- a/recipes/php-quickhelp
+++ b/recipes/php-quickhelp
@@ -1,0 +1,1 @@
+(php-quickhelp :fetcher github :repo "vpxyz/php-quickhelp")


### PR DESCRIPTION
### Brief summary of what the package does

php-quickhelp provvide a company-quickhelp backend and eldoc backend for php. It's works with company-php or with company-phpactor. Require jq external command

### Direct link to the package repository

https://github.com/vpxyz/php-quickhelp

### Your association with the package

I am the author and current maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
