### PR TITLE
Add recipe for ll-debug

### DIFF
--- a/recipes/ll-debug
+++ b/recipes/ll-debug
@@ -1,0 +1,2 @@
+(ll-debug :repo "black7375/ll-debug" :fetcher github)
+


### PR DESCRIPTION
### Brief summary of what the package does

Low level debug tools.
- Region toggle to Comment
- Add debug Message(Format: `(message "logging %S" foo)`)

### Direct link to the package repository

https://github.com/black7375/ll-debug

### Your association with the package
- An enthusiastic user

It's the first time I've found it on a emacs wiki([Debugging With Emacs](https://www.emacswiki.org/emacs/DebuggingWithEmacs)).
Homepage: www.cbrunzema.de/software.html#ll-debug

However, since 2004, there has been no update, so there is a deprecated API, and I fixed it.
And I'll try to add new feature.

Currently, only API has been modified.

### Relevant communications with the upstream package maintainer

It has not been uploaded to the store.

![image](https://user-images.githubusercontent.com/25581533/100142216-713bac00-2e8b-11eb-9a93-339d4f6a1172.png)

I sent him an e-mail.
I want to register if there is an answer that him allow or if there is no reception for a long time.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings:
```
Level: info
Keycode C-v embedded in doc string. Use \\<Keymap> & \\[function] instead
Keycode C-u embedded in doc string. Use \\<Keymap> & \\[function] instead
```
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
