### PR TITLE
Add modern-sh

### DIFF
--- a/recipes/modern-sh
+++ b/recipes/modern-sh
@@ -1,0 +1,4 @@
+(modern-sh
+  :fetcher github
+  :repo "damon-kwok/modern-sh"
+  :files (:defaults "etc"))


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs minor mode for editing shell script.

![modern-sh-screenshot](https://user-images.githubusercontent.com/1702133/89370167-a83a5600-d712-11ea-92b3-e23d8bf11ad9.png)


### Direct link to the package repository

https://github.com/damon-kwok/modern-sh

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
