### PR TITLE
Recipe: Add burly

### DIFF
--- a/recipes/burly
+++ b/recipes/burly
@@ -1,0 +1,1 @@
+(burly :fetcher github :repo "alphapapa/burly.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides tools to save and restore window configurations in Emacs, including buffers that may not be live anymore. In this way, it’s like a lightweight “workspace” manager, allowing you to easily restore a set of windows, their layout in a frame, and the buffers in them.

### Direct link to the package repository

https://github.com/alphapapa/burly.el

### Your association with the package

Author, maintainer, enthusiastic user.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
