### PR TITLE
Add flycheck-aspell and flymake-aspell packages.

### DIFF
--- a/recipes/flycheck-aspell
+++ b/recipes/flycheck-aspell
@@ -1,3 +1,3 @@
 (flycheck-aspell :fetcher github 
 		 :repo "leotaku/flycheck-aspell"
-		 :files ("flycheck-aspell.el" "README.md"))
+		 :files ("flycheck-aspell.el"))

--- a/recipes/flycheck-aspell
+++ b/recipes/flycheck-aspell
@@ -1,0 +1,3 @@
+(flycheck-aspell :fetcher github 
+		 :repo "leotaku/flycheck-aspell"
+		 :files ("flycheck-aspell.el" "README.md"))

--- a/recipes/flymake-aspell
+++ b/recipes/flymake-aspell
@@ -1,0 +1,3 @@
+(flymake-aspell :fetcher github 
+		:repo "leotaku/flycheck-aspell"
+		:files ("flymake-aspell.el" "README.md"))

--- a/recipes/flymake-aspell
+++ b/recipes/flymake-aspell
@@ -1,3 +1,3 @@
 (flymake-aspell :fetcher github 
 		:repo "leotaku/flycheck-aspell"
-		:files ("flymake-aspell.el" "README.md"))
+		:files ("flymake-aspell.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Provides integration between apell and flycheck/flymake
respectively. Specified as seperate packages.

### Direct link to the package repository

https://github.com/your/awesome_package

### Your association with the package

I am just a happy user, and have coordinated this with the package
maintainer [here](https://github.com/leotaku/flycheck-aspell/issues/7).

### Relevant communications with the upstream package maintainer

None needed. 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them