### PR TITLE
xwidgets-reuse.el -Reuse xwidgets sessions to reduce resource consumption.

### DIFF
--- a/recipes/xwidgets-reuse
+++ b/recipes/xwidgets-reuse
@@ -1,0 +1,1 @@
+(xwidgets-reuse :fetcher github :repo "lordpretzel/xwidgets-reuse" :files ("xwidgets-reuse.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Allows xwidget sessions to be reused for several purposes. Users can register minor modes with the package for their purposes. When a url is browsed then optionally a minor mode to be activated (presumably for key bindings) can be passed to `xwidgets-reuse-xwidget-reuse-browse-url` that will be activated and all other minor modes registered with `xwidgets-reuse` will be turned of. Example use cases are viewing `elfeed` feeds or `mu4e` emails in xwidget-webkit with custom key binding. See `https://github.com/lordpretzel/xwidgets-reuse` for an elfeed setup and `https://github.com/lordpretzel/mu4e-views` for a package using this package to add xwidget-webkit as a method for viewing emails in `mu4e`.

### Direct link to the package repository

https://github.com/lordpretzel/xwidgets-reuse

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
