### PR TITLE
Add anaconda-mode.py to anaconda-mode files

### DIFF
--- a/recipes/anaconda-mode
+++ b/recipes/anaconda-mode
@@ -1,1 +1,4 @@
-(anaconda-mode :fetcher github :repo "pythonic-emacs/anaconda-mode")
+(anaconda-mode
+ :fetcher github
+ :repo "pythonic-emacs/anaconda-mode"
+ :files (:defaults "anaconda-mode.py"))


### PR DESCRIPTION
We're about to add an external Python file to `anaconda-mode`.

See https://github.com/pythonic-emacs/anaconda-mode/pull/407
