### PR TITLE
Recipe: Add scrollable-quick-peek

### DIFF
--- a/recipes/scrollable-quick-peek
+++ b/recipes/scrollable-quick-peek
@@ -1,0 +1,1 @@
+(scrollable-quick-peek :repo "jpablobr/scrollable-quick-peek" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

 This package adds the command `scrollable-quick-peek-show' which extends [quick-peek-show](https://github.com/cpitclaudel/quick-peek) to allow for scrolling within the quick-peek overlay.

### Direct link to the package repository

https://github.com/jpablobr/scrollable-quick-peek

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
