### PR TITLE
fixed hard-coded shell path so it works on freebsd

### DIFF
--- a/html/Makefile
+++ b/html/Makefile
@@ -1,4 +1,4 @@
-SHELL  := /bin/bash
+SHELL  := bash
 
 .PHONY: all clean updates.rss
 all: updates.rss


### PR DESCRIPTION
This is not a new package. I was setting up an internal melpa mirror on a freeBSD machine, and the build failed b/c in one of the makfiles the path for the bash shell was hard coded to `bin/bash` instead of just saying `bash`.

The error:

```
 • Building html/archive.json ...
 • Building html index ...
gmake -C html
gmake[1]: Entering directory '/usr/home/yourfate/workspace/melpa/html'
erb updates.rss.erb > updates.rss.tmp && mv updates.rss.tmp updates.rss
gmake[1]: /bin/bash: No such file or directory
gmake[1]: *** [Makefile:7: updates.rss] Error 127
gmake[1]: Leaving directory '/usr/home/yourfate/workspace/melpa/html'
gmake: *** [Makefile:44: index] Error 2
```

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] this is not a new package but a bugfix in the melpa code itself, so some of the above does not apply.
- [ ] I have confirmed some of these without doing them
