### PR TITLE
Add recipe for ob-reticulate

### DIFF
--- a/recipes/ob-reticulate
+++ b/recipes/ob-reticulate
@@ -1,0 +1,1 @@
+(ob-reticulate :fetcher github :repo "jackkamm/ob-reticulate")


### PR DESCRIPTION
### Brief summary of what the package does

Integrates the R reticulate package with Org Babel (specifically, ob-R and ob-python). This allows executing python code, and accessing the results, from within an R session.

### Direct link to the package repository

https://github.com/jackkamm/ob-reticulate

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
