### PR TITLE
Remove archived iy-go-to-char

### DIFF
--- a/recipes/iy-go-to-char
+++ b/recipes/iy-go-to-char
@@ -1,1 +1,0 @@
-(iy-go-to-char :fetcher github :repo "doitian/iy-go-to-char")


### PR DESCRIPTION
The repo is unmaintained and has been archived.

See also https://github.com/melpa/melpa/issues/7225
