### PR TITLE
Add flymake-proselint recipe

### DIFF
--- a/recipes/flymake-proselint
+++ b/recipes/flymake-proselint
@@ -1,0 +1,1 @@
+(flymake-proselint :repo "manuel-uberti/flymake-proselint" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package makes it possible to use [proselint](http://proselint.com/) with Emacs built-in Flymake.

### Direct link to the package repository

https://github.com/manuel-uberti/flymake-proselint

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Note

When I try to install the recipe as per [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org), I get the error `Package ‘flymake-quickdef-1.0.0’ is unavailable`, although the package exists: https://melpa.org/#/flymake-quickdef
