### PR TITLE
Add recipe for impatient-showdown.

### DIFF
--- a/recipes/impatient-showdown
+++ b/recipes/impatient-showdown
@@ -1,0 +1,1 @@
+(impatient-showdown :repo "jcs-elpa/impatient-showdown" :fetcher github)

--- a/recipes/impatient-showdown
+++ b/recipes/impatient-showdown
@@ -1,1 +1,4 @@
-(impatient-showdown :repo "jcs-elpa/impatient-showdown" :fetcher github)
+(impatient-showdown 
+  :repo "jcs-elpa/impatient-showdown" 
+  :fetcher github
+  :files (:defaults "preview.html"))


### PR DESCRIPTION
### Brief summary of what the package does

Preview markdown buffer live over HTTP using showdown.

### Direct link to the package repository

https://github.com/jcs-elpa/impatient-showdown

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
