### PR TITLE
Adds unisonlang-mode

### DIFF
--- a/recipes/unisonlang-mode
+++ b/recipes/unisonlang-mode
@@ -1,0 +1,1 @@
+(unisonlang-mode :repo "dariooddenino/unison-mode-emacs" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package adds syntax highlighting and some basic commands for the Unison programming language.

### Direct link to the package repository

https://github.com/dariooddenino/unison-mode-emacs


### Your association with the package

I am the mantainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
