### PR TITLE
[Documentation] Update package links to melpa repositories

### DIFF
--- a/html/partials/getting-started.html
+++ b/html/partials/getting-started.html
@@ -18,10 +18,10 @@
       </p>
 
       <pre><code>(require 'package)
-(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/") t)
 ;; Comment/uncomment this line to enable MELPA Stable if desired.  See `package-archive-priorities`
 ;; and `package-pinned-packages`. Most users will not need or want to do this.
-;;(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/packages/") t)
+;;(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/") t)
 (package-initialize)</code></pre>
 
       <p>
@@ -39,7 +39,7 @@
       </p>
 
       <pre><code>(add-to-list 'package-archives
-             '("melpa-stable" . "https://stable.melpa.org/packages/") t)</code></pre>
+             '("melpa-stable" . "https://stable.melpa.org/") t)</code></pre>
 
       <h3>Customizations</h3>
       <p>


### PR DESCRIPTION
The URLs provided in the snipped in the documentation are redirections:

- https://melpa.org/packages/ redirects to https://melpa.org/
- https://stable.melpa.org/packages/ redirects to https://stable.melpa.org/

Going directly to the final URLs avoids to wait for the redirection so the execution is faster (so it's a better user experience).

### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
