### PR TITLE
New recipe: clojure-essential-ref

### DIFF
--- a/recipes/clojure-essential-ref
+++ b/recipes/clojure-essential-ref
@@ -1,0 +1,4 @@
+(clojure-essential-ref :repo "p3r7/clojure-essential-ref"
+                       :fetcher github
+                       :files (:defaults
+                               (:exclude "clojure-essential-ref-nov.el")))


### PR DESCRIPTION
### Brief summary of what the package does

This package is aimed at Clojure / CIDER user.

Provides command `clojure-essential-ref` for browsing the documentation for symbol at point in book [Clojure, The Essential Reference](https://livebook.manning.com/book/clojure-the-essential-reference/). 

The book is basically an in-depth documentation of the standard ("core") library. 

This package only allows to browse the online version of the book.

NB: Sibling package [clojure-essential-ref-nov](https://github.com/p3r7/clojure-essential-ref/blob/master/clojure-essential-ref-nov.el) (not yet submitted to MELPA) enables browsing the ebook version of the book. I've put this feature in a separate package as it relies on [nov.el](https://depp.brause.cc/nov.el/) and I didn't want to force this dependency.

### Direct link to the package repository

https://github.com/p3r7/clojure-essential-ref

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
