### PR TITLE
Add recipe for show-font-mode

### DIFF
--- a/recipes/show-font-mode
+++ b/recipes/show-font-mode
@@ -1,0 +1,3 @@
+(show-font-mode
+ :fetcher github
+ :repo "melissaboiko/show-font-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Show low-level selected font at point on mode line; show properties such as pixel width; colorise buffer to highlight different fontset choices.

### Direct link to the package repository

https://github.com/melissaboiko/show-font-mode

### Your association with the package

authoress

### Relevant communications with the upstream package maintainer
none

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
