### PR TITLE
Add recipe for cascading-dir-locals

### DIFF
--- a/recipes/cascading-dir-locals
+++ b/recipes/cascading-dir-locals
@@ -1,0 +1,1 @@
+(cascading-dir-locals :fetcher github :repo "fritzgrabo/cascading-dir-locals")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a global minor mode that changes how Emacs handles the lookup of applicable dir-locals files (`.dir-locals.el`): instead of starting at the directory of the visited file and moving up the directory tree only until a first dir-locals file is found, collect and apply all (!) dir-locals files found from the current directory up to the root one.

Values specified in files nearer to the current directory take precedence over values in files farther away from it.

You might want to use this to set dir-local variables that apply to all of your projects only once, then override or add variables on a per-project basis.

### Direct link to the package repository

https://github.com/fritzgrabo/cascading-dir-locals

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
