### PR TITLE
Add a recipe for 2bit.el

### DIFF
--- a/recipes/2bit
+++ b/recipes/2bit
@@ -1,0 +1,1 @@
+(2bit :fetcher github :repo "davep/2bit.el")


### PR DESCRIPTION
### Brief summary of what the package does

`2bit.el` provides low-level code for Emacs lisp that allows loading genetic sequence data from 2bit files -- a common format for storing such data. Building on that code, it also provides a couple of commands for pulling sequences into a buffer.

### Direct link to the package repository

https://github.com/davep/2bit.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
