### PR TITLE
Split dylan-mode into dylan and dime

### DIFF
--- a/recipes/dime
+++ b/recipes/dime
@@ -1,0 +1,2 @@
+(dime :files ("dime*.el")
+      :fetcher github :repo "dylan-lang/dylan-emacs-support")

--- a/recipes/dylan
+++ b/recipes/dylan
@@ -1,0 +1,3 @@
+(dylan :files ("dylan*.el")
+       :fetcher github :repo "dylan-lang/dylan-emacs-support"
+       :old-names (dylan-mode))

--- a/recipes/dylan-mode
+++ b/recipes/dylan-mode
@@ -1,4 +1,0 @@
-(dylan-mode
- :repo "dylan-lang/dylan-emacs-support"
- :fetcher github
- :files ("*.el" "dtags" "etags.regex"))


### PR DESCRIPTION
The `dylan-mode` package contains a lot more stuff than simply the major mode. Split it into `dylan` and `dime`. `dylan` contains editing modes; `dime` is an IDE forked from the Common Lisp SLIME IDE.

### Brief summary of what the package does

[Dylan proramming language](http://opendylan.org/) support

### Direct link to the package repository

https://github.com/dylan-lang/dylan-emacs-support

### Your association with the package

Contributor

### Relevant communications with the upstream package maintainer

Can be done in this MELPA PR thread.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
