### PR TITLE
Remove non-default files

### DIFF
--- a/recipes/org-re-reveal
+++ b/recipes/org-re-reveal
@@ -1,4 +1,3 @@
 (org-re-reveal
  :repo "oer/org-re-reveal"
- :fetcher gitlab
- :files (:defaults "LICENSES" "Readme.org" "local.css" "images"))
+ :fetcher gitlab)


### PR DESCRIPTION
Change recipe for org-re-reveal as requested over there: https://gitlab.com/oer/org-re-reveal/-/issues/48

I hope that this is fine without further explanations as the recipe uses default settings for `files` now.