### PR TITLE
Add recipe for udev-mode

### DIFF
--- a/recipes/udev-mode
+++ b/recipes/udev-mode
@@ -1,0 +1,1 @@
+(udev-mode :fetcher github :repo "benley/emacs-udev-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for editing [udev rules files](https://www.freedesktop.org/software/systemd/man/udev.html)

### Direct link to the package repository

https://github.com/benley/emacs-udev-mode

### Your association with the package

Package author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
