### PR TITLE
add virtual-comment

### DIFF
--- a/recipes/virtual-comment
+++ b/recipes/virtual-comment
@@ -1,0 +1,1 @@
+(virtual-comment :fetcher github :repo "thanhvg/emacs-virtual-comment")


### PR DESCRIPTION
### Brief summary of what the package does
This package allows adding virtual comments to files in buffers. These comments
don't belong to the files so they don't. They are saved in project root or a
global file which can be viewed and searched. The file name is `.evc`.

### Direct link to the package repository

https://github.com/thanhvg/emacs-virtual-comment

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

Non needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
