### PR TITLE
ado-mode recipe added

### DIFF
--- a/recipes/ado-mode
+++ b/recipes/ado-mode
@@ -1,5 +1,4 @@
 (ado-mode
  :fetcher github
  :repo "louabill/ado-mode"
- :files ("lisp/*.el" "scripts" "syntax_testers" "templates"
-		 (:exclude ".DS_Store" "*/.DS_Store" "*/Scratch")))
+ :files ("lisp/*.el" "scripts" "templates"))

--- a/recipes/ado-mode
+++ b/recipes/ado-mode
@@ -1,0 +1,5 @@
+(ado-mode
+ :fetcher github
+ :repo "louabill/ado-mode"
+ :files ("lisp/*.el" "scripts" "syntax_testers" "templates"
+		 (:exclude ".DS_Store" "*/.DS_Store" "*/Scratch")))


### PR DESCRIPTION
### Brief summary of what the package does

Ado-mode is a major mode for editing all types Stata files (do, ado, mata, smcl, sthlp, etc.)

Ado-mode provides the following useful features:
* Context sensitive highlighting (aka font-locking) of Stata commands and common constructions within Stata. 
* Smart indentation based on nesting of blocks.
* Ability to send code from Emacs to Stata for execution.
* Autoupdate of timestamps.

The package has been in existence since 1996 and gets an update with every Stata release.

### Direct link to the package repository

https://github.com/louabill/ado-mode

### Your association with the package

I'm the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (mostly)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
- [x] I know that some of the code is likely to be crufty because the package 24 years old, and has had only one major overhaul.