### PR TITLE
Add elegant-agenda-mode

### DIFF
--- a/recipes/elegant-agenda-mode
+++ b/recipes/elegant-agenda-mode
@@ -1,0 +1,2 @@
+(elegant-agenda-mode :repo "justinbarclay/elegant-agenda-mode"
+                     :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

elegant-org-agenda is a theme, of sorts, for org-agenda that overrides some fonts and typefaces to create an elegant looking agenda.

### Direct link to the package repository

https://github.com/justinbarclay/elegant-agenda-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them


### Additional
For what it's worth I've also set-up [melpazoid](https://github.com/justinbarclay/elegant-agenda-mode/runs/1416134117) to verify linting rules are maintained.