### PR TITLE
Add recipe for orgstrap

### DIFF
--- a/recipes/orgstrap
+++ b/recipes/orgstrap
@@ -1,0 +1,3 @@
+(orgstrap :repo "tgbugs/orgstrap"
+          :fetcher github
+          :files ("orgstrap.el"))


### PR DESCRIPTION
### Brief summary of what the package does

orgstrap is a specification and tools for standalone self-bootstrapping org-mode files.

### Direct link to the package repository

https://github.com/tgbugs/orgstrap

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

Of course I know him. He's me!

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
