### PR TITLE
Add einkless-theme

### DIFF
--- a/recipes/einkless-theme
+++ b/recipes/einkless-theme
@@ -1,0 +1,4 @@
+(einkless-theme
+  :fetcher git
+  :url "https://git.sr.ht/~lthms/colorless-themes.el"
+  :files ("einkless-theme.el"))


### PR DESCRIPTION
### Brief summary of what the package does

After [nordless](https://github.com/melpa/melpa/pull/5269) and [lavenderless](https://github.com/melpa/melpa/pull/6686), we propose to add to Melpa `einkless`, a light-theme inspired by eink and built with the `colorless-themes` macro. Compare to nordless and lavenderless, einkless is light and monochrome.

### Direct link to the package repository

https://git.sr.ht/~lthms/colorless-themes.el

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
