### PR TITLE
Add desktop-mail-user-agent recipe

### DIFF
--- a/recipes/desktop-mail-user-agent
+++ b/recipes/desktop-mail-user-agent
@@ -1,0 +1,2 @@
+(desktop-mail-user-agent
+ :fetcher github :repo "lassik/emacs-desktop-mail-user-agent")


### PR DESCRIPTION
### Brief summary of what the package does

If you're running Emacs as a desktop application on the X Window System, MacOS, or Windows, this package launches the desktop environment's default mail app to write mail messages from Emacs. The `compose-mail` command, and other commands using it indirectly, are affected.

To install, call `desktop-mail-user-agent`. It sets `mail-user-agent` and stores the old `mail-user-agent` to use as a fallback for complex mail-sending tasks that require editing the mail message in an Emacs buffer.

Currently this package only concerns sending mail. Reading mail via `read-mail-command` is not affected.

### Direct link to the package repository

https://github.com/lassik/emacs-desktop-mail-user-agent

### Your association with the package

Just wrote it.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them