### PR TITLE
added recipe for org-auto-tangle

### DIFF
--- a/recipes/org-auto-tangle
+++ b/recipes/org-auto-tangle
@@ -1,2 +1,1 @@
-(org-auto-tangle :repo "yilkalargaw/org-auto-tangle" :fetcher github
-		 :files ("org-auto-tangle.el"))
+(org-auto-tangle :repo "yilkalargaw/org-auto-tangle" :fetcher github)

--- a/recipes/org-auto-tangle
+++ b/recipes/org-auto-tangle
@@ -1,0 +1,2 @@
+(org-auto-tangle :repo "yilkalargaw/org-auto-tangle" :fetcher github
+		 :files ("org-auto-tangle.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package allows to tangle org files asynchronously by simply adding the option ```#+auto_tangle: t```. This is especially useful in literate emacs init and config files. You can simply use this package and the aforementioned org option to enable you to automatically tangle the file without blocking emacs (i.e. asynchronously).

### Direct link to the package repository

https://github.com/yilkalargaw/org-auto-tangle

### Your association with the package

I am a maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
