### PR TITLE
fullframe repo is moving

### DIFF
--- a/recipes/fullframe
+++ b/recipes/fullframe
@@ -1,1 +1,1 @@
-(fullframe :repo "tomterl/fullframe" :fetcher github)
+(fullframe :repo "https://git.sr.ht/~tregner/fullframe" :fetcher git)

--- a/recipes/fullframe
+++ b/recipes/fullframe
@@ -1,1 +1,1 @@
-(fullframe :repo "https://git.sr.ht/~tregner/fullframe" :fetcher git)
+(fullframe :url "https://git.sr.ht/~tregner/fullframe" :fetcher git)

--- a/recipes/fullframe
+++ b/recipes/fullframe
@@ -1,1 +1,1 @@
-(fullframe :url "https://git.sr.ht/~tregner/fullframe" :fetcher git)
+(fullframe :url "https://git.sr.ht/~tomterl/fullframe" :fetcher git)


### PR DESCRIPTION
My packages are moving to sourcehut, updating fullframe first.

It's just a change in repo url.