### PR TITLE
Add tr-ime recipe

### DIFF
--- a/recipes/tr-ime
+++ b/recipes/tr-ime
@@ -1,0 +1,2 @@
+(tr-ime :fetcher github :repo "trueroad/tr-emacs-ime-module"
+	:files ("lisp/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Tr-ime emulates the C implementation part of an IME patch for GNU Emacs that allows to input Japanese using the Windows IME (Input Method Editor).

### Direct link to the package repository

https://github.com/trueroad/tr-emacs-ime-module

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
