### PR TITLE
Add lsp-sonarlint recipe

### DIFF
--- a/recipes/lsp-sonarlint
+++ b/recipes/lsp-sonarlint
@@ -1,0 +1,6 @@
+(lsp-sonarlint
+	  :fetcher gitlab
+	  :repo "sasanidas/lsp-sonarlint"
+	  :files ("lsp-sonarlint.el"
+		  ("languages" "languages/*")
+		  ("server" "server/*")))

--- a/recipes/lsp-sonarlint
+++ b/recipes/lsp-sonarlint
@@ -2,5 +2,5 @@
 	  :fetcher github
 	  :repo "emacs-lsp/lsp-sonarlint"
 	  :files ("lsp-sonarlint.el"
-		  ("languages" "languages/*")
+		  ("languages" "languages/*/*.el")
 		  ("server" "server/*")))

--- a/recipes/lsp-sonarlint
+++ b/recipes/lsp-sonarlint
@@ -1,6 +1,6 @@
 (lsp-sonarlint
-	  :fetcher gitlab
-	  :repo "sasanidas/lsp-sonarlint"
+	  :fetcher github
+	  :repo "emacs-lsp/lsp-sonarlint"
 	  :files ("lsp-sonarlint.el"
 		  ("languages" "languages/*")
 		  ("server" "server/*")))


### PR DESCRIPTION
### Brief summary of what the package does

LSP client to support Sonarlint linter through the lsp-mode package using the
[sonarlint-language-server](https://github.com/SonarSource/sonarlint-language-server)

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-sonarlint

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
