### PR TITLE
Add metal-archives-shopping-list recipe

### DIFF
--- a/recipes/metal-archives-shopping-list
+++ b/recipes/metal-archives-shopping-list
@@ -1,0 +1,1 @@
+(metal-archives-shopping-list :fetcher github :repo "seblemaguer/metal-archives.el" :files ("metal-archives-shopping-list.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Package to generate a shopping list (org file) using the Metal-Archives (http://metal-archives.com/) API

### Direct link to the package repository

https://github.com/seblemaguer/metal-archives.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
