### PR TITLE
Add xref-rst package

### DIFF
--- a/recipes/xref-rst
+++ b/recipes/xref-rst
@@ -1,0 +1,3 @@
+(xref-rst
+ :repo "ideasman42/emacs-xref-rst"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This package supports looking up references in reStructuredText multi-file projects (`ref`, `term`, `doc` & file references).

This is useful for quickly navigating between sections in large, cross referenced manuals for example

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-xref-rst

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
