### PR TITLE
exclude flycheck-keg.el from keg package

### DIFF
--- a/recipes/keg
+++ b/recipes/keg
@@ -1,2 +1,2 @@
 (keg :fetcher github :repo "conao3/keg.el"
-     :files (:defaults (:exclude "keg-mode.el")))
+     :files (:defaults (:exclude "keg-mode.el" "flycheck-keg.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Keg: Modern Elisp package development system.
Flycheck-keg: Flycheck for Keg projects.

### Direct link to the package repository

https://github.com/conao3/keg.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Note:
I should exclude `flycheck-keg.el` file from `keg` package.
`flycheck-keg` is included MELPA at #6966 and this issue reported
@akirak at
https://github.com/melpa/melpa/pull/6966#issuecomment-647276465