### PR TITLE
Add company-wordfreq recipe

### DIFF
--- a/recipes/company-wordfreq
+++ b/recipes/company-wordfreq
@@ -1,0 +1,1 @@
+(company-wordfreq :fetcher github :repo "johannes-mueller/company-wordfreq.el")


### PR DESCRIPTION
### Brief summary of what the package does

A company-backend for human language texts based on word frequency dictionaries.

### Direct link to the package repository

https://github.com/johannes-mueller/company-wordfreq.el

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
