### PR TITLE
Include missing sound files

### DIFF
--- a/recipes/metronome
+++ b/recipes/metronome
@@ -1,1 +1,1 @@
-(metronome :repo "jagrg/metronome" :fetcher gitlab)
+(metronome :repo "jagrg/metronome" :fetcher gitlab :files (:defaults "sounds"))


### PR DESCRIPTION
The issue was reported [here](https://gitlab.com/jagrg/metronome/-/issues/1).

> There is no sounds directory included with the MELPA package -
> hence mentronome-click and metronome-accent refer non-existent
> files. The sounds directory needs to be added/included in the
> MELPA recipe.