### PR TITLE
Add recipe for org-pandoc-import

### DIFF
--- a/recipes/org-pandoc-import
+++ b/recipes/org-pandoc-import
@@ -1,0 +1,1 @@
+(org-pandoc-import :repo "tecosaur/org-pandoc-import" :fetcher github :files ("*.el" "filters/*" "preprocessors/*"))


### PR DESCRIPTION
### Brief summary of what the package does

Leverage Pandoc to convert non-org formats to org, and supplies a minor mode to do
on-the-fly conversion transparently and automatically, exporting to the original format on save.

### Direct link to the package

https://github.com/tecosaur/org-pandoc-import

### Your association with the package

Maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them