### PR TITLE
Add recipe for flycheck-cpplint

### DIFF
--- a/recipes/flycheck-cpplint
+++ b/recipes/flycheck-cpplint
@@ -1,0 +1,1 @@
+(flycheck-cpplint :repo "terzievk/flycheck-cpplint" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Add cpplint to flycheck. Cpplint is a static C/C++ code checker based on google's c/c++ style guide.
Cpplint is actively maintained and can be found here:
https://github.com/cpplint/cpplint

### Relevant communications with the upstream package maintainer


There is a compatibility problem between flycheck and cpplint. Cpplint uses the current file name to create header guard warnings, but flycheck uses temporary files when calling the linter. I came up with two workarounds:
- use source-original instead of source (however this is not practical since it severely hinders the flycheck performance and works only when the file is saved after each edit)
- use cpplint with the option "--filter=-build/header_guard" to disable header guard warnings (however this compromises the integrity of the linter)

Neither of the solutions is acceptable, so I am closing this pr...
