### PR TITLE
Add recipe for embark-consult

### DIFF
--- a/recipes/embark-consult
+++ b/recipes/embark-consult
@@ -1,0 +1,3 @@
+(embark-consult :repo "oantolin/embark"
+                :fetcher github
+                :files ("embark-consult.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Provides Consult integration for Embark.

Consult provides a series of command that use completing-read as the main component of their UI, for example it includes a `consult-line` command similar to the famous `swiper` command.

Embark provides a convenient way to run arbitrary commands passing minibuffer completions as arguments to them, for example you could run describe-function on a command you are typing at the M-x prompt. It also has commands to collect all minibuffer completions into a dedicated buffer where you can act on them in many ways.

This package currently provides a command to trigger Consult's notion of "preview" from an Embark Collect buffer, and a minor mode do this automatically as you move around the Embark Collect buffer. Embark already contains some Consult-specific configuration, which would eventually be moved to this package.

### Direct link to the package repository

https://github.com/oantolin/embark

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
