### PR TITLE
Etherpad recipe

### DIFF
--- a/recipes/ethermacs
+++ b/recipes/ethermacs
@@ -1,1 +1,0 @@
-(ethermacs :repo "zzkt/ethermacs" :fetcher github)

--- a/recipes/ethermacs
+++ b/recipes/ethermacs
@@ -1,0 +1,1 @@
+(ethermacs :repo "zzkt/ethermacs" :fetcher github)

--- a/recipes/etherpad
+++ b/recipes/etherpad
@@ -1,0 +1,1 @@
+(etherpad :repo "zzkt/ethermacs" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A simple interface using the Etherpad API to enable emacs to edit documents on an etherpad server.

### Direct link to the package repository

https://github.com/zzkt/ethermacs

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
