### PR TITLE
weblorg: Add themes directory to the package

### DIFF
--- a/recipes/weblorg
+++ b/recipes/weblorg
@@ -1,1 +1,1 @@
-(weblorg :fetcher github :repo "emacs-love/weblorg")
+(weblorg :fetcher github :repo "emacs-love/weblorg" :files (:defaults "themes"))


### PR DESCRIPTION
### Brief summary of what the PR does

After some thorough cleanup on the project's directory, we're ready to start shipping the themes. Right now it's only 96K and we don't expect to grow much more since it's always going to be mostly text files (all images are svg so far);

### Direct link to the package repository

https://github.com/emacs-love/weblorg

### Your association with the package

author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
