### PR TITLE
Add ob-latex-as-png recipe

### DIFF
--- a/recipes/ob-latex-as-png
+++ b/recipes/ob-latex-as-png
@@ -1,0 +1,1 @@
+(ob-latex-as-png :fetcher github :repo "alhassy/ob-latex-as-png")


### PR DESCRIPTION
### Brief summary of what the package does

An Org-babel “language” whose execution produces PNGs from LaTeX snippets; useful for shipping *arbitrary* LaTeX results in HTML

### Direct link to the package repository

https://github.com/alhassy/ob-latex-as-png

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
