### PR TITLE
new package: consult-notmuch

### DIFF
--- a/recipes/consult-notmuch
+++ b/recipes/consult-notmuch
@@ -1,0 +1,3 @@
+(consult-notmuch
+ :fetcher git
+ :url "https://codeberg.org/jao/consult-notmuch")


### PR DESCRIPTION
### Brief summary of what the package does

Perform notmuch queries using consult autocompletion.

### Direct link to the package repository

https://codeberg.org/jao/consult-notmuch

### Your association with the package

Author and maintainer

### Checklist

Please confirm with `x`:

- [x ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [ x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
