### PR TITLE
Remove less-css-mode and auth-source-pass

### DIFF
--- a/recipes/auth-source-pass
+++ b/recipes/auth-source-pass
@@ -1,4 +1,0 @@
-(auth-source-pass
- :fetcher github
- :repo "DamienCassou/auth-password-store"
- :old-names (auth-password-store))

--- a/recipes/less-css-mode
+++ b/recipes/less-css-mode
@@ -1,1 +1,0 @@
-(less-css-mode :repo "purcell/less-css-mode" :fetcher github)


### PR DESCRIPTION
Remove @purcell's less-css-mode

It is part of Emacs since version 26.1 and is not maintained in the
old upstream repository anymore.

See https://github.com/purcell/less-css-mode/commit/c7fa3d56d83206.

Remove @DamienCassou's 

It is part of Emacs since version 26.1 and while there still is a
separate upstream repository it is being maintained more actively
as part of Emacs than in that repository.

When it is desirable that a package that is part of Emacs is also
made available from an Elpa archive, then GNU Elpa should be used
for that purpose, not Melpa.

@purcell @riscy I hope that you agree that we should avoid adding any such packages going forward.