### PR TITLE
Add darkless-theme

### DIFF
--- a/recipes/darkless-theme
+++ b/recipes/darkless-theme
@@ -1,0 +1,4 @@
+(darkless-theme
+  :fetcher git
+  :url "https://git.sr.ht/~lthms/colorless-themes.el"
+  :files ("darkless-theme.el"))


### PR DESCRIPTION
### Brief summary of what the package does

After [nordless](https://github.com/melpa/melpa/pull/5269) and [lavenderless](https://github.com/melpa/melpa/pull/6686), we propose to add to Melpa `darkless`, a gray scale theme built with the `colorless-themes` macro. Compare to nordless and lavenderless, darkless is monochrome.

### Direct link to the package repository

https://git.sr.ht/~lthms/colorless-themes.el

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
