### PR TITLE
Add `mode-line-idle` package

### DIFF
--- a/recipes/mode-line-idle
+++ b/recipes/mode-line-idle
@@ -1,0 +1,3 @@
+(mode-line-idle
+ :repo "ideasman42/emacs-mode-line-idle"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Support adding entries in the `mode-line-format` with delayed evaluation (when idle).

I posted an [RFC to reddit](https://www.reddit.com/r/emacs/comments/lelgm3/rfc_mode_line_idle_simple_delayed_evaluation_for/), while I didn't get any detailed feedback, the up-voted indicate interest.

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-mode-line-idle/

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
