### PR TITLE
Add recipe for eshell-outline

### DIFF
--- a/recipes/eshell-outline
+++ b/recipes/eshell-outline
@@ -1,0 +1,1 @@
+(eshell-outline :fetcher git :url "git://jamzattack.xyz/eshell-outline.git")


### PR DESCRIPTION
### Brief summary of what the package does

`eshell-outline-mode` defines a few commands to integrate
`outline-minor-mode` into `eshell`.  Some eshell-specific keys have
been rebound so that they have multiple uses.

### Direct link to the package repository

https://git.jamzattack.xyz/eshell-outline

git://jamzattack.xyz/eshell-outline.git

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
