### PR TITLE
Add package org-tag-beautify

### DIFF
--- a/recipes/org-tag-beautify
+++ b/recipes/org-tag-beautify
@@ -1,4 +1,1 @@
-(org-tag-beautify
- :repo "stardiviner/org-tag-beautify"
- :fetcher github
- :files (:defaults "data/*"))
+(org-tag-beautify :repo "stardiviner/org-tag-beautify" :fetcher github)

--- a/recipes/org-tag-beautify
+++ b/recipes/org-tag-beautify
@@ -1,0 +1,4 @@
+(org-tag-beautify
+ :repo "stardiviner/org-tag-beautify"
+ :fetcher github
+ :files (:defaults "data/*"))


### PR DESCRIPTION
### Brief summary of what the package does

This package use org-pretty-tags to prettify Org tags with icons or images.

### Direct link to the package repository

https://github.com/stardiviner/org-tag-beautify

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**No needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
