### PR TITLE
Add unicad pacakge

### DIFF
--- a/recipes/unicad
+++ b/recipes/unicad
@@ -1,0 +1,1 @@
+(unicad :repo "ukari/unicad" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This pacakge is an Elisp program port from Mozilla universal charset auto detector. 

If I add `(set-language-environment "UTF-8")` in the emacs.d config file, my emacs can't detect some charset like gb18030 successfully. With this package it works.

### Direct link to the package repository

https://github.com/ukari/unicad

### Your association with the package

I am the melpa recipe maintainer, and have been got the publish permission from author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
