### PR TITLE
Add molar-mass recipe

### DIFF
--- a/recipes/molar-mass
+++ b/recipes/molar-mass
@@ -1,0 +1,1 @@
+(molar-mass :fetcher github :repo "sergiruiztrepat/molar-mass")


### PR DESCRIPTION
Molar-mass calculates molar mass of a given molecule

### Brief summary of what the package does

Calculates molar mas (or molecular weigth) of a given molecule. 
Ex: M-x molar-mass => H2O => "Molar mass of H2O : 18.015 g/mol (uma)"

### Direct link to the package repository

https://github.com/sergiruiztrepat/molar-mass

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [X ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [ X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X ] My elisp byte-compiles cleanly
- [ X] `M-x checkdoc` is happy with my docstrings
- [ X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
