### PR TITLE
Add restclient jq recipe

### DIFF
--- a/recipes/restclient-jq
+++ b/recipes/restclient-jq
@@ -1,3 +1,3 @@
-(restclient :repo "pashky/restclient.el"
-            :fetcher github
-            :files ("restclient-jq.el"))
+(restclient-jq :repo "pashky/restclient.el"
+	       :fetcher github
+	       :files ("restclient-jq.el"))

--- a/recipes/restclient-jq
+++ b/recipes/restclient-jq
@@ -1,0 +1,3 @@
+(restclient :repo "pashky/restclient.el"
+            :fetcher github
+            :files ("restclient-jq.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds jq support to restclient mode.

### Direct link to the package repository

https://github.com/pashky/restclient.el

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them
