### PR TITLE
Add recipe for hybrid-reverse-theme

### DIFF
--- a/recipes/hybrid-reverse-theme
+++ b/recipes/hybrid-reverse-theme
@@ -1,0 +1,1 @@
+(hybrid-reverse-theme :repo "Riyyi/emacs-hybrid-reverse" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Material color scheme based on the Hybrid Reverse theme for Vim. 

### Direct link to the package repository

https://github.com/Riyyi/emacs-hybrid-reverse

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
