### PR TITLE
Restore smart-dash with GitHub repo

### DIFF
--- a/recipes/smart-dash
+++ b/recipes/smart-dash
@@ -1,0 +1,1 @@
+(smart-dash :fetcher github :repo "malsyned/smart-dash")


### PR DESCRIPTION
The smart-dash mode homepage at http://malsyned.net/smart-dash.html
points to the GitHub repository at
https://github.com/malsyned/smart-dash.git now.

This is my attempt to "resurrect" this package after it was removed in 6d7595ad (Remove six packages that still used Hg repositories on Bitbucket, 2020-06-01).

### Brief summary of what the package does

> Smart-Dash mode is an Emacs minor mode which redefines the dash key to insert an underscore within C-style identifiers and a dash otherwise.

### Direct link to the package repository

https://github.com/malsyned/smart-dash

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

None.

### Checklist

If the undone things on the checklist need to be done for this "resurrection", if you will, let me know. I may be able to work with the upstream maintained to get some of them addressed.

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
    * I have not done this. This package was removed in 6d7595ad (Remove six packages that still used Hg repositories on Bitbucket, 2020-06-01). This PR, as currently authored, restores this package using its new GitHub Git repository instead of the old BitBucket Mercurial repository. The code is the same.
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
    * It is not. But it wasn't before either. 😉
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
