### PR TITLE
Update bbdb-vcard with the default value of :files.

### DIFF
--- a/recipes/bbdb-vcard
+++ b/recipes/bbdb-vcard
@@ -1,3 +1,2 @@
 (bbdb-vcard :repo "tohojo/bbdb-vcard"
-            :fetcher github
-            :files ("bbdb-vcard.el" "vcard.el"))
+            :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Imports vcards to bbdb.

### Direct link to the package repository

https://github.com/tohojo/bbdb-vcard

### Your association with the package

Enthusiastic user who found a one-liner bug.

### Relevant communications with the upstream package maintainer

Not yet, but I do not believe a single line adjustment will  change anything. I will write a request though.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
