### PR TITLE
Add explanation of how review time is divided between pull requests

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -240,7 +240,9 @@ this process.
 MELPA maintainers spend a lot of time reviewing proposed packages and
 also have quite a lot of other non-MELPA-related activities. Please be
 patient as it might take a week (sometimes several) before one starts
-having a look at your pull request. 
+having a look at your pull request. Also be aware that the maintainers
+try to divide reviewing time fairly between authors; you can help them
+by limiting the number of pull requests you have open at once.
 
 If you were asked to make several changes, then you should explicitly
 mention everything that you have fixed, and possibly even link to the


### PR DESCRIPTION
As mentioned [here](https://github.com/melpa/melpa/pull/7096), I'm attempting to divide review time between authors, which affects some of our contributors with lots of pull requests open.

I didn't put a hard number down because I think it varies by case.  Personally I'd like to push the logistics back onto authors and see only one open _recipe_ PR per person at a time.  @jcs090218, mentioning you here since this is affecting you visibly.