### PR TITLE
Add helm-switch-to-repl

### DIFF
--- a/recipes/helm-switch-to-repl
+++ b/recipes/helm-switch-to-repl
@@ -1,0 +1,2 @@
+(helm-switch-to-repl :fetcher github
+                     :repo "emacs-helm/helm-switch-to-repl")


### PR DESCRIPTION
### Brief summary of what the package does

Helm action to switch directory in various REPLs.

### Direct link to the package repository

https://github.com/emacs-helm/helm-switch-to-repl

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [-] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  It mistakenly complains about methods having the wrong prefix, besides that all good.
- [x] My elisp byte-compiles cleanly
- [-] `M-x checkdoc` is happy with my docstrings
  Docstrings in specialized methods are useless, so I chose to ignore those.  `checkdoc` complains that `helm-type-file` is ambiguous because it does not know what a "Helm source" is.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
