### PR TITLE
Add helm-atoms package

### DIFF
--- a/recipes/helm-atoms
+++ b/recipes/helm-atoms
@@ -1,0 +1,1 @@
+(helm-atoms :fetcher github :repo "dantecatalfamo/helm-atoms")


### PR DESCRIPTION
### Brief summary of what the package does

This package adds a way to perform an interactive reverse variable lookup using helm. It allows you to find the name of an elisp variable by only knowing the value of its contents.

### Direct link to the package repository

https://github.com/dantecatalfamo/helm-atoms

### Your association with the package

I'm the maintainer!

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
