### PR TITLE
Added recipe for restclient-jq

### DIFF
--- a/recipes/restclient-jq
+++ b/recipes/restclient-jq
@@ -1,0 +1,3 @@
+(restclient-jq :repo "pashky/restclient.el"
+	       :fetcher github
+	       :files ("restclient-jq.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Integrate `restclient` with `jq-mode`. Allows to set `restclient` buffer variables from a JSON response.

### Direct link to the package repository

https://github.com/pashky/restclient.el

### Your association with the package

Enthusiast. @pashky is the author of the package. I just created the recipe.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] Public Domain. The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] (not applicable, IMHO) `M-x checkdoc` is happy with my docstrings 
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them :-)


