### PR TITLE
Fix remainder issue

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -212,7 +212,7 @@
       }
     };
     this.maxPage = function() {
-      return Math.floor(getItemList().length / this.pageLength());
+      return Math.ceil(getItemList().length / this.pageLength());
     };
     this.prevPages = function() {
       return _.last(_.range(1, this.pageNumber()),


### PR DESCRIPTION
What I suggest here is that, when you search a package on melpa website, it shows 1st-50th packages but not 51st package until when package count goes at least 100. This PR solves ignoring results.