### PR TITLE
Update sql-sqlline

### DIFF
--- a/recipes/sql-sqlline
+++ b/recipes/sql-sqlline
@@ -1,4 +1,4 @@
 (sql-sqlline
  :fetcher gitlab
- :repo "matteo.redaelli/sql-sqlline"
+ :repo "matteoredaelli/sql-sqlline"
  :files ("artifacts/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Emacs comes with a SQL interpreter which is able to open a connection to databases and present you with a prompt you are probably familiar with (e.g. =mysql>=, =pgsql>=, etc.). But it cannot connect to less known databases like Amazon Athena, Amazon Redshift, (Facebook) PrestoDB,...

This mode gives you the ability to do that through SqlLine (https://github.com/julianhyde/sqlline) command

### Direct link to the package repository

https://gitlab.com/matteoredaelli/sql-sqlline 

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [ X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- X[ ] My elisp byte-compiles cleanly
- [ X] `M-x checkdoc` is happy with my docstrings
- [X ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
