### PR TITLE
Add recipe for avy-embark-collect

### DIFF
--- a/recipes/avy-embark-collect
+++ b/recipes/avy-embark-collect
@@ -1,0 +1,3 @@
+(avy-embark-collect :repo "oantolin/embark"
+                    :fetcher github
+                    :files ("avy-embark-collect.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Uses avy to jump to entries in an Embark collect buffer (those collect, for example, all minibuffer completions in a single buffer where they can be examined at leisure and actions can be run on them).  This is only of interest to users of the Embark package.

### Direct link to the package repository

https://github.com/oantolin/embark

### Your association with the package

Package maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
