### PR TITLE
Add utimeclock package

### DIFF
--- a/recipes/utimeclock
+++ b/recipes/utimeclock
@@ -1,0 +1,3 @@
+(utimeclock
+ :repo "ideasman42/emacs-utimeclock"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Track time spent on a task, without needing it's own major mode (intended to be used with other major modes).

Unlike other time tracking options such as ORG's agenda or clock-table, this is very short, where a days work easily fits in a single line, e.g.

`time: 9:00-12:05 1:30-2:00 2:05-5:56`

This package provides a function to clock on/off and return the total time (as well as accumulate all times in the buffer).

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-utimeclock

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

None.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
