### PR TITLE
Add ocamlformat package

### DIFF
--- a/recipes/ocamlformat
+++ b/recipes/ocamlformat
@@ -1,0 +1,1 @@
+(ocamlformat :fetcher github :repo "ocaml-ppx/ocamlformat" :files ("emacs/ocamlformat.el"))


### PR DESCRIPTION
### Brief summary of what the package does

ocamlformat.el is an emacs package for formatting OCaml code using the
ocamlformat command-line tool.

### Direct link to the package repository

https://github.com/ocaml-ppx/ocamlformat

### Your association with the package

Enthusiastic user, OCaml developer

### Relevant communications with the upstream package maintainer

ocaml-ppx/ocamlformat#1474 (already merged) added package.el metadata to the elisp file.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
