### PR TITLE
Add w32-ime recipe

### DIFF
--- a/recipes/w32-ime
+++ b/recipes/w32-ime
@@ -1,0 +1,1 @@
+(w32-ime :fetcher github :repo "trueroad/w32-ime.el")


### PR DESCRIPTION
### Brief summary of what the package does

w32-ime makes Japanese input with Windows IME (Input Method Editor) more convenient.

### Direct link to the package repository

https://github.com/trueroad/w32-ime.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
