### PR TITLE
Update eide Gitlab namespace in URL

### DIFF
--- a/recipes/eide
+++ b/recipes/eide
@@ -1,1 +1,1 @@
-(eide :fetcher git :url "https://forge.tedomum.net/eide/eide.git" :files ("src/*.el" "src/themes/*.el"))
+(eide :fetcher git :url "https://forge.tedomum.net/hjuvi/eide.git" :files ("src/*.el" "src/themes/*.el"))


### PR DESCRIPTION
In Tedomum's Gitlab, the project namespace was changed from 'eide' (a
specific group that I deleted) to 'hjuvi' (my user account).

The information can be checked on the official website:
https://eide.hjuvi.fr.eu.org/pages/development.html

Also, if you go to the old URL, there is a redirection, and a popup is
displayed that mentions the change of namespace:
https://forge.tedomum.net/eide/eide

### Brief summary of what the package does

A package for Emacs that provides IDE features.

### Direct link to the package repository

https://forge.tedomum.net/hjuvi/eide

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
