### PR TITLE
Add recipe for license-snippets

### DIFF
--- a/recipes/license-snippets
+++ b/recipes/license-snippets
@@ -1,0 +1,4 @@
+(license-snippets
+ :repo "sei40kr/license-snippets"
+ :fetcher github
+ :files (:defaults "snippets"))


### PR DESCRIPTION
### Brief summary of what the package does

LICENSE templates for yasnippet.

### Direct link to the package repository

https://github.com/sei40kr/license-snippets

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
