### PR TITLE
eglot-fsharp: Split fsharp-mode package

### DIFF
--- a/recipes/eglot-fsharp
+++ b/recipes/eglot-fsharp
@@ -1,0 +1,3 @@
+(eglot-fsharp :fetcher github
+	      :repo "fsharp/emacs-fsharp-mode"
+	      :files ("eglot-fsharp.el"))


### PR DESCRIPTION
Add `eglot-fsharp` package so that users who only need the basic
functionality of `fsharp-mode` or use `lsp-mode` don't have to install
the `eglot` dependency.

[https://github.com/fsharp/emacs-fsharp-mode/pull/253](https://github.com/fsharp/emacs-fsharp-mode/pull/253)

I will submit the removal of `fsharp-mode` `eglot` dependency in  https://melpa.org/#/fsharp-mode via a subsequent PR.

This is not a new package. I am preparing the split of the existing `fsharp-mode` package so that users of `eglot` can still use `lsp` support via this melpa package.