### PR TITLE
Add recipe for run-command

### DIFF
--- a/recipes/run-command
+++ b/recipes/run-command
@@ -1,0 +1,2 @@
+(run-command :fetcher github
+             :repo "bard/emacs-run-command")


### PR DESCRIPTION
### Brief summary of what the package does

Allows picking (via Helm or Ivy) external commands from dynamic, context-dependent lists, and running them via `compile'.

### Direct link to the package repository

https://github.com/bard/emacs-run-command

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
