### PR TITLE
Add eping recipe

### DIFF
--- a/recipes/eping
+++ b/recipes/eping
@@ -1,0 +1,1 @@
+(eping :fetcher github :repo "sean-hut/eping" :branch "releases")

--- a/recipes/eping
+++ b/recipes/eping
@@ -1,1 +1,1 @@
-(eping :fetcher github :repo "sean-hut/eping" :branch "releases")
+(eping :fetcher github :repo "sean-hut/eping" :branch "develop")

--- a/recipes/eping
+++ b/recipes/eping
@@ -1,1 +1,1 @@
-(eping :fetcher github :repo "sean-hut/eping" :branch "develop")
+(eping :fetcher github :repo "sean-hut/eping")


### PR DESCRIPTION
### Brief summary of what the package does

`eping` checks internet connectivity using `ping`.

### Direct link to the package repository

https://github.com/sean-hut/eping

### Your association with the package

I am the:
- package author
- package maintainer
- MELPA recipe author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

In regards to "I've built and installed the package using the instructions in CONTRIBUTING.org":

The package builds with both `make recipes/eping` as well as `STABLE=t make recipes/eping`.

I am using the [straight package manager](https://github.com/raxod502/straight.el) and package-install-file does not look like it is compatible with straight.  It says "Package ‘dash-2.12.0’ is unavailable".

I can install and use eping with straight like this.

```elisp
(straight-use-package 
 '(eping :type git :host github :branch "releases" :repo "sean-hut/eping"))

(use-package eping)
```