### PR TITLE
add Chinese wubi input dict version 98

### DIFF
--- a/recipes/pyim-wb98dict
+++ b/recipes/pyim-wb98dict
@@ -1,0 +1,3 @@
+(pyim-wb98dict :repo "HesperusArcher/pyim-wb98dict"
+               :fetcher github
+               :files (:defaults "*.pyim"))


### PR DESCRIPTION
### Brief summary of what the package does

Chinese input method wubi have two versions that have published copyright. Althrough `pyim` only have `wbdict` (version 86) by default, this repo is the version 98, which is newer and more self-consistent for typing characters.

### Direct link to the package repository

https://github.com/HesperusArcher/pyim-wb98dict

### Your association with the package

I am the maintainer of the package, and the original data obtained from [98wubi-tables](https://github.com/yanhuacuo/98wubi-tables), and I converted it into a type available for `pyim`.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them
