### PR TITLE
Add default directory to organize-imports-java

### DIFF
--- a/recipes/organize-imports-java
+++ b/recipes/organize-imports-java
@@ -1,4 +1,4 @@
 (organize-imports-java
  :repo "jcs-elpa/organize-imports-java"
  :fetcher github
- :files (:defaults "sdk"))
+ :files (:defaults "sdk" "default"))


### PR DESCRIPTION
Add default directory for default package configuration file.

https://github.com/jcs-elpa/organize-imports-java/tree/master/default