### PR TITLE
Add base-convert-live recipe

### DIFF
--- a/recipes/base-convert-live
+++ b/recipes/base-convert-live
@@ -1,0 +1,1 @@
+(base-convert-live :fetcher github :repo "lassik/emacs-base-convert-live")


### PR DESCRIPTION
### Brief summary of what the package does

Convert number from one base (aka radix) to others.

Binary (base 2), octal (base 8), decimal (base 10) and hexadecimal (base 16) are supported for both input and output.

The converter doesn't ask you which input and output base you want to use. Instead, it accepts free-form text input, tries to parse it using all supported bases, and displays successful conversions of those numbers to all supported bases.

### Direct link to the package repository

https://github.com/lassik/emacs-base-convert-live

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
