### PR TITLE
Add recipe for tab-bar-lost-commands

### DIFF
--- a/recipes/tab-bar-lost-commands
+++ b/recipes/tab-bar-lost-commands
@@ -1,0 +1,1 @@
+(tab-bar-lost-commands :fetcher github :repo "fritzgrabo/tab-bar-lost-commands")


### PR DESCRIPTION
### Brief summary of what the package does

The "lost commands" of the Emacs tab bar.

That is, simple and convenient commands that help with common tab bar use-cases regarding the creation, selection and movement of tabs.

### Direct link to the package repository

https://github.com/fritzgrabo/tab-bar-lost-commands

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

Please note that the package linter dutifully complains about the commands in this package not starting with the package's prefix `tab-bar-lost-commands-`. That's because the package name is rather long and I chose to use the prefix `tab-bar-lc-` ("lc" for "lost commands") instead. I think this should be in accordance with the [Emacs Lisp Coding Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html#Coding-Conventions), which state that 

> If one prefix is insufficient, your package can use two or three alternative common prefixes, so long as they make sense.

Let me know if there's a better way to do this. Thanks!

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
