### PR TITLE
Remove lsp-scala

### DIFF
--- a/recipes/lsp-scala
+++ b/recipes/lsp-scala
@@ -1,1 +1,0 @@
-(lsp-scala :repo "rossabaker/lsp-scala" :fetcher github)


### PR DESCRIPTION
In response to #7225. The functionality of this packages lives on as [lsp-metals](https://github.com/emacs-lsp/lsp-metals).
