### PR TITLE
New recipe: magrant

### DIFF
--- a/recipes/magrant
+++ b/recipes/magrant
@@ -1,0 +1,2 @@
+(magrant :repo "p3r7/magrant"
+         :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

magrant provides an interface similar to magit for [Vagrant](https://www.vagrantup.com/).

It uses the same underlying library ([transient](https://github.com/magit/transient)) for turning a command line program into an Emacs interface.

Other packages are built around the same principle like [kubel](https://github.com/abrochard/kubel) and [docker](https://github.com/Silex/docker.el).

### Direct link to the package repository

https://github.com/p3r7/magrant

### Your association with the package

Maintainer.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
