### PR TITLE
Add recipe for burnt-toast package.

### DIFF
--- a/recipes/burnt-toast
+++ b/recipes/burnt-toast
@@ -1,0 +1,4 @@
+(burnt-toast
+ :fetcher github
+ :repo "cedarbaum/burnt-toast.el"
+ :files (:defaults ("icons" "icons/*.png")))


### PR DESCRIPTION
### Brief summary of what the package does

This package adds Elisp bindings for the [BurntToast](https://github.com/Windos/BurntToast) PowerShell module, which allows creating notifications on Windows 10. This package also includes an optional feature to add an alert style to the [Alert](https://github.com/jwiegley/alert) package which creates alerts using this library.

### Direct link to the package repository

https://github.com/cedarbaum/burnt-toast.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

N/A.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
