### PR TITLE
Add recipe for org-appear

### DIFF
--- a/recipes/org-appear
+++ b/recipes/org-appear
@@ -1,0 +1,1 @@
+(org-appear :fetcher github :repo "awth13/org-appear")


### PR DESCRIPTION
### Brief summary of what the package does

The package unhides invisible parts of Org elements when cursor enters an element. 

### Direct link to the package repository

https://github.com/awth13/org-appear

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed.**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Additional notes

`checkdoc` registers two errors related to disambiguation of `org-appear-mode`. Since `org-appear-mode` is a minor mode and neither of "function, command, variable, option or symbol", and since there is no ambiguity for a human reader, I decided to ignore these two errors. Please let me know if there is a better way to address this.