### PR TITLE
Add recipe for saveplace-pdf-view

### DIFF
--- a/recipes/saveplace-pdf-view
+++ b/recipes/saveplace-pdf-view
@@ -1,0 +1,1 @@
+(saveplace-pdf-view :fetcher github :repo "nicolaisingh/saveplace-pdf-view")


### PR DESCRIPTION
### Brief summary of what the package does

Extend `save-place-mode` to allow automatically persisting between Emacs sessions the current page/position of the PDF file being visited with `pdf-view-mode`.

### Direct link to the package repository

https://github.com/nicolaisingh/saveplace-pdf-view

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
