### PR TITLE
Update xref-js2 recipe

### DIFF
--- a/recipes/xref-js2
+++ b/recipes/xref-js2
@@ -1,1 +1,1 @@
-(xref-js2 :fetcher github :repo "NicolasPetton/xref-js2")
+(xref-js2 :fetcher github :repo "js-emacs/xref-js2")


### PR DESCRIPTION
`xref-js2` has been transferred to a new GiHub organization.

This PR updates the `xref-js2` recipe to match the new GitHub owner of the repository.

### Brief summary of what the package does

xref-js2 adds navigation to definitions or references to JavaScript projects in Emacs.
xref-js2 adds an xref backend for JavaScript files.

### Direct link to the package repository

https://github.com/js-emacs/xref-js2

### Your association with the package

I am the author of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

**I have not gone through all checklist items as the package is already in MELPA and this PR only updates the repository in the recipe**.

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
