### PR TITLE
Accomodate olav35 changing name to fossegrim

### DIFF
--- a/recipes/eradio
+++ b/recipes/eradio
@@ -1,3 +1,3 @@
 (eradio
  :fetcher github
- :repo "olav35/eradio")
+ :repo "fossegrim/eradio")


### PR DESCRIPTION
For proof that fossegrim is olav35, see https://github.com/olav35 and
https://github.com/fossegrim.