### PR TITLE
Add recipe for tab-bar-echo-area

### DIFF
--- a/recipes/tab-bar-echo-area
+++ b/recipes/tab-bar-echo-area
@@ -1,0 +1,1 @@
+(tab-bar-echo-area :fetcher github :repo "fritzgrabo/tab-bar-echo-area")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a global minor mode to temporarily display a list of available tab names (with the current tab's name highlighted) in the echo area after tab-related commands.

The list of tab names shows after creating, closing, switching to, and renaming a tab, and remains visible until the next command is issued.

This is intended to be used as an unobtrusive replacement for the Emacs built-in `tab-bar-mode`.

### Direct link to the package repository

https://github.com/fritzgrabo/tab-bar-echo-area

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them