### PR TITLE
add tree-sitter-indent to melpa

### DIFF
--- a/recipes/tree-sitter-indent
+++ b/recipes/tree-sitter-indent
@@ -1,0 +1,3 @@
+(tree-sitter-indent :fetcher git
+                    :url "https://codeberg.org/FelipeLema/tree-sitter-indent.el.git"
+                    :branch "main")

--- a/recipes/tree-sitter-indent
+++ b/recipes/tree-sitter-indent
@@ -1,3 +1,2 @@
 (tree-sitter-indent :fetcher git
-                    :url "https://codeberg.org/FelipeLema/tree-sitter-indent.el.git"
-                    :branch "main")
+                    :url "https://codeberg.org/FelipeLema/tree-sitter-indent.el.git")


### PR DESCRIPTION
### Brief summary of what the package does

Use Tree-sitter as backend to source code indentation.

### Direct link to the package repository

https://codeberg.org/FelipeLema/tree-sitter-indent.el

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

CC'ing @theothornhill because "they made me do this"