### PR TITLE
add git-grep

### DIFF
--- a/recipes/git-grep
+++ b/recipes/git-grep
@@ -1,0 +1,1 @@
+(git-grep :repo "tychoish/git-grep.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides `find-grep` like interface around git-grep

### Direct link to the package repository

https://github.com/tychoish/git-grep.el

### Your association with the package

This is a very small but extremely useful package that I've been using
for years and I wanted to extract it and package it up for general use. 

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them