### PR TITLE
Add recipe `jmt-mode`.

### DIFF
--- a/recipes/jmt-mode
+++ b/recipes/jmt-mode
@@ -1,0 +1,1 @@
+(jmt-mode :repo "Michael-Allan/Java_Mode_Tamed" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Introduces a derived major mode (`jmt-mode`) that makes it easier to control the Java mode 
built into Emacs, mostly in regard to syntax highlighting.

### Direct link to the package repository

https://github.com/Michael-Allan/Java_Mode_Tamed

### Your association with the package

Author, maintainer and user.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them


