### PR TITLE
Moving the repo to sourcehut

### DIFF
--- a/recipes/repl-toggle
+++ b/recipes/repl-toggle
@@ -1,1 +1,1 @@
-(repl-toggle :repo "tomterl/repl-toggle" :fetcher github)
+(repl-toggle :url "https://git.sr.ht/~tomterl/repl-toggle" :fetcher git)


### PR DESCRIPTION
After fullframe my second and last published package moves to sourcehut.

