### PR TITLE
Add xenops recipe

### DIFF
--- a/recipes/xenops
+++ b/recipes/xenops
@@ -1,3 +1,3 @@
 (xenops :fetcher github
         :repo "dandavison/xenops"
-        :files ("lisp/*.el" "LICENSE" "README.md"))
+        :files ("lisp/*.el"))

--- a/recipes/xenops
+++ b/recipes/xenops
@@ -1,0 +1,3 @@
+(xenops :fetcher github
+        :repo "dandavison/xenops"
+        :files ("lisp/*.el" "LICENSE" "README.md"))


### PR DESCRIPTION
### Brief summary of what the package does

Xenops is a minor-mode for editing LaTeX documents. The basic aim of Xenops is to provide a notebook-style LaTeX editing environment in which you do not have to continuously regenerate the PDF to view rendered math/TikZ content. Its main feature is

- LaTeX math/TikZ/table content is rendered automatically when the cursor is moved out of the element. Rendering is asynchronous (using [emacs-aio](https://github.com/skeeto/emacs-aio)).

It has various additional features. For example:

- SymPy and Mathematica code blocks can be executed: their results are rendered as images of traditional mathematical notation rather than as code (this is possible because both Sympy and Mathematica allow their results to be returned as LaTeX code.)

Xenops can be used with auctex; it replaces the preview-latex functionality within auctex.

Unlike preview-latex, Xenops can (and does by default) render to SVG, which can produce perfectly crisp images of math fragments (depending on your system's display resolution and SVG rendering library).

Unlike Org-mode, Xenops is intended to be used with plain `.tex` files and thus can be used to collaborate with people using other LaTeX editing systems. (It is also possible to activate the Xenops minor-mode in Org-mode, since LaTeX math environments are valid Org syntax).

### Direct link to the package repository

https://github.com/dandavison/xenops

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
