### PR TITLE
Add recipe for propcheck

### DIFF
--- a/recipes/propcheck
+++ b/recipes/propcheck
@@ -1,0 +1,1 @@
+(propcheck :repo "Wilfred/propcheck" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

propcheck is an implementation of property-based testing for elisp. Given a property, it attempts to find a counterexample. It's similar to packages like hypothesis (Python), hedgehog (Haskell) or proptest (Rust).

### Direct link to the package repository

https://github.com/Wilfred/propcheck

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (mostly)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
