### PR TITLE
find-file-in-project repo is transfered

### DIFF
--- a/recipes/find-file-in-project
+++ b/recipes/find-file-in-project
@@ -1,2 +1,2 @@
-(find-file-in-project :repo "technomancy/find-file-in-project" :fetcher github)
+(find-file-in-project :repo "redguardtoo/find-file-in-project" :fetcher github)
 


### PR DESCRIPTION
### Brief summary of what the package does

Find file/directory and review Diff/Patch/Commit quickly everywhere.

### Direct link to the package repository

https://github.com/redguardtoo/find-file-in-project

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

See https://github.com/redguardtoo/find-file-in-project/issues/121#event-4251697963

The original owner transferred the repo to me.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
