### PR TITLE
Add recipe for org-z

### DIFF
--- a/recipes/org-z
+++ b/recipes/org-z
@@ -1,0 +1,2 @@
+(org-z :fetcher github
+       :repo "landakram/org-z")


### PR DESCRIPTION
### Brief summary of what the package does

org-z is an global minor mode that enables a lightweight, Org mode style zettelkasten. Unlike a traditional zettelkasten, org-z focuses on headings rather than pages, allowing you to make hyperlinks within a single Org mode document.

### Direct link to the package repository

https://github.com/landakram/org-z

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
