### PR TITLE
Add recipe for vc-defer.

### DIFF
--- a/recipes/vc-defer
+++ b/recipes/vc-defer
@@ -1,0 +1,3 @@
+(vc-defer
+ :repo "google/vc-defer"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The Vc-Defer package aims to make Emacs faster by deferring
non-essential work related to Emacs' built in "VC" mode, with a
minimum negative impact. In particular, all VC commands should still
work normally when invoked explicitly, even in buffers that Emacs has
not yet determined the VC state for.

### Direct link to the package repository

https://github.com/google/vc-defer

### Your association with the package

I am the maintainer (not author) of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
