### PR TITLE
Add recipe for covid

### DIFF
--- a/recipes/covid
+++ b/recipes/covid
@@ -1,0 +1,1 @@
+(covid :fetcher github :repo "falloutphil/covid")


### PR DESCRIPTION
### Brief summary of what the package does
The package provides an interactive command for downloading latest WHO data for a specific country and then doing the standardized 7 and 14 day cumulative metric calculations over a specified date range.
The WHO data is then tabulated and graphed alongside the calculated metrics in Org and (optionally) GnuPlot

### Direct link to the package repository

https://github.com/falloutphil/covid

### Your association with the package

Sole author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

