### PR TITLE
* recipes/amsreftex: new recipe

### DIFF
--- a/recipes/amsreftex
+++ b/recipes/amsreftex
@@ -1,0 +1,1 @@
+(amsreftex :fetcher github :repo "franburstall/amsreftex")


### PR DESCRIPTION
### Brief summary of what the package does

Adds support to reftex for amsrefs databases

### Direct link to the package repository

https://github.com/franburstall/amsreftex

### Your association with the package

I am the author/maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback.  NOTE: two issues raised by package-lint are not addressed for a reason: see comments in amsreftex.el
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
