### PR TITLE
Add inf-elixir

### DIFF
--- a/recipes/inf-elixir
+++ b/recipes/inf-elixir
@@ -1,0 +1,1 @@
+(inf-elixir :fetcher github :repo "J3RN/inf-elixir")


### PR DESCRIPTION
### Brief summary of what the package does

In the tradition of other `inf-*` packages, `inf-elixir` provides access to an Elixir REPL running in a buffer.

As a quick aside, `inf-elixir` (again, following tradition) defines a `run-elixir` function which, naturally, does not have the `inf-elixir-` prefix.

### Direct link to the package repository

https://github.com/J3RN/inf-elixir

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
