### PR TITLE
Include Julia Pkg toml files in package

### DIFF
--- a/recipes/julia-snail
+++ b/recipes/julia-snail
@@ -1,4 +1,4 @@
 (julia-snail
  :fetcher github
  :repo "gcv/julia-snail"
- :files (:defaults "*.jl"))
+ :files (:defaults "*.jl" "*.toml"))


### PR DESCRIPTION
The julia-snail recipe was approved for MELPA in the past (#6653, #6903). I need to update the recipe to include descriptor files for Julia's own package manager.


### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
