### PR TITLE
Add recipe for just-mode.el

### DIFF
--- a/recipes/just-mode
+++ b/recipes/just-mode
@@ -1,0 +1,1 @@
+(just-mode :repo "leon-barrett/just-mode.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for editing justfiles, as defined by the tool "just": https://github.com/casey/just

### Direct link to the package repository

https://github.com/leon-barrett/just-mode.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
