### PR TITLE
org-tree-slide-pauses recipe

### DIFF
--- a/recipes/org-tree-slide-pauses
+++ b/recipes/org-tree-slide-pauses
@@ -1,0 +1,1 @@
+(org-tree-slide-pauses :fetcher github :repo "cnngimenez/org-tree-slide-pauses")


### PR DESCRIPTION
### Brief summary of what the package does

Provide `\pause` Beamer-like commands to org-tree-slide. When the presentation starts, it shadows the text between pauses and show it one by one with the typical C-> (M-x `org-tree-slide-move-next-tree`) for easy explanation. 
Org-mode list are also supported automatically!

### Direct link to the package repository

https://github.com/cnngimenez/org-tree-slide-pauses

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
