### PR TITLE
Switch eshell-outline to https transport

### DIFF
--- a/recipes/eshell-outline
+++ b/recipes/eshell-outline
@@ -1,1 +1,1 @@
-(eshell-outline :fetcher git :url "git://jamzattack.xyz/eshell-outline.git")
+(eshell-outline :fetcher git :url "https://git.jamzattack.xyz/eshell-outline")


### PR DESCRIPTION
See #3004.  Thanks @jamzattack for enabling this!

### Direct link to the package repository

https://git.jamzattack.xyz/eshell-outline/

### Relevant communications with the upstream package maintainer

See https://github.com/melpa/melpa/issues/3004#issuecomment-727154038.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them