### PR TITLE
Recipe/clojure essential ref nov

### DIFF
--- a/recipes/clojure-essential-ref
+++ b/recipes/clojure-essential-ref
@@ -1,0 +1,4 @@
+(clojure-essential-ref :repo "p3r7/clojure-essential-ref"
+                       :fetcher github
+                       :files (:defaults
+                               (:exclude "clojure-essential-ref-nov.el")))

--- a/recipes/clojure-essential-ref-nov
+++ b/recipes/clojure-essential-ref-nov
@@ -1,0 +1,4 @@
+(clojure-essential-ref-nov :repo "p3r7/clojure-essential-ref"
+                           :fetcher github
+                           :files (:defaults
+                                   (:exclude "clojure-essential-ref.el")))


### PR DESCRIPTION
### Brief summary of what the package does

This package is an extension to package [clojure-essential-ref](https://melpa.org/#/clojure-essential-ref) (MELPA submission PR https://github.com/melpa/melpa/pull/7010).

Provides command `clojure-essential-ref-nov` for browsing the documentation for symbol at point in a local ebook of [Clojure, The Essential Reference](https://www.manning.com/books/clojure-the-essential-reference).

I've made a separate package for the ebook browsing feature as it relies on [nov.el](https://depp.brause.cc/nov.el/) and I didn't want to force this dependency on every user.

### Direct link to the package repository

https://github.com/p3r7/clojure-essential-ref

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
