### PR TITLE
Add recipe for emacs material candy theme

### DIFF
--- a/recipes/material-candy
+++ b/recipes/material-candy
@@ -1,0 +1,1 @@
+(material-candy :fetcher github :repo "shaneikennedy/emacs-material-candy")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs port of material-candy theme by [millsp](https://github.com/millsp/material-candy)

### Direct link to the package repository

https://github.com/shaneikennedy/emacs-material-candy

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
