### PR TITLE
Update recipe for Chronometrist to use GitHub, exclude new optional file

### DIFF
--- a/recipes/chronometrist
+++ b/recipes/chronometrist
@@ -1,3 +1,6 @@
 (chronometrist
- :fetcher git
- :url "https://framagit.org/contrapunctus/chronometrist/")
+ :repo "contrapunctus-1/chronometrist"
+ :fetcher github
+ :files (:defaults
+         "elisp/*.el"
+         (:exclude "elisp/chronometrist-goals.el")))


### PR DESCRIPTION
### Brief summary of what the package does
A time tracker with useful displays of data

### Direct link to the package repository
https://github.com/contrapunctus-1/chronometrist

### Your association with the package
Author

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist
Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
  - false positive in chronometrist-sexp.el
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
