### PR TITLE
Add recipe for atl-markup.

### DIFF
--- a/recipes/atl-markup
+++ b/recipes/atl-markup
@@ -1,0 +1,1 @@
+(atl-markup :repo "jcs-elpa/atl-markup" :fetcher github)

--- a/recipes/auto-truncate-lines
+++ b/recipes/auto-truncate-lines
@@ -1,0 +1,1 @@
+(auto-truncate-lines :repo "jcs-elpa/auto-truncate-lines" :fetcher github)

--- a/recipes/auto-truncate-lines
+++ b/recipes/auto-truncate-lines
@@ -1,1 +1,0 @@
-(auto-truncate-lines :repo "jcs-elpa/auto-truncate-lines" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Automatically truncate lines for markup languages.

### Direct link to the package repository

https://github.com/jcs-elpa/atl-markup

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
