### PR TITLE
Add julia-repl-vterm recipe

### DIFF
--- a/recipes/julia-repl-vterm
+++ b/recipes/julia-repl-vterm
@@ -1,0 +1,2 @@
+(julia-repl-vterm :repo "shg/julia-repl-vterm.el" :fetcher github)
+

--- a/recipes/julia-repl-vterm
+++ b/recipes/julia-repl-vterm
@@ -1,2 +1,0 @@
-(julia-repl-vterm :repo "shg/julia-repl-vterm.el" :fetcher github)
-

--- a/recipes/julia-vterm
+++ b/recipes/julia-vterm
@@ -1,0 +1,1 @@
+(julia-vterm :repo "shg/julia-vterm.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides a major-mode for inferior Julia process that runs in vterm, and a minor-mode that extends julia-mode to support interaction with the inferior Julia process.

### Direct link to the package repository

https://github.com/shg/julia-repl-vterm.el

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them


package-lint has complaints about inconsistency between the function names and the package prefix. Let me know if this needs to be addressed.