### PR TITLE
Update recipe for embark to include texinfo manual

### DIFF
--- a/recipes/embark
+++ b/recipes/embark
@@ -1,3 +1,3 @@
 (embark :repo "oantolin/embark"
         :fetcher github
-        :files ("embark.el"))
+        :files ("embark.el" "embark.texi"))


### PR DESCRIPTION
This is a simple change to the recipe to include the texinfo manual. (I specify `:files`, because this repo also houses one more small embark related package, and I might add other small embark related packages in the future.)