### PR TITLE
Add recipe solo-jazz-theme

### DIFF
--- a/recipes/solo-jazz-theme
+++ b/recipes/solo-jazz-theme
@@ -1,0 +1,3 @@
+(solo-jazz-theme
+ :fetcher github
+ :repo "cstby/solo-jazz-emacs-theme")


### PR DESCRIPTION
### Brief summary of what the package does

An original theme inspired by the 1992 Solo Jazz cup design.

### Direct link to the package repository

https://github.com/cstby/solo-jazz-emacs-theme

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None Needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings **See notes below**
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Notes
- M-x checkdoc advsied me to disambiguate `rainbow-mode`, but I saw no way to do so that passed the check.
