### PR TITLE
Add a recipe for the ptemplate-templates package

### DIFF
--- a/recipes/ptemplate-templates
+++ b/recipes/ptemplate-templates
@@ -1,0 +1,2 @@
+(ptemplate-templates :fetcher github :repo "nbfalcon/ptemplate-templates"
+                     :files ("*.el" "rsc"))


### PR DESCRIPTION
### Brief summary of what the package does

It is the official collection of templates for my ptemplate plugin, now
with Emacs integration inspired by yasnippet-snippets.

### Direct link to the package repository

https://github.com/nbfalcon/ptemplate-templates

### Your association with the package

Maintainer and author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

The plugin (ptemplate-templates.el), which is responsible for making the templates in that same repo available to users, package-lints with one error: eval-after-load is for use in configurations only.

In it, I add the templates to the template directory list of ptemplate in an autoloaded eval-after-load 'ptemplate block. I don't know how to best handle this - on one hand, doing that isn't really elegant, but on the other hand it provides an out-of-the-box experience: just installing the package is enough. yasnippet-snippets does the same. What do you think?