### PR TITLE
add consult

### DIFF
--- a/recipes/consult
+++ b/recipes/consult
@@ -1,0 +1,3 @@
+(consult
+ :repo "minad/consult"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides various commands based on completing-read: consult-buffer (buffer/recent file switching), consult-line (swiper-like search), consult-mark (select from the mark ring), ... It is meant to be used together with icomplete/selectrum as a substitute for ivy/counsel.

### Direct link to the package repository

https://github.com/minad/consult

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
