### PR TITLE
Add recipe for ron-mode

### DIFF
--- a/recipes/ron-mode
+++ b/recipes/ron-mode
@@ -1,0 +1,1 @@
+(recipe :fetcher git :url "https://codeberg.org/Hutzdog/ron-mode")

--- a/recipes/ron-mode
+++ b/recipes/ron-mode
@@ -1,1 +1,1 @@
-(recipe :fetcher git :url "https://codeberg.org/Hutzdog/ron-mode")
+(ron-mode :fetcher git :url "https://codeberg.org/Hutzdog/ron-mode")


### PR DESCRIPTION
# Rusty Object Notation (RON) EMACS Major Mode
### What is RON
Rusty Object Notation (RON) is a relatively obscure format for storing data in the Rust Programming Language. It is predominantly used by the Amethyst Game Engine (https://amethyst.rs/) as an alternative to JSON.

### Source
https://chiselapp.com/user/Hutzdog/repository/ron-mode/home
(git mirror, used for compatibility) https://codeberg.org/Hutzdog/ron-mode

### Your association with the package
I am the author of the package, which takes inspiration from nabero's RON Mode package.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). (BSD 2-Clause)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them (Nice tripwire, BTW)
