### PR TITLE
Add recipe for tab-bar-groups

### DIFF
--- a/recipes/tab-bar-groups
+++ b/recipes/tab-bar-groups
@@ -1,0 +1,1 @@
+(tab-bar-groups :fetcher github :repo "fritzgrabo/tab-bar-groups")


### PR DESCRIPTION
### Brief summary of what the package does

Tab groups for the tab bar.

Tabs with the same base name (`foo`, `foo<1>`, `foo<2>` all share the base name "foo") are considered a group.

This package provides convenient commands to create and work with tabs in groups.

### Direct link to the package repository

https://github.com/fritzgrabo/tab-bar-groups

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them