### PR TITLE
Changed peg repo to emacs-straight/peg

### DIFF
--- a/recipes/peg
+++ b/recipes/peg
@@ -1,1 +1,1 @@
-(peg :fetcher github :repo "ellerh/peg.el")
+(peg :fetcher github :repo "emacs-straight/peg")


### PR DESCRIPTION
### Brief summary of what the package does

This package implements Parsing Expression Grammars for Emacs Lisp. old repo `ellerh/peg.el` has not been updated for five years, and the new warehouse uses synchronized robots.

### Direct link to the package repository

https://github.com/emacs-straight/peg

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
