### PR TITLE
Explicitly set branch for leo package to main

### DIFF
--- a/recipes/leo
+++ b/recipes/leo
@@ -1,1 +1,1 @@
-(leo :repo "mtenders/emacs-leo" :fetcher github)
+(leo :repo "mtenders/emacs-leo" :fetcher github :branch "main")


### PR DESCRIPTION
I explicitly set the branch of `leo` to `main`, because e.g. `straight.el `defaults to `master`.