### PR TITLE
Add planemo-mode

### DIFF
--- a/recipes/planemo-mode
+++ b/recipes/planemo-mode
@@ -1,0 +1,1 @@
+(planemo-mode :fetcher gitlab :repo "mtekman/planemo-mode.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a minor mode for developing tool wrappers for the [GalaxyProject](https://galaxyproject.eu/), which makes use of a [specific XML-based schema](https://docs.galaxyproject.org/en/master/dev/schema.html) in conjunction with the [Cheetah template engine](https://cheetahtemplate.org/).

The mode brings Bash and Cheetah fontification (inspired by the [Cheetah Mode](https://www.emacswiki.org/emacs/CheetahMode) in the Emacs Wiki) and indentation functions. 

### Direct link to the package repository

https://gitlab.com/mtekman/planemo-mode.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
