### PR TITLE
Switch visible-mark to new sr.ht location

### DIFF
--- a/recipes/visible-mark
+++ b/recipes/visible-mark
@@ -1,3 +1,3 @@
 (visible-mark
- :repo "iankelling/visible-mark"
- :fetcher gitlab)
+ :url "https://git.sr.ht/~iank/visible-mark"
+ :fetcher git)


### PR DESCRIPTION
The author has moved visible-mark to https://sr.ht/~iank/visible-mark/ as can be seen from:

https://gitlab.com/iankelling/visible-mark/-/commit/93a745c085b56aa4c75875b361445cbb62fe8880