### PR TITLE
Add anchor-theme-buffer-local to recipe

### DIFF
--- a/recipes/anchor-theme-buffer-local
+++ b/recipes/anchor-theme-buffer-local
@@ -1,0 +1,3 @@
+(anchor-theme-buffer-local :fetcher github
+			   :repo "GongYiLiao/anchor-theme-buffer-local"
+			   :files ("anchor-theme-buffer-local.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides functions that can set a custom theme to curernt buffer only, without affecting other buffers,

### Direct link to the package repository

https://github.com/GongYiLiao/anchor-theme-buffer-local

### Your association with the package

I am the creator and maintainer of the package 

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

Please confirm with `x`:

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
