### PR TITLE
Update the location of the repo. for the Klere theme.

### DIFF
--- a/recipes/klere-theme
+++ b/recipes/klere-theme
@@ -1,1 +1,1 @@
-(klere-theme :repo "WammKD/emacs-klere-theme" :fetcher github)
+(klere-theme :fetcher git :url "https://codeberg.org/WammKD/emacs-klere-theme.git")


### PR DESCRIPTION
### Brief summary of what the package does

A dark theme for Emacs

### Direct link to the package repository

https://codeberg.org/WammKD/emacs-klere-theme

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

This isn't really a change, of any kind; I just recently moved to Codeberg so I'm updating the repo. for this package.