### PR TITLE
Point tree-sitter-langs to the new repo

### DIFF
--- a/recipes/tree-sitter-langs
+++ b/recipes/tree-sitter-langs
@@ -1,4 +1,4 @@
 (tree-sitter-langs :repo "ubolonton/tree-sitter-langs"
                    :fetcher github
-                   :files ("*.el"
+                   :files (:defaults
                            "queries"))

--- a/recipes/tree-sitter-langs
+++ b/recipes/tree-sitter-langs
@@ -1,4 +1,4 @@
-(tree-sitter-langs :repo "ubolonton/emacs-tree-sitter"
+(tree-sitter-langs :repo "ubolonton/tree-sitter-langs"
                    :fetcher github
-                   :files ("langs/*.el"
-                           "langs/queries"))
+                   :files ("*.el"
+                           "queries"))


### PR DESCRIPTION
### Brief summary of what the package does

This changes the recipe for `tree-sitter-langs` to point to the new repo.

It was split from the main repo https://github.com/ubolonton/emacs-tree-sitter to
- Provide a new hosting for pre-compiled language grammars. Previously we used bintray, which is [shutting down](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). The new repository hosts the binaries with GitHub Releases.  
- Provide better separation of concerns: core functionalities vs. supports for individual languages.

### Direct link to the package repository

https://github.com/ubolonton/tree-sitter-langs

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
