### PR TITLE
Add recipe for indent-control

### DIFF
--- a/recipes/indent-control
+++ b/recipes/indent-control
@@ -1,0 +1,1 @@
+(indent-control :repo "jcs-elpa/indent-control" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package combine all indentation into a giant list. So user can manages the indentation for each major mode a bit easier to one interface. Another feature is the package records down the previous edited indentation level and it keeps it to all other buffers.

### Direct link to the package repository

https://github.com/jcs-elpa/indent-control

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
