### PR TITLE
Add erc-matterircd

### DIFF
--- a/recipes/erc-matterircd
+++ b/recipes/erc-matterircd
@@ -1,0 +1,1 @@
+(erc-matterircd :fetcher github :repo "alexmurray/erc-matterircd")


### PR DESCRIPTION
### Brief summary of what the package does

Provides integration between `erc` and `matterircd` to automatically login to the remote mattermost server on connection to matterircd, and correctly reformats markdown-based formatting used by mattermost for display in erc buffers.

### Direct link to the package repository

https://github.com/alexmurray/erc-matterircd

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
