### PR TITLE
Change branch in recipe for humanoid-themes

### DIFF
--- a/recipes/humanoid-themes
+++ b/recipes/humanoid-themes
@@ -1,2 +1,3 @@
 (humanoid-themes :repo "humanoid-colors/emacs-humanoid-themes"
-                 :fetcher github)
+                 :fetcher "github"
+                 :branch "main")


### PR DESCRIPTION
Update the default package branch to `main` instead of `master`.

### Brief summary of what the package does

A color theme made for coding and working with a dark and a light version.
It works well with true color as well as in a 256 color terminal.

### Direct link to the package repository

https://github.com/humanoid-colors/emacs-humanoid-themes
https://gitlab.com/tasmo/emacs-humanoid-themes

### Your association with the package

I'm the author and the maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
