### PR TITLE
Recipe for the “holy-books” package

### DIFF
--- a/recipes/holy-books
+++ b/recipes/holy-books
@@ -1,0 +1,1 @@
+    (holy-books :fetcher github :repo "alhassy/holy-books")


### PR DESCRIPTION
### Brief summary of what the package does

Provide Org-mode links, tooltips, and Lisp look-ups for the Quran & the Bible.

For example,

    Sometimes I start a task with the Lord's name--- basmala:darkgreen|20px|span
     ---which means quran:1:1|darkgreen.  My friends like to say bible:Genesis:1:3|darkblue.

Upon HTML export, the links are replaced by the requested verses.
Example resulting export can be found at https://alhassy.github.io/holy-books/

### Direct link to the package repository

https://github.com/alhassy/holy-books

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
