### PR TITLE
mu4e-views

### DIFF
--- a/recipes/mu4e-views
+++ b/recipes/mu4e-views
@@ -1,1 +1,1 @@
-(mu4e-views :fetcher github :repo "lordpretzel/mu4e-views" :files ("mu4e-views.el"))
+(mu4e-views :fetcher github :repo "lordpretzel/mu4e-views")

--- a/recipes/mu4e-views
+++ b/recipes/mu4e-views
@@ -1,0 +1,1 @@
+(mu4e-views :fetcher github :repo "lordpretzel/mu4e-views" :files ("mu4e-views.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Add xwidget-webkit as a new method for viewing emails in `mu4e`. Keybindings are available in the xwidgets window to make the integration smoother.

### Direct link to the package repository

https://github.com/lordpretzel/mu4e-views

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Notes

This packages requires the `xwidget-reuse` package for which I also submitted a pull request to melpa. It won't work until `xwidgets-reuse` is available in melpa.