### PR TITLE
Add new package eFar

### DIFF
--- a/recipes/efar
+++ b/recipes/efar
@@ -1,0 +1,1 @@
+(efar :repo "suntsov/efar" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides FAR-like file manager for Emacs.

### Direct link to the package repository

https://github.com/suntsov/efar

### Your association with the package

I'm the author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
