### PR TITLE
Update spray recipe

### DIFF
--- a/recipes/spray
+++ b/recipes/spray
@@ -1,3 +1,3 @@
 (spray
- :repo "iankelling/spray"
- :fetcher gitlab)
+ :url "https://git.sr.ht/~iank/spray"
+ :fetcher git)


### PR DESCRIPTION
spray's current recipe will fail to build anything, as the gitlab repository now just hosts a migration notice:

https://gitlab.com/iankelling/spray

I've contacted the author on the mailing list at the new forge:

https://lists.sr.ht/~iank/spray/%3C87zh2mkftq.fsf%40gmail.com%3E
