### PR TITLE
Add devdocs-lookup

### DIFF
--- a/recipes/devdocs-lookup
+++ b/recipes/devdocs-lookup
@@ -1,0 +1,1 @@
+(devdocs-lookup :fetcher github :repo "skeeto/devdocs-lookup")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides an interactive function devdocs-lookup to quickly jump to documentation on a particular API at devdocs.io with your browser.

### Direct link to the package repository

https://github.com/skeeto/devdocs-lookup

### Your association with the package

User

### Relevant communications with the upstream package maintainer

https://github.com/skeeto/devdocs-lookup/issues/11

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
