### PR TITLE
Create doom-modeline-now-playing

### DIFF
--- a/recipes/doom-modeline-now-playing
+++ b/recipes/doom-modeline-now-playing
@@ -1,0 +1,3 @@
+(doom-modeline-now-playing
+ :fetcher github
+ :repo "elken/doom-modeline-now-playing") 


### PR DESCRIPTION
### Brief summary of what the package does

Adds a `now-playing` segment for `doom-modeline` to use, showing current playing song information

### Direct link to the package repository

https://github.com/elken/doom-modeline-now-playing

### Your association with the package

It's my package

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
