### PR TITLE
Add leaf-defaults recipe

### DIFF
--- a/recipes/leaf-defaults
+++ b/recipes/leaf-defaults
@@ -1,0 +1,1 @@
+(leaf-defaults :fetcher github :repo "conao3/leaf-defaults.el")


### PR DESCRIPTION
### Brief summary of what the package does

Add :defaults and :convert-defaults to [leaf](https://github.com/conao3/leaf.el).

### Direct link to the package repository

https://github.com/conao3/leaf-defaults.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

## Note

This feature is cut from [leaf-keywords](https://github.com/conao3/leaf-keywords.el).

Since this keyword was causing a lot of unnecessary code to be
downloaded who did not need `:defaults`, I decided that it was
appropriate to provide it in a separate package.  As soon as this
package is merged, the duplicate code can be removed from
`leaf-keywords`.