### PR TITLE
Add go-expr-completion recipes

### DIFF
--- a/recipes/go-expr-completion
+++ b/recipes/go-expr-completion
@@ -1,0 +1,1 @@
+(go-expr-completion :repo "fujimisakari/emacs-go-expr-completion" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package is based on a [vim-go-expr-completion](https://github.com/110y/vim-go-expr-completion), to complete a left-hand side from given expression for Go.

### Direct link to the package repository

https://github.com/fujimisakari/emacs-go-expr-completion

### Your association with the package

I'm the package's maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
