### PR TITLE
Rename auth-source-pass git repository

### DIFF
--- a/recipes/auth-source-pass
+++ b/recipes/auth-source-pass
@@ -1,4 +1,4 @@
 (auth-source-pass
  :fetcher github
- :repo "DamienCassou/auth-password-store"
+ :repo "DamienCassou/auth-source-pass"
  :old-names (auth-password-store))


### PR DESCRIPTION
I renamed the repository of auth-source-pass from https://github.com/DamienCassou/auth-password-store (the former name of the project) to https://github.com/DamienCassou/auth-source-pass. The first one redirects to the new one but there is no reason to keep using the old name in Melpa.