### PR TITLE
Adds restclient-jq as separate package

### DIFF
--- a/recipes/restclient-jq
+++ b/recipes/restclient-jq
@@ -1,3 +1,3 @@
-(restclient :repo "pashky/restclient.el"
-            :fetcher github
-            :files ("restclient-jq.el"))
+(restclient-jq :repo "pashky/restclient.el"
+	       :fetcher github
+	       :files ("restclient-jq.el"))

--- a/recipes/restclient-jq
+++ b/recipes/restclient-jq
@@ -1,0 +1,3 @@
+(restclient :repo "pashky/restclient.el"
+            :fetcher github
+            :files ("restclient-jq.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Resclient-jq extends restclient for jq support

### Direct link to the package repository

https://github.com/pashky/restclient.el

### Your association with the package

An enthusiastic user.

### Relevant communications with the upstream package maintainer

** None Needed **

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
