### PR TITLE
Update lsp-mode recipe adding clients folder

### DIFF
--- a/recipes/lsp-mode
+++ b/recipes/lsp-mode
@@ -1,1 +1,4 @@
-(lsp-mode :repo "emacs-lsp/lsp-mode" :fetcher github)
+(lsp-mode :repo "emacs-lsp/lsp-mode"
+          :fetcher github
+          :files (:defaults
+                  "clients/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

We intend to move all lsp-FOO.el clients from our package to a `clients` folder.

### Direct link to the package repository

https://github.com/emacs-lsp/lsp-mode

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
