### PR TITLE
Add default-font-presets package

### DIFF
--- a/recipes/default-font-presets
+++ b/recipes/default-font-presets
@@ -1,0 +1,3 @@
+(default-font-presets
+ :repo "ideasman42/emacs-default-font-presets"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This package supports user-defined list of font presets.

This is useful since listing all available font's isn't especially useful, developers may want to switch between a handful of high-quality mono-spaced fonts for example.

Functionality:

- Cycle next/previous font.
- Select the font preset (choice or ivy when it's installed).
- Scale the current font.

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-default-font-presets

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
