### PR TITLE
Add recipe for yaps

### DIFF
--- a/recipes/yaps
+++ b/recipes/yaps
@@ -1,0 +1,1 @@
+(yaps :repo "rayw000/yaps" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Yaps makes your `*scratch*` buffer content persistent and cannot be killed (bury instead).

### Similar packages
https://github.com/Fanael/persistent-scratch
Comparing to `persistent-scratch`, `yaps` provides feature which keeps the `*scratch*` buffer not killed.

### Direct link to the package repository

https://github.com/rayw000/yaps

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
