### PR TITLE
Exclude eglot-fsharp (multiple packages repository)

### DIFF
--- a/recipes/fsharp-mode
+++ b/recipes/fsharp-mode
@@ -1,3 +1,4 @@
 (fsharp-mode
  :fetcher github
- :repo "fsharp/emacs-fsharp-mode")
+ :repo "fsharp/emacs-fsharp-mode"
+ :files (:defaults (:exclude "eglot-fsharp.el")))


### PR DESCRIPTION
Just a followup to #7336 

`eglot-fsharp.el` is still distributed in base package: https://github.com/fsharp/emacs-fsharp-mode/issues/265