### PR TITLE
Add recipe for docstr

### DIFF
--- a/recipes/docstr
+++ b/recipes/docstr
@@ -1,0 +1,1 @@
+(docstr :repo "jcs-elpa/docstr" :fetcher github :files (:defaults "clients/*.el"))

--- a/recipes/docstr
+++ b/recipes/docstr
@@ -1,1 +1,1 @@
-(docstr :repo "jcs-elpa/docstr" :fetcher github :files (:defaults "clients/*.el"))
+(docstr :repo "jcs-elpa/docstr" :fetcher github :files (:defaults "langs/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A document string minor mode.

This was original opened https://github.com/melpa/melpa/pull/7222, but I am not able to reopen it! So I have made a new PR.

### Direct link to the package repository

https://github.com/jcs-elpa/docstr

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
