### PR TITLE
highlight-parentheses.el moved to sr.ht

### DIFF
--- a/recipes/highlight-parentheses
+++ b/recipes/highlight-parentheses
@@ -1,3 +1,4 @@
 (highlight-parentheses
- :repo "tsdh/highlight-parentheses.el"
- :fetcher github)
+ :fetcher git
+ :url "https://git.sr.ht/~tsdh/highlight-parentheses.el"
+ :branch "main")


### PR DESCRIPTION
highlight-parentheses.el already is in MELPA.  I, the maintainer, just moved it
from GitHub to SourceHut [1].  This PR adjusts the recipe accordingly.

[1] https://sr.ht/~tsdh/highlight-parentheses.el/