### PR TITLE
[website] Drop Windows non-TLS suggestion

### DIFF
--- a/html/partials/getting-started.html
+++ b/html/partials/getting-started.html
@@ -41,13 +41,6 @@
       <pre><code>(add-to-list 'package-archives
              '("melpa-stable" . "https://stable.melpa.org/packages/") t)</code></pre>
 
-      <p>
-        <strong>Note:</strong> <em>There are some problems using the
-          <code>https</code> location with Emacs on Windows. There is
-          currently no known easy fix for this. You can still use MELPA
-          by using the non-SSL location by replacing <code>https</code>
-          with <code>http</code>.</em>
-      </p>
       <h3>Customizations</h3>
       <p>
         What if you only want some of your packages to be installed


### PR DESCRIPTION
When checking the Website I've noticed there's one paragraph left that suggests Windows issues with TLS can be mitigated by using the non-TLS URL. This is false, therefore I've removed it. I'm open to suggestions how to reword this, for example by pointing to the official download with bundled dependencies instead.