### PR TITLE
Add ca65-mode recipe

### DIFF
--- a/recipes/ca65-mode
+++ b/recipes/ca65-mode
@@ -1,4 +1,3 @@
 (ca65-mode
  :fetcher github
- :repo "wendelscardua/ca65-mode"
- :branch "main")
+ :repo "wendelscardua/ca65-mode")

--- a/recipes/ca65-mode
+++ b/recipes/ca65-mode
@@ -1,0 +1,4 @@
+(ca65-mode
+ :fetcher github
+ :repo "wendelscardua/ca65-mode"
+ :branch "main")


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for editing [ca65 assembly](https://cc65.github.io/doc/ca65.html) files.

### Direct link to the package repository

https://github.com/wendelscardua/ca65-mode

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
