### PR TITLE
Add treemacs-all-the-icons recipe.

### DIFF
--- a/recipes/treemacs-all-the-icons
+++ b/recipes/treemacs-all-the-icons
@@ -1,0 +1,4 @@
+(treemacs-all-the-icons
+ :fetcher github
+ :repo "Alexander-Miller/treemacs"
+ :files ("src/extra/treemacs-all-the-icons.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Add an icon theme for treemacs based on all-the-icons.

### Direct link to the package repository

https://github.com/Alexander-Miller/treemacs
https://github.com/Alexander-Miller/treemacs/blob/master/src/extra/treemacs-all-the-icons.el

### Your association with the package

Maintainer of treemacs
The theme was contributed by @ericdallo

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
