### PR TITLE
Add: lakota-input package recipe

### DIFF
--- a/recipes/lakota-input
+++ b/recipes/lakota-input
@@ -1,0 +1,1 @@
+(lakota-input :fetcher git :url "https://git.sr.ht/~shoshin/lakota-input.git")


### PR DESCRIPTION
### Brief summary of what the package does

Adds a quail package with two input modes for the Lakota language.

### Direct link to the package repository

https://git.sr.ht/~shoshin/lakota-input.git

### Your association with the package

Creator and maintaner

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
