### PR TITLE
Add clj-decompiler recipe

### DIFF
--- a/recipes/clj-decompiler
+++ b/recipes/clj-decompiler
@@ -1,0 +1,1 @@
+(clj-decompiler :fetcher github :repo "bsless/clj-decompiler.el")


### PR DESCRIPTION
### Brief summary of what the package does

`clj-decompiler` is a package for `clojure-mode` build on top of CIDER which adds an injected clj dependency for a decompiler and exposes it as two functions, which decompile the generated Java classes to Java source or to bytecode.

### Direct link to the package repository

https://github.com/bsless/clj-decompiler.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
