### PR TITLE
Update dashboard-ls repo link.

### DIFF
--- a/recipes/dashboard-ls
+++ b/recipes/dashboard-ls
@@ -1,1 +1,1 @@
-(dashboard-ls :repo "jcs-elpa/dashboard-ls" :fetcher github)
+(dashboard-ls :repo "emacs-dashboard/dashboard-ls" :fetcher github)


### PR DESCRIPTION
I have transferred `dashboard-ls` to `emacs-dashboard` organization. Update the URL to the new location.