### PR TITLE
Add l recipe

### DIFF
--- a/recipes/l
+++ b/recipes/l
@@ -1,0 +1,1 @@
+(l :fetcher git :url "https://git.sr.ht/~tarsius/l")


### PR DESCRIPTION
@purcell I'm adding a recipe for [`l`](https://git.sr.ht/~tarsius/l). We [discussed](https://twitter.com/magit_emacs/status/1355445828358467584) this briefly and you convinced me to not name it `f`.

Back when I [announced](https://emacsair.me/2021/01/28/llama-0.1/) `llama`, I also added that to Melpa. It defines a macro named `##`. Do you want me to remove `llama` from Melpa? Note that the macro isn't named `##` by choice. That symbol is the only symbol that exhibits the necessary behavior. Unlike in the case of `l` there really is no choice here.