### PR TITLE
Add dired-posframe recipe

### DIFF
--- a/recipes/dired-posframe
+++ b/recipes/dired-posframe
@@ -1,0 +1,1 @@
+(dired-posframe :fetcher github :repo "conao3/dired-posframe.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package is a [peep-dired](https://github.com/asok/peep-dired) inspired, dired glimpse package using [posframe](https://github.com/tumashu/posframe).

### Direct link to the package repository

https://github.com/conao3/dired-posframe.el

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them