### PR TITLE
Adding abridge-diff

### DIFF
--- a/recipes/abridge-diff
+++ b/recipes/abridge-diff
@@ -1,0 +1,1 @@
+(abridge-diff :repo "jdtsmith/abridge-diff" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A simple Emacs package for abridging refined diff hunks (for example in magit). 

### Direct link to the package repository

https://github.com/jdtsmith/abridge-diff

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
