### PR TITLE
Added v-mode

### DIFF
--- a/recipes/v-mode
+++ b/recipes/v-mode
@@ -1,0 +1,4 @@
+(v-mode
+  :fetcher github
+  :repo "damon-kwok/v-mode"
+  :files (:defaults "etc"))


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs major mode  for the [V](https://vlang.io/) programming language.

### Direct link to the package repository

https://github.com/damon-kwok/v-mode

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
