### PR TITLE
Remove evil-magit

### DIFF
--- a/recipes/evil-magit
+++ b/recipes/evil-magit
@@ -1,1 +1,0 @@
-(evil-magit :repo "emacs-evil/evil-magit" :fetcher github)


### PR DESCRIPTION
This project was merged with evil-collection and will cause conflicts if both
are installed.

### Direct link to the package repository

https://github.com/emacs-evil/evil-magit

### Your association with the package

Author and maintainer


