### PR TITLE
Add recipe for lsp-focus.

### DIFF
--- a/recipes/lsp-focus
+++ b/recipes/lsp-focus
@@ -1,0 +1,3 @@
+(lsp-focus
+ :fetcher github
+ :repo "emacs-lsp/lsp-focus")


### PR DESCRIPTION
### Brief summary of what the package does

Adds LSP support for [Focus](https://github.com/larstvei/Focus)

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-focus

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
