### PR TITLE
Recipe for the “agda-editor-tactics” package

### DIFF
--- a/recipes/agda-editor-tactics
+++ b/recipes/agda-editor-tactics
@@ -1,2 +1,1 @@
-    (agda-editor-tactics :fetcher github :repo "alhassy/
-next-700-module-systems")
+    (agda-editor-tactics :fetcher github :repo "alhassy/next-700-module-systems")

--- a/recipes/agda-editor-tactics
+++ b/recipes/agda-editor-tactics
@@ -1,0 +1,2 @@
+    (agda-editor-tactics :fetcher github :repo "alhassy/
+next-700-module-systems")


### PR DESCRIPTION
### Brief summary of what the package does

Agda uses a number of editor tactics, such as C-c C-c, to perform case
analysis or to extract inner definitions to the toplevel. We add a new
tactic, with an eye toward building an Elisp API for Agda records.

For now, one may select an Agda record, then press `M-x agda-editor-tactics-as-Σ-nested`, tabbing along the way, to obtain a transformed Σ-product form of the record.

This tactic was requested in the Agda mailing list,
I will likely produce other tactics as requested ---time permitting.

### Direct link to the package repository

https://github.com/alhassy/next-700-module-systems

### Your association with the package

Enthusiastic maintainer.

### Relevant communications with the upstream package maintainer

The final .el file is tangled from an Org file, which requires the use
of noweb-refs and so two (silent) warnings from the linter cannot be fixed.
(I have used a similar setup for previously accepted Melpa contributions.)

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
