### PR TITLE
Add validate-html.

### DIFF
--- a/recipes/validate-html
+++ b/recipes/validate-html
@@ -1,0 +1,1 @@
+(validate-html :fetcher github :repo "arthurgleckler/validate-html")


### PR DESCRIPTION
### Brief summary of what the package does

This file installs the command validate-html, which sends the
current buffer to the World Wide Web Consortium's HTML Validator
service and displays the results in a dedicated buffer in Compilation mode.  Use
standard Compilation commands like next-error to move through the
errors in the source buffer.

### Direct link to the package repository

https://github.com/arthurgleckler/validate-html

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
