### PR TITLE
dw: Change repo name to account for typo-fix

### DIFF
--- a/recipes/dw
+++ b/recipes/dw
@@ -1,1 +1,1 @@
-(dw :fetcher github :repo "integral-dw/dw-passphase-generator")
+(dw :fetcher github :repo "integral-dw/dw-passphrase-generator")


### PR DESCRIPTION
I am a blind idiot and only now realized my repo had a missing "r" all this time...
It's already fixed on my end, sorry for the inconvenience.