### PR TITLE
Add sqlite3

### DIFF
--- a/recipes/sqlite3
+++ b/recipes/sqlite3
@@ -1,0 +1,7 @@
+(sqlite3 :fetcher github
+         :repo "pekingduck/emacs-sqlite3-api"
+         :files (:defaults
+                 "Makefile"
+                 "consts.c"
+                 "emacs-module.h"
+                 "sqlite3-api.c"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a dynamic module for GNU Emacs 25+ that provides
direct access to the core SQLite3 C API from Emacs Lisp.

### Direct link to the package repository

https://github.com/pekingduck/emacs-sqlite3-api

### Your association with the package

Someone who thinks that sqlite must be available as a module, though currently I use `emacsql` and its custom sqlite executable.

### Relevant communications with the upstream package maintainer

I wrote the wrapper library that gives this package its name. https://github.com/pekingduck/emacs-sqlite3-api/pull/2#issuecomment-655282392

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them