### PR TITLE
AWS Cloudformation mode

### DIFF
--- a/recipes/cfn-mode
+++ b/recipes/cfn-mode
@@ -1,0 +1,7 @@
+(cfn-mode
+ :fetcher gitlab
+ :repo "worr/cfn-mode"
+ :version-regexp "cfn-mode/v\\(.+\\)"
+ :files ("cfn-mode/cfn-mode.el"
+         "cfn-mode/cfn-properties.dat"
+         "cfn-mode/cfn-resources.dat"))

--- a/recipes/flycheck-cfn
+++ b/recipes/flycheck-cfn
@@ -1,0 +1,5 @@
+(flycheck-cfn
+ :fetcher gitlab
+ :repo "worr/cfn-mode"
+ :version-regexp "flycheck-cfn/v\\(.+\\)"
+ :files ("flycheck-cfn/flycheck-cfn.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`cfn-mode` provides basic support for additional syntax highlighting and functionality on top of `yaml-mode` for AWS Cloudformation templates. `flycheck-cfn` augments this by adding checkers for the 2 of the big open source linters, `cfn-lint` and `cfn_nag`.

### Direct link to the package repository

https://gitlab.com/worr/cfn-mode/

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
