### PR TITLE
New package consult-spotify, with auxiliary package espotify

### DIFF
--- a/recipes/consult-spotify
+++ b/recipes/consult-spotify
@@ -1,0 +1,4 @@
+(consult-spotify
+ :fetcher git
+ :url "https://codeberg.org/jao/espotify"
+ :files ("consult-spotify.el"))

--- a/recipes/espotify
+++ b/recipes/espotify
@@ -1,0 +1,4 @@
+(espotify
+ :fetcher git
+ :url "https://codeberg.org/jao/espotify"
+ :files ("espotify.el"))


### PR DESCRIPTION
### Brief summary of what the package does

consult-spotify allows querying albums, tracks, etc. from spotify and
playing them, using consult.  it uses a base library, espotify, which
can also be used by itself, and the additional embark-spotify extends
it with embark actions.

the three packages are very closely related: their .el files are
tangled from a single .org document that describes their
implementation, interleaving them in the prose as convenient.

so they not only live in the same repo, they live in the same file :)

### Direct link to the package repository

https://codeberg.org/jao/espotify

### Your association with the package

Author and maintaner

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
  Since there's a very detailed description in the source .org file, i
  have not added dummy docstrings or duplicated the one given in the
  text for /private/ functions.  For public functions and commands i
  think checkdoc is happy.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them