### PR TITLE
add erc-yank package

### DIFF
--- a/recipes/erc-yank
+++ b/recipes/erc-yank
@@ -1,0 +1,1 @@
+(erc-yank :repo "jwiegley/erc-yank" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Intercepts large messages sent to IRC channels and automatically
creates a gist and sends a link instead.

### Direct link to the package repository

https://github.com/jwiegley/erc-yank

### Your association with the package

I am not the maintainer, but I have been a user for many years. I saw
this issue https://github.com/jwiegley/erc-yank/issues/1, and thought
that I'd just submit it.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them