### PR TITLE
Add gcode-mode recipe

### DIFF
--- a/recipes/gcode-mode
+++ b/recipes/gcode-mode
@@ -1,0 +1,2 @@
+(gcode-mode :repo "wavexx/gcode-mode.el"
+            :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Introduces a new ``gcode-mode`` major mode aimed to high-light gcode for 3d-printers. The mode is currently very basic.

### Direct link to the package repository

https://gitlab.com/wavexx/gcode-mode.el

### Your association with the package

Author

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
- [x] I added an extra item just for the sake of it
