### PR TITLE
Switch gemini-mode to https transport

### DIFF
--- a/recipes/gemini-mode
+++ b/recipes/gemini-mode
@@ -1,3 +1,3 @@
 (gemini-mode
  :fetcher git
- :url "http://git.carcosa.net/jmcbray/gemini.el.git")
+ :url "https://git.carcosa.net/jmcbray/gemini.el.git")


### PR DESCRIPTION
See #3004.


### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them