### PR TITLE
Add kwallet-auth-source package

### DIFF
--- a/recipes/auth-source-kwallet
+++ b/recipes/auth-source-kwallet
@@ -1,0 +1,1 @@
+(auth-source-kwallet :fetcher github :repo "vaartis/auth-source-kwallet")


### PR DESCRIPTION
### Brief summary of what the package does

A small package I wrote that allows to use KWallet as an auth-source.

### Direct link to the package repository

https://github.com/vaartis/auth-source-kwallet

### Your association with the package

I'm the maintainer / creator of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
