### PR TITLE
Add docopt recipe

### DIFF
--- a/recipes/docopt
+++ b/recipes/docopt
@@ -1,0 +1,3 @@
+(docopt :fetcher github
+        :repo "r0man/docopt.el"
+        :files (:defaults "src/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

The docopt.el Emacs package is a Docopt (http://docopt.org)
implementation in Emacs Lisp. It has functionality to parse a Docopt
usage/help string and provide an Emacs transient command to execute
the Docopt program, with the user provided inputs.

At my current work we have a lot of command line tools that people
use. These tools all use Docopt as the help format and I'm using this
package to build a magit like interface on top of them.

### Direct link to the package repository

https://github.com/r0man/docopt.el

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [?] My elisp byte-compiles cleanly
- [?] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

#### Byte compile errors

I tried to remove most byte compile errors. Those are the ones I could
not figure out yet.

```
[roman@thinkpad docopt.el]$ make v=vvv lint-compile
LOG (2020-10-23 13:00:02): Linting compilation...
Package cl is deprecated
Error loading autoloads: (void-function helm-make-source)

In toplevel form:
src/docopt-argv.el:103:1:Error: variable ‘_’ not left unused

In toplevel form:
src/docopt-option.el:312:1:Error: the following functions are not known to be defined: option-1, option-2

In toplevel form:
src/docopt-parser.el:187:1:Error: variable ‘_’ not left unused

In toplevel form:
src/docopt-program.el:250:1:Error: the function ‘docopt-parse’ is not known to be defined.

In toplevel form:
src/docopt-transient.el:333:1:Error: Unused lexical variable ‘vterm-shell’
ERROR (2020-10-23 13:00:04): Linting compilation failed.
LOG (2020-10-23 13:00:04): Finished with 1 errors.
make: *** [Makefile:52: lint-compile] Error 1
```

#### Checkdoc Errors

I think I removed all checkdoc errors, except the ones releated to
aspell. Any ideas I can tell checkdoc to not warn about those words?

```
[roman@thinkpad docopt.el]$ make v=vvv lint-checkdoc
LOG (2020-10-23 13:03:04): Linting checkdoc...
Package cl is deprecated
Error loading autoloads: (void-function helm-make-source)
Starting new Ispell process /usr/bin/aspell with default dictionary... \
Starting new Ispell process /usr/bin/aspell with default dictionary...done
docopt-analyzer.el:48: Error checking word DOCOPT using aspell with default dictionary
docopt-analyzer.el:103: Error checking word DEDUPLICATE using aspell with default dictionary
docopt-analyzer.el:103: Error checking word DOCOPT using aspell with default dictionary
docopt-analyzer.el:195: Error checking word DOCOPT using aspell with default dictionary
docopt-argument.el:73: Error checking word EQUAL-ISH using aspell with default dictionary
docopt-argument.el:79: Error checking word DOCOPT using aspell with default dictionary
docopt-argument.el:87: Error checking word DOCOPT using aspell with default dictionary
docopt-argument.el:98: Error checking word DOCOPT using aspell with default dictionary
docopt-argv.el:240: All variables and subroutines might as well have a documentation string
docopt-command.el:69: Error checking word DOCOPT using aspell with default dictionary
docopt-command.el:72: Error checking word DOCOPT using aspell with default dictionary
docopt-command.el:81: Error checking word DOCOPT using aspell with default dictionary
docopt-either.el:64: Error checking word DOCOPT using aspell with default dictionary
docopt-either.el:74: Error checking word DOCOPT using aspell with default dictionary
docopt-either.el:79: Error checking word DOCOPT using aspell with default dictionary
docopt-either.el:97: Error checking word DOCOPT using aspell with default dictionary
docopt-either.el:101: Error checking word DOCOPT using aspell with default dictionary
docopt-either.el:105: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:51: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:54: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:58: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:65: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:69: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:72: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:76: Error checking word EQUAL-ISH using aspell with default dictionary
docopt-generic.el:79: Error checking word EQUAL-ISH using aspell with default dictionary
docopt-generic.el:83: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:90: Error checking word DOCOPT using aspell with default dictionary
docopt-generic.el:104: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:74: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:85: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:90: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:100: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:104: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:108: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:112: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:116: Error checking word DOCOPT using aspell with default dictionary
docopt-group.el:121: Error checking word DOCOPT using aspell with default dictionary
docopt-option.el:87: Error checking word EQUAL-ISH using aspell with default dictionary
docopt-option.el:137: Error checking word DOCOPT using aspell with default dictionary
docopt-option.el:147: Error checking word DOCOPT using aspell with default dictionary
docopt-option.el:151: Error checking word DOCOPT using aspell with default dictionary
docopt-option.el:156: Error checking word DOCOPT using aspell with default dictionary
docopt-option.el:191: Error checking word DOCOPT using aspell with default dictionary
docopt-option.el:198: Error checking word DOCOPT using aspell with default dictionary
docopt-option.el:202: Error checking word DOCOPT using aspell with default dictionary
docopt-option.el:251: Error checking word DOCOPT using aspell with default dictionary
docopt-options-shortcut.el:62: Error checking word DOCOPT using aspell with default dictionary
docopt-options-shortcut.el:66: Error checking word DOCOPT using aspell with default dictionary
docopt-options-shortcut.el:70: Error checking word DOCOPT using aspell with default dictionary
docopt-options-shortcut.el:74: Error checking word DOCOPT using aspell with default dictionary
docopt-options-shortcut.el:85: Error checking word DOCOPT using aspell with default dictionary
docopt-parser.el:81: Error checking word DOCOPT using aspell with default dictionary
docopt-parser.el:89: Error checking word DOCOPT using aspell with default dictionary
docopt-parser.el:242: Error checking word DOCOPT using aspell with default dictionary
docopt-parser.el:252: Error checking word DOCOPT using aspell with default dictionary
docopt-parser.el:258: Error checking word DOCOPT using aspell with default dictionary
docopt-parser.el:264: Error checking word DOCOPT using aspell with default dictionary
docopt-parser.el:324: Error checking word DOCOPT using aspell with default dictionary
docopt-parser.el:421: Argument ‘state’ should appear (as STATE) in the doc string
docopt-program.el:39: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:89: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:93: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:97: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:104: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:130: Error checking word EQUAL-ISH using aspell with default dictionary
docopt-program.el:168: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:180: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:191: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:209: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:214: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:218: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:222: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:226: Error checking word DOCOPT using aspell with default dictionary
docopt-program.el:233: Error checking word DOCOPT using aspell with default dictionary
docopt-repeated.el:43: Error checking word DOCOPT using aspell with default dictionary
docopt-repeated.el:52: Error checking word DOCOPT using aspell with default dictionary
docopt-repeated.el:56: Error checking word DOCOPT using aspell with default dictionary
docopt-repeated.el:60: Error checking word DOCOPT using aspell with default dictionary
docopt-repeated.el:64: Error checking word DOCOPT using aspell with default dictionary
docopt-repeated.el:68: Error checking word DOCOPT using aspell with default dictionary
docopt-standard-input.el:38: Error checking word DOCOPT using aspell with default dictionary
docopt-standard-input.el:42: Error checking word DOCOPT using aspell with default dictionary
docopt-standard-input.el:46: Error checking word DOCOPT using aspell with default dictionary
docopt-standard-input.el:54: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:44: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:118: Error checking word SHORTARG using aspell with default dictionary
docopt-transient.el:132: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:147: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:165: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:182: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:253: Error checking word S-EXPRS using aspell with default dictionary
docopt-transient.el:259: Error checking word S-EXPRS using aspell with default dictionary
docopt-transient.el:266: Error checking word S-EXPRS using aspell with default dictionary
docopt-transient.el:275: Error checking word S-EXPRS using aspell with default dictionary
docopt-transient.el:280: Error checking word S-EXPRS using aspell with default dictionary
docopt-transient.el:285: Error checking word S-EXPRS using aspell with default dictionary
docopt-transient.el:290: Error checking word S-EXPRS using aspell with default dictionary
docopt-transient.el:355: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:366: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:377: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:389: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:437: Error checking word DOCOPT using aspell with default dictionary
docopt-transient.el:476: Error checking word S-EXPRS using aspell with default dictionary
docopt-transient.el:492: Error checking word S-EXPRS using aspell with default dictionary
docopt-usage-pattern.el:74: Error checking word DOCOPT using aspell with default dictionary
docopt-usage-pattern.el:79: Error checking word DOCOPT using aspell with default dictionary
docopt-usage-pattern.el:91: Error checking word DOCOPT using aspell with default dictionary
docopt-usage-pattern.el:95: Error checking word DOCOPT using aspell with default dictionary
docopt-usage-pattern.el:99: Error checking word DOCOPT using aspell with default dictionary
docopt-usage-pattern.el:103: Error checking word DOCOPT using aspell with default dictionary
docopt-util.el:59: Error checking word DOCOPT using aspell with default dictionary
docopt.el:44: Error checking word DOCOPT using aspell with default dictionary
docopt.el:50: Error checking word DOCOPT using aspell with default dictionary
docopt.el:59: Error checking word DOCOPT using aspell with default dictionary
docopt.el:64: Error checking word DOCOPT using aspell with default dictionary
```
