### PR TITLE
Remove package wcheck-mode; it's maintained in GNU Elpa repository

### DIFF
--- a/recipes/wcheck-mode
+++ b/recipes/wcheck-mode
@@ -1,1 +1,0 @@
-(wcheck-mode :fetcher github :repo "tlikonen/wcheck-mode")


### PR DESCRIPTION
wcheck-mode is maintained in the GNU Elpa repository and is unnecessary to have it in Melpa too.

I'm the original and almost sole author of wcheck-mode. To confirm this the commit in this pull request is signed with the same OpenPGP key (4E1055DC84E9DFF613D78557719D69D324539450) as the commits in the original wcheck-mode repository (https://github.com/tlikonen/wcheck-mode).