### PR TITLE
Remove company-org-roam from MELPA

### DIFF
--- a/recipes/company-org-roam
+++ b/recipes/company-org-roam
@@ -1,2 +1,0 @@
-(company-org-roam :fetcher github
-                   :repo "org-roam/company-org-roam")


### PR DESCRIPTION
`company-org-roam` has been deprecated in favour of simply using `capf` for a while now, removing the package from MELPA to prevent further confusion.

### Your association with the package

I'm the original author of the package.

### Relevant communications with the upstream package maintainer

None needed.