### PR TITLE
Add pikchr-mode recipe

### DIFF
--- a/recipes/pikchr-mode
+++ b/recipes/pikchr-mode
@@ -1,0 +1,2 @@
+(pikchr-mode :fetcher github
+             :repo "kljohann/pikchr-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This package adds a major mode with syntax highlighting for the [pikchr](https://pikchr.org) diagram markup language.

### Direct link to the package repository

https://github.com/kljohann/pikchr-mode

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them