### PR TITLE
Add recipe hiccup-cli

### DIFF
--- a/recipes/hiccup-cli
+++ b/recipes/hiccup-cli
@@ -1,0 +1,4 @@
+(hiccup-cli
+ :repo "kwrooijen/hiccup-cli"
+ :fetcher github
+ :files ("elisp/*.el" "elisp/*.el.in"))


### PR DESCRIPTION
### Brief summary of what the package does

Emacs interface for a command line tool to convert HTML to Clojure [Hiccup](https://github.com/weavejester/hiccup) syntax.

### Direct link to the package repository

https://github.com/kwrooijen/hiccup-cli

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). (elisp directory is GPL3, the command line tool is MIT, installed separately)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
