### PR TITLE
Add feed-discovery recipe

### DIFF
--- a/recipes/feed-discovery
+++ b/recipes/feed-discovery
@@ -1,0 +1,1 @@
+(feed-discovery :fetcher github :repo "HKey/feed-discovery")


### PR DESCRIPTION
### Brief summary of what the package does

This package allows user to discover feed urls from a website url by RSS/Atom autodiscovery.
It has been created to help feed management of [elfeed](https://github.com/skeeto/elfeed).

### Direct link to the package repository

https://github.com/HKey/feed-discovery

### Your association with the package

The author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

