### PR TITLE
Add recipe for code-cells

### DIFF
--- a/recipes/cells
+++ b/recipes/cells
@@ -1,1 +1,0 @@
-(cells :fetcher github :repo "astoff/cells.el")

--- a/recipes/cells
+++ b/recipes/cells
@@ -1,0 +1,1 @@
+(cells :fetcher github :repo "astoff/cells.el")

--- a/recipes/code-cells
+++ b/recipes/code-cells
@@ -1,0 +1,1 @@
+(code-cells :fetcher github :repo "astoff/code-cells.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package does two related but technically independent things. First, it provides utilities to edit code split into cells, like the python-cell package already does, but in a language-independent way.

The second function is to allow editing Jupyter (ipynb) notebooks. These are JSON files, and the package installs a major-mode-alist entry to convert them to a regular script (using an external tool) when the file is opened, and back to ipynb format when saving.

### Direct link to the package repository

https://github.com/astoff/cells.el/

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
    - I get the warning `cells.el:107:1:Warning: Unused lexical variable ‘using-region’`, but this is exactly what I want to do. That variable is supposed to be available to the user inside a macro body.

- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
