### PR TITLE
Add buffer-ring recipe

### DIFF
--- a/recipes/buffer-ring
+++ b/recipes/buffer-ring
@@ -1,0 +1,2 @@
+(buffer-ring :repo "countvajhula/buffer-ring"
+             :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

[This is a companion PR to #7469 .]

[This package (written in 2009)](https://www.emacswiki.org/emacs/BufferRing) allows you to organize buffers in rings, and organize such rings in rings as well. It derives from the older MTorus package, but provides just the basics without any frills. There are other great packages that derive from MTorus, like [this recent one](https://github.com/chimay/torus) which looks great and seems to be very mature. Due to its minimalism, the present package is probably a good option especially for developers, if you need a buffer ring data structure to power some other functionality. I plan to use it in an upcoming package, [rigpa](https://github.com/countvajhula/rigpa).

### Direct link to the package repository

https://github.com/countvajhula/buffer-ring

### Your association with the package

I am volunteering to maintain this package, but I'm not the original author. See the [companion PR](https://github.com/melpa/melpa/pull/7469) for more details.

I've made a number of modifications to this package, including:

- supporting buffers being part of more than one ring
- bugfixes in deletion and search
- updating code to account for the additions and deprecations in dynamic-ring
- using lexical binding
- adding lots of tests!

### Relevant communications with the upstream package maintainer

See companion PR.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
