### PR TITLE
Add citeproc-org recipe

### DIFF
--- a/recipes/citeproc-org
+++ b/recipes/citeproc-org
@@ -1,0 +1,3 @@
+(citeproc-org :repo "andras-simonyi/citeproc-org"
+	      :fetcher github
+	      :files ("*.el" "chicago-author-date.csl" "locales-en-US.xml"))

--- a/recipes/citeproc-org
+++ b/recipes/citeproc-org
@@ -1,3 +1,3 @@
 (citeproc-org :repo "andras-simonyi/citeproc-org"
 	      :fetcher github
-	      :files ("*.el" "chicago-author-date.csl" "locales-en-US.xml"))
+	      :files (:defaults "chicago-author-date.csl" "locales-en-US.xml"))


### PR DESCRIPTION
### Brief summary of what the package does

citeproc-org renders citations and bibliographies in exported Org documents in Citation Style Language (CSL) styles using the citeproc-el Emacs Lisp library (which is already in MELPA). 

### Direct link to the package repository

https://github.com/andras-simonyi/citeproc-org

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
