### PR TITLE
Add recipe for nroam

### DIFF
--- a/recipes/nroam
+++ b/recipes/nroam
@@ -1,0 +1,1 @@
+(nroam :fetcher github :repo "NicolasPetton/nroam")


### PR DESCRIPTION
### Brief summary of what the package does

nroam is a supplementary package for org-roam that replaces the backlink side buffer of Org-roam. Instead, it displays org-roam backlinks at the end of org-roam buffers. The user can also click a button to see unlinked occurrences of the buffer title (as defined by org-roam-unlinked-references).

For a longer rationale about this package, see https://github.com/NicolasPetton/nroam/#rationale.

### Direct link to the package repository

https://github.com/NicolasPetton/nroam

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
