### PR TITLE
Fix org-treeusage repo after repo rename

### DIFF
--- a/recipes/org-treeusage
+++ b/recipes/org-treeusage
@@ -1,1 +1,1 @@
-(org-treeusage :fetcher gitlab :repo "mtekman/org-treeusage-el")
+(org-treeusage :fetcher gitlab :repo "mtekman/org-treeusage.el")


### PR DESCRIPTION
### Brief summary of what the package does

Performs an `ncdu`-like operation on an org-mode document.

This PR simply renames the old  "org-treeusage-el" to "org-treeusage.el" after a change of the repository path

Related to https://github.com/melpa/melpa/commit/2db07414d2d39b2d40a2ae91491032844b82d801#commitcomment-44832349

### Direct link to the package repository

https://gitlab.com/mtekman/org-treeusage.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

