### PR TITLE
Add recipe for ob-ess-julia

### DIFF
--- a/recipes/ob-ess-julia
+++ b/recipes/ob-ess-julia
@@ -1,0 +1,4 @@
+(ob-ess-julia
+ :fetcher github
+ :repo "frederic-santos/ob-ess-julia"
+ :files ("*.el" "*.jl"))


### PR DESCRIPTION
### Brief summary of what the package does

`ob-ess-julia` adds a lightweight support for Julia language with Org babel.

It is based on the orphaned package [`ob-julia`](https://github.com/gjkerns/ob-julia) by G. J. Kerns, and uses Emacs Speaks Statistics in the background.

An [example org file](https://github.com/frederic-santos/ob-ess-julia/blob/master/examples-ob-ess-julia.org) is available to test it (this obviously needs Julia to be installed).

### Direct link to the package repository

https://github.com/frederic-santos/ob-ess-julia

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Notes
#### Byte compile warnings

There are a few warnings about unused lisp variables, but they correspond to features still to be further implemented.

#### Package-lint warnings

There are numerous instances where `package-lint` complains about function names and their prefixes. They cannot be changed, since their name is imposed by `ob-core.el`.