### PR TITLE
Say "took an unknown amount of time" on website

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -503,7 +503,9 @@
       return t ? moment(t).fromNow() : "unknown";
     }
     function duration() {
-      return ctrl.duration() ? moment.duration(ctrl.duration(), 'seconds').humanize() : "unknown";
+      return ctrl.duration() ?
+        moment.duration(ctrl.duration(), 'seconds').humanize() :
+        "an unknown amount of time";
     }
     if (ctrl.running()) {
       return m(".alert.alert-warning", [


### PR DESCRIPTION
If the duration of the last build cannot be determined, the website says "last took unknown". This changes it to say "last took an unknown amount of time".