### PR TITLE
Add gkroam package

### DIFF
--- a/recipes/gkroam
+++ b/recipes/gkroam
@@ -1,0 +1,1 @@
+(gkroam :fetcher github :repo "Kinneyzhang/gkroam.el")


### PR DESCRIPTION
### Brief summary of what the package does

Gkroam is a lightweight roam replica on top of emacs org-mode.

### Direct link to the package repository

https://github.com/Kinneyzhang/gkroam.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them