### PR TITLE
Add recipe for hiddenquote

### DIFF
--- a/recipes/hiddenquote
+++ b/recipes/hiddenquote
@@ -1,0 +1,2 @@
+(hiddenquote :repo "mauroaranda/hiddenquote/hiddenquote" :fetcher gitlab
+             :files ("*.el" "puzzles"))


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for a word puzzle game.

### Direct link to the package repository

[hiddenquote](https://gitlab.com/mauroaranda/hiddenquote/hiddenquote)

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Actually, checkdoc is not entirely happy.  It complains with docstrings like this:

> Return a `hiddenquote-edit' instance, read from the file slot in SELF.

It asks me to disambiguate it (offering function, command and others).  I don't think that makes sense:
To me, it is pretty clear: it returns an instance of a class named hiddenquote-edit.