### PR TITLE
Added recipe for popper.el.

### DIFF
--- a/recipes/popper
+++ b/recipes/popper
@@ -1,0 +1,1 @@
+(popper :fetcher github :repo "karthink/popper")


### PR DESCRIPTION
### Brief summary of what the package does

`popper.el` provides a minor-mode to designate buffers as "popups" and summon
and dismiss them with a key. Useful for many things, including toggling display
of REPLS, documentation, compilation or shell output, etc.

### Direct link to the package repository

https://github.com/karthink/popper

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
