### PR TITLE
Add recipe for org-latex-instant-preview

### DIFF
--- a/recipes/org-latex-impatient
+++ b/recipes/org-latex-impatient
@@ -1,0 +1,2 @@
+(org-latex-impatient :repo "yangsheng6810/org-latex-impatient"
+                           :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

It provides instant preview of LaTeX snippets in `org-mode` via MathJax outputed SVG

### Direct link to the package repository

https://github.com/yangsheng6810/org-latex-instant-preview

### Your association with the package

I am the maintainer 

### Relevant communications with the upstream package maintainer

None needed

### Checklist



Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

NOTE: Since `package-lint` is not compatible with `names`, a package I used for namespacing, I took the macro expanded version to run through `package-lint`. I received the following errors, which I think are all false positives.
```
11:36: error: Package names is not installable.
11:52: error: Package s is not installable.
11:64: error: Package posframe is not installable.
11:83: error: Package org is not installable.
11:95: error: Package dash is not installable.
34:4: error: Aliases should start with the package's prefix "org-latex-instant-preview".
39:0: error: "posframe-poshandler-point-window-center" doesn't start with package's prefix "org-latex-instant-preview".
```
Since package install works according to directions in CONTRIBUTING.org, I assume the first 5 errors are false positive. The error regarding alias is a workaround for a bug in `names`. The error regarding `posframe-poshandler-point-window-center` adds a function to show a posframe at some specific point. I have made a pull request regarding this function to `posframe.el`, which has been submitted and (partially) approved, but it is waiting for my FSF assignment before it can be merged. While we are waiting, I am adding a separate implementation, which will be removed once my pull request to `posframe` is merged.

