### PR TITLE
Add recipe for ednc

### DIFF
--- a/recipes/ednc
+++ b/recipes/ednc
@@ -1,0 +1,1 @@
+(ednc :repo "sinic/ednc" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The Emacs Desktop Notification Center (EDNC) implements a Desktop Notifications service according to [the freedesktop.org specification](https://people.gnome.org/~mccann/docs/notification-spec/notification-spec-latest.html), suitable to replace standalone daemons like [Dunst](https://dunst-project.org/).

### Direct link to the package repository

https://github.com/sinic/ednc

### Your association with the package

I'm the package author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
