### PR TITLE
Add recipe for ox-bb

### DIFF
--- a/recipes/ox-bb
+++ b/recipes/ox-bb
@@ -1,0 +1,1 @@
+(ox-bb :fetcher github :repo "mmitch/ox-bb")


### PR DESCRIPTION
### Brief summary of what the package does

`ox-bb` is an Org mode export backend that converts Org files to _BBCode_ (see [Wikipedia](https://en.wikipedia.org/wiki/BBCode)), a form of markup that is often found in many web forums.

### Direct link to the package repository

https://github.com/mmitch/ox-bb

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

n/a

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
