### PR TITLE
Update parse-it recipe adding langs folder

### DIFF
--- a/recipes/parse-it
+++ b/recipes/parse-it
@@ -1,1 +1,1 @@
-(parse-it :repo "jcs-elpa/parse-it" :fetcher github)
+(parse-it :repo "jcs-elpa/parse-it" :fetcher github :files (:defaults "langs/*.el"))


### PR DESCRIPTION
I have moved language files to `langs` folder. Update it's recipe.