### PR TITLE
Restore wisp-mode and update url to hg.sr.ht

### DIFF
--- a/recipes/wisp-mode
+++ b/recipes/wisp-mode
@@ -1,1 +1,1 @@
-(wisp-mode :fetcher hg :url "https://hg.sr.ht/~arnebab/wisp")
+(wisp-mode :fetcher hg :url "https://hg.sr.ht/~arnebab/wisp" :files ("wisp-mode.el"))

--- a/recipes/wisp-mode
+++ b/recipes/wisp-mode
@@ -1,0 +1,1 @@
+(wisp-mode :fetcher hg :url "https://hg.sr.ht/~arnebab/wisp")


### PR DESCRIPTION
Wisp mode was removed in commit 6d7595adb2a4b762fd5a320cc31e253fedee28c1 because the bitbucket repos were killed by bitbucket. wisp-mode moved to hg.sr.ht; this reflects the change.

### Brief summary of what the package does

wisp-mode provides highlighting and editing support for wisp-files. See https://www.draketo.de/english/wisp

### Direct link to the package repository

https://hg.sr.ht/~arnebab/wisp

### Your association with the package

Creator and maintainer

### Relevant communications with the upstream package maintainer

Restores the package.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
