### PR TITLE
Add recipe for spotify+

### DIFF
--- a/recipes/spotify+
+++ b/recipes/spotify+
@@ -1,4 +1,4 @@
 (spotify+
   :fetcher github
-   :repo "SnootierMoon/emacs-spotify-plus")
+  :repo "SnootierMoon/emacs-spotify-plus")
 

--- a/recipes/spotify+
+++ b/recipes/spotify+
@@ -1,0 +1,4 @@
+(spotify+
+  :fetcher github
+   :repo "SnootierMoon/emacs-spotify-plus")
+


### PR DESCRIPTION
### Brief summary of what the package does

It's a working early version of a Spotify plugin for Emacs. Unlike any other Spotify plugin on melpa (literally), it uses the PKCE OAuth2 flow which is much more secure because it is designed for open source serverless applications like Emacs plugins. Other Spotify plugins give out client secrets which is a big security risk, or force you to make your own at the Spotify developer's website, which is very annoying. With PKCE, you don't have to do either.

### Direct link to the package repository

https://github.com/SnootierMoon/emacs-spotify-plus

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
