### PR TITLE
Add M2-mode recipe

### DIFF
--- a/recipes/M2-mode
+++ b/recipes/M2-mode
@@ -1,0 +1,4 @@
+(M2-mode
+ :fetcher github
+ :repo "Macaulay2/M2-emacs"
+ :files (:defaults "M2-*" "README.md" (:exclude "*.in")))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a major mode for editing Macaulay2 source files as well as a comint mode for running Macaulay2 as a command interpreter in an Emacs buffer.

### Direct link to the package repository

https://github.com/Macaulay2/M2-emacs

### Your association with the package

I'm a project member and contributor.

### Relevant communications with the upstream package maintainer

[Currently working on fixing linting errors.]

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
