### PR TITLE
Add recipe for git-assembler-mode

### DIFF
--- a/recipes/git-assembler-mode
+++ b/recipes/git-assembler-mode
@@ -1,0 +1,2 @@
+(git-assembler-mode :repo "wavexx/git-assembler-mode.el"
+                    :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

New major mode to edit [git-assembler](https://www.thregr.org/~wavexx/software/git-assembler/) configuration files. Provides basic font-lock support.

### Direct link to the package repository

https://gitlab.com/wavexx/git-assembler-mode.el

### Your association with the package

Author

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

package-lint complains about the summary not starting with a capital letter, but that's because that's exactly the name of the upstream tool, which I'd like to keep as-is.