### PR TITLE
Remove org-taskforecast

### DIFF
--- a/recipes/org-taskforecast
+++ b/recipes/org-taskforecast
@@ -1,1 +1,0 @@
-(org-taskforecast :fetcher github :repo "HKey/org-taskforecast")


### PR DESCRIPTION
Please remove the package.
I am the author, I removed its repository.