### PR TITLE
Add tree-sitter and tree-sitter-langs

### DIFF
--- a/recipes/tree-sitter
+++ b/recipes/tree-sitter
@@ -4,4 +4,4 @@
                      "Cargo.toml"
                      "Cargo.lock"
                      "src"
-                     (:exclude "lisp/tree-sitter-tests.el"))
+                     (:exclude "lisp/tree-sitter-tests.el")))

--- a/recipes/tree-sitter
+++ b/recipes/tree-sitter
@@ -1,7 +1,4 @@
 (tree-sitter :repo "ubolonton/emacs-tree-sitter"
              :fetcher github
              :files ("lisp/*.el"
-                     "Cargo.toml"
-                     "Cargo.lock"
-                     "src"
                      (:exclude "lisp/tree-sitter-tests.el")))

--- a/recipes/tree-sitter
+++ b/recipes/tree-sitter
@@ -1,0 +1,7 @@
+(tree-sitter :repo "ubolonton/emacs-tree-sitter"
+             :fetcher github
+             :files ("lisp/*.el"
+                     "Cargo.toml"
+                     "Cargo.lock"
+                     "src"
+                     (:exclude "lisp/tree-sitter-tests.el"))

--- a/recipes/tree-sitter-langs
+++ b/recipes/tree-sitter-langs
@@ -1,0 +1,4 @@
+(tree-sitter-langs :repo "ubolonton/emacs-tree-sitter"
+                   :fetcher github
+                   :files ("langs/*.el"
+                           "langs/queries"))

--- a/recipes/tsc
+++ b/recipes/tsc
@@ -1,0 +1,6 @@
+(tsc :repo "ubolonton/emacs-tree-sitter"
+     :fetcher github
+     :files ("core/*.el"
+             "core/Cargo.toml"
+             "core/Cargo.lock"
+             "core/src"))


### PR DESCRIPTION
### Brief summary of what the package does

Incremental parsing for Emacs.

- `tree-sitter`: Core APIs, minor modes for syntax highlighting, tree/query debugging.
- `tree-sitter-langs`: Bundle of grammars and syntax highlighting queries for some common languages.

### Direct link to the package repository

https://github.com/ubolonton/emacs-tree-sitter

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Notes
- `checkdoc` is not entirely happy, but its suggestions seem pedantic/inaccurate.
- These packages download pre-built binaries upon installation, from GitHub (dynamic module) and bintray (grammars).