### PR TITLE
[Documentation] Direct link to README.md file

### DIFF
--- a/html/partials/getting-started.html
+++ b/html/partials/getting-started.html
@@ -136,8 +136,7 @@
       <p>
 	In so many words, fork the project's source tree
 	and create a pull request with a recipe for your package.
-	The <tt>README.md</tt> file on GitHub has more details.
-	See the next section for a link.
+	The <a href="https://github.com/melpa/melpa/blob/master/README.md">README.md</a> file on GitHub has more details.
       </p>
       <a name="development"></a>
       <h2>Development</h2>


### PR DESCRIPTION
It's more convenient for the user.

However, I would understand you want to limit the numbers of github references in case you want to change repository host to another one in the future.

I can reformat lines to limit length if you prefer:
```
The
<a href="https://github.com/melpa/melpa/blob/master/README.md">README.md</a>
file on GitHub has more details.
```


### Checklist

Please confirm with `x`:

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
