### PR TITLE
Fix leuven-theme

### DIFF
--- a/recipes/leuven-theme
+++ b/recipes/leuven-theme
@@ -1,3 +1,4 @@
 (leuven-theme
  :fetcher github
- :repo "fniessen/emacs-leuven-theme")
+ :repo "fniessen/emacs-leuven-theme"
+ :files ("lisp/*.el"))


### PR DESCRIPTION
.el files moved to lisp/ subdirectory.

### Direct link to the package repository

https://github.com/fniessen/emacs-leuven-theme/

### Your association with the package

Friend: see https://github.com/fniessen/emacs-leuven-theme/issues/80

### Checklist

Please confirm with `x`:

- ~[ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).~
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- ~[ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback~
- ~[ ] My elisp byte-compiles cleanly~
- ~[ ] `M-x checkdoc` is happy with my docstrings~
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
