### PR TITLE
Update helm-searcher repo link

### DIFF
--- a/recipes/helm-searcher
+++ b/recipes/helm-searcher
@@ -1,1 +1,1 @@
-(helm-searcher :repo "jcs-elpa/helm-searcher" :fetcher github)
+(helm-searcher :repo "emacs-helm/helm-searcher" :fetcher github)


### PR DESCRIPTION
I have transferred [helm-searcher](https://github.com/emacs-helm/helm-searcher) to [emacs-helm](https://github.com/emacs-helm) organization. Update the URL to the new location.