### PR TITLE
Add recipe for ghc-rts.

### DIFF
--- a/recipes/ghc-rts
+++ b/recipes/ghc-rts
@@ -1,0 +1,6 @@
+(ghc-rts :repo "ilitzroth/ghc-rts.el"
+         :fetcher github
+         :files ("ghc-rts.el"
+                 "emacs-ghc-rts.cpp"
+                 "emacs-ghc-rts.hpp"
+                 "Makefile"))


### PR DESCRIPTION
### Brief summary of what the package does
Package consists of a binary module that initializes GHC
runtime system.

### Direct link to the package repository

https://github.com/ilitzroth/ghc-rts.el

### Your association with the package
Maintainer, (sole) contributor and enthusiastic user.

### Relevant communications with the upstream package maintainer
Package will compile the extension on the fly when the user calls the 
functions in this package. There might be problems with that on different
compilers/os's but that will need to be addressed when problems arise.

The  package is actually a building block for an upcoming package of mine 
which will allow one to write haskell code that can used by emacs. 
That will not require c/c++ and main use of that will be using 
development tools from emacs directly.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
