### PR TITLE
add reddigg recipe

### DIFF
--- a/recipes/reddigg
+++ b/recipes/reddigg
@@ -1,0 +1,1 @@
+(reddigg :fetcher github :repo "thanhvg/emacs-reddigg")


### PR DESCRIPTION
### Brief summary of what the package does

This package allows you to browse reddit in org-mode.

### Direct link to the package repository

https://github.com/thanhvg/emacs-reddigg

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
