### PR TITLE
Remove consult-selectrum

### DIFF
--- a/recipes/consult
+++ b/recipes/consult
@@ -1,4 +1,4 @@
 (consult
  :repo "minad/consult"
  :fetcher github
- :files (:defaults (:exclude "consult-flycheck.el" "consult-selectrum.el")))
+ :files (:defaults (:exclude "consult-flycheck.el")))

--- a/recipes/consult-selectrum
+++ b/recipes/consult-selectrum
@@ -1,4 +1,0 @@
-(consult-selectrum
- :repo "minad/consult"
- :fetcher github
- :files ("consult-selectrum.el"))


### PR DESCRIPTION
Consult supports Selectrum out of the box now. This way the maintenance effort and experience for end users is improved. I had multiple bug reports where people had incomplete configurations and figuring it out always costs time. @purcell can you please merge this?