### PR TITLE
Add agda mode

### DIFF
--- a/recipes/agda-mode
+++ b/recipes/agda-mode
@@ -1,0 +1,1 @@
+(agda-mode :fetcher github :repo "agda/agda" :files ("src/data/emacs-mode/*.el"))

--- a/recipes/agda-mode
+++ b/recipes/agda-mode
@@ -1,1 +1,0 @@
-(agda-mode :fetcher github :repo "agda/agda" :files ("src/data/emacs-mode/*.el"))

--- a/recipes/agda2-mode
+++ b/recipes/agda2-mode
@@ -1,4 +1,2 @@
 (agda2-mode :fetcher github :repo "agda/agda"
-        ;; eri and annotation are seperate packages
-        :files ("src/data/emacs-mode/agda*.el")
-)
+            :files ("src/data/emacs-mode/agda*.el"))

--- a/recipes/agda2-mode
+++ b/recipes/agda2-mode
@@ -1,1 +1,4 @@
-(agda2-mode :fetcher github :repo "agda/agda" :files ("src/data/emacs-mode/*.el"))
+(agda2-mode :fetcher github :repo "agda/agda"
+        ;; eri and annotation are seperate packages
+        :files ("src/data/emacs-mode/agda*.el")
+)

--- a/recipes/agda2-mode
+++ b/recipes/agda2-mode
@@ -1,0 +1,1 @@
+(agda2-mode :fetcher github :repo "agda/agda" :files ("src/data/emacs-mode/*.el"))

--- a/recipes/annotation
+++ b/recipes/annotation
@@ -1,0 +1,1 @@
+(annotation :fetcher github :repo "agda/agda" :files ("src/data/emacs-mode/annotation.el"))

--- a/recipes/eri
+++ b/recipes/eri
@@ -1,0 +1,1 @@
+(eri :fetcher github :repo "agda/agda" :files ("src/data/emacs-mode/eri.el"))


### PR DESCRIPTION
I'm not the maintainer of this package, 
I just added this because it's annoying to not have this tracked in melpa.
I use nixos and because it's not in melpa, it's not in nixos making setting up this thing a lot harder.

It is part of the main agda repository: https://github.com/agda/agda
Has been used a long time but nobody bothered to add to melpa.
I wish to use nix for emacs config management and adding this
to melpa, adds it to nix.

My association is that I'm writing a blog post about agda at the moment,
but while doing that I wish to leave the state of agda
better and more accisable than I found it in.

There is an issue to do this upstream:
https://github.com/agda/agda/issues/3360
I'm doing this because it looked easy and I have reasonable
gains out of it.

### Brief summary of what the package does

Helps you write agda, a programming langauge that's practically impossible to do without this mode.

### Direct link to the package repository

https://github.com/agda/agda

### Your association with the package

Enthusiastic user.

### Relevant communications with the upstream package maintainer

https://github.com/agda/agda/issues/3360

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). BSD like: https://agda.readthedocs.io/en/v2.5.2/license.html
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

