### PR TITLE
Make Python 3 the default Python in CI (#7482)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,18 @@ jobs:
       run: |
         sudo apt-get install emacs25
         sudo apt-get install git jq mercurial python3 texinfo
-        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 3
 
         # Work around SSL-related failures, see
         # https://stackoverflow.com/questions/21477683/mercurial-https-clone-abort-error-wrong-version-number
         echo "[ui]\ntls = False" > $HOME/.hgrc
 
-        # Use cask to install development dependencies
-        curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+        # Install Cask
+        git clone https://github.com/cask/cask $HOME/.cask
+        export "PATH=$HOME/.cask/bin:$PATH"
+        sed -i '' 's,^#!.*python.*,#! /usr/bin/env python3,' $HOME/.cask/bin/cask
     - name: Run cask
       run: |
-        ~/.cask/bin/cask
+        $HOME/.cask/bin/cask
     - name: Check changed recipes
       run: |
         [ "$GITHUB_EVENT_NAME" = "push" ] \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,9 @@ jobs:
 
         # Install Cask
         git clone https://github.com/cask/cask $HOME/.cask
-        export "PATH=$HOME/.cask/bin:$PATH"
 
         # Ensure Cask uses Python 3, not Python 2.
-        sed -i 's,^#!.*python.*,#! /usr/bin/env python3,' $HOME/.cask/bin/cask
+        perl -i -pe 's,^#!.*python.*,#! /usr/bin/env python3,' $HOME/.cask/bin/cask
     - name: Run cask
       run: |
         $HOME/.cask/bin/cask

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install emacs25
-        sudo apt-get install git jq mercurial texinfo
+        sudo apt-get install git jq mercurial python3 texinfo
+        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 3
 
         # Work around SSL-related failures, see
         # https://stackoverflow.com/questions/21477683/mercurial-https-clone-abort-error-wrong-version-number

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
         # Install Cask
         git clone https://github.com/cask/cask $HOME/.cask
         export "PATH=$HOME/.cask/bin:$PATH"
-        sed -i '' 's,^#!.*python.*,#! /usr/bin/env python3,' $HOME/.cask/bin/cask
+
+        # Ensure Cask uses Python 3, not Python 2.
+        sed -i 's,^#!.*python.*,#! /usr/bin/env python3,' $HOME/.cask/bin/cask
     - name: Run cask
       run: |
         $HOME/.cask/bin/cask


### PR DESCRIPTION
If I understood issue #7482 correctly, MELPA CI needs to be upgraded from Python 2 to Python 3. This PR does that.