### PR TITLE
Fix upstream url of flycheck-grammalecte

### DIFF
--- a/recipes/flycheck-grammalecte
+++ b/recipes/flycheck-grammalecte
@@ -1,4 +1,4 @@
 (flycheck-grammalecte
  :fetcher git
- :url "https://git.deparis.io/flycheck-grammalecte/"
+ :url "https://git.umaneti.net/flycheck-grammalecte/"
  :files (:defaults "flycheck-grammalecte.py" "conjugueur.py"))


### PR DESCRIPTION
### Brief summary of what this MR does

I change my own git repositories domain name recently. This MR reflect this change for the upstream URL of the package `flycheck-grammalecte`

### Direct link to the package repository

https://git.umaneti.net/flycheck-grammalecte/

### Your association with the package

I’m the current maintainer

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I have confirmed some of these without doing them
