### PR TITLE
Add recipe: binder

### DIFF
--- a/recipes/binder
+++ b/recipes/binder
@@ -1,0 +1,1 @@
+(binder :fetcher github :repo "rnkn/binder")


### PR DESCRIPTION
### Brief summary of what the package does

Binder is an Emacs global minor mode facilitating multi-file writing projects, taking influence from popular writing app Scrivener. Using a project file `.binder.el` in a project's top-level directory it tracks a linear-list of files and properties including their order, inclusion state in the final project, notes, and tags.

### Direct link to the package repository

https://github.com/rnkn/binder

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
