### PR TITLE
add new recipe for ll-debug (https://github.com/replrep/ll-debug)

### DIFF
--- a/recipes/ll-debug
+++ b/recipes/ll-debug
@@ -1,0 +1,2 @@
+(ll-debug :fetcher github
+          :repo "replrep/ll-debug")


### PR DESCRIPTION
### Brief summary of what the package does
ll-debug provides functions to quickly insert unique debug statements for various languages ("printf-style" low level debugging when a debugger is not available or not practical). Additionally there are some functions for generating statements printing values of variables and for dwim-style commenting/uncommenting. Currently supported languages are scheme, common lisp, emacs lisp, perl, c, c++, java, ruby, shell, octave, javascript/typescript and clojure.

### Direct link to the package repository
https://github.com/replrep/ll-debug

### Your association with the package
I am the author and maintainer.

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings *PLEASE SEE COMMENT BELOW*
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

checkdoc complains about mentioning "C-v" in the docstring for ll-debug-install-suggested-keybindings. I think that is ok because this function remaps C-v to be a prefix key that is unrelated to the original binding. This is only done on explicit user demand.