### PR TITLE
split consult package

### DIFF
--- a/recipes/consult
+++ b/recipes/consult
@@ -1,3 +1,4 @@
 (consult
  :repo "minad/consult"
- :fetcher github)
+ :fetcher github
+ :files ("consult.el"))

--- a/recipes/consult-flycheck
+++ b/recipes/consult-flycheck
@@ -1,0 +1,4 @@
+(consult-flycheck
+ :repo "minad/consult"
+ :fetcher github
+ :files ("consult-flycheck.el"))

--- a/recipes/consult-selectrum
+++ b/recipes/consult-selectrum
@@ -1,0 +1,4 @@
+(consult-selectrum
+ :repo "minad/consult"
+ :fetcher github
+ :files ("consult-selectrum.el"))


### PR DESCRIPTION
### Brief summary of what the package does
The consult package has been split after discussion with @purcell, such that the main consult.el package only depends on Emacs core components, see https://github.com/minad/consult/pull/53 and https://github.com/minad/consult/pull/54.

### Direct link to the package repository

https://github.com/minad/consult

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
