### PR TITLE
Switch to new fork for origami?

### DIFF
--- a/recipes/origami
+++ b/recipes/origami
@@ -1,1 +1,1 @@
-(origami :fetcher github :repo "gregsexton/origami.el")
+(origami :fetcher github :repo "jcs-elpa/origami.el")


### PR DESCRIPTION
Base on the thread here #6716; I would like to take over [origami](https://github.com/gregsexton/origami.el) (if @gregsexton agreed?).

I have started a fork here [jcs-elpa/origami.el](https://github.com/jcs-elpa/origami.el). I consider this as a much updated version due to that I have been fixing bug and clean up the code for few weeks. And it has new features and supports more programming languages by default.