### PR TITLE
Add recipe for auth-source-keytar

### DIFF
--- a/recipes/auth-source-keytar
+++ b/recipes/auth-source-keytar
@@ -1,0 +1,1 @@
+(auth-source-keytar :repo "emacs-grammarly/auth-source-keytar" :fetcher github)

--- a/recipes/keytar
+++ b/recipes/keytar
@@ -1,0 +1,1 @@
+(keytar :repo "emacs-grammarly/keytar" :fetcher github)

--- a/recipes/keytar
+++ b/recipes/keytar
@@ -1,1 +1,0 @@
-(keytar :repo "emacs-grammarly/keytar" :fetcher github)    

--- a/recipes/keytar
+++ b/recipes/keytar
@@ -1,0 +1,1 @@
+(keytar :repo "emacs-grammarly/keytar" :fetcher github)    


### PR DESCRIPTION
### Brief summary of what the package does

Emacs-Lisp interface for node-keytar

### Direct link to the package repository

* https://github.com/emacs-grammarly/keytar
* https://github.com/emacs-grammarly/auth-source-keytar

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
