### PR TITLE
Make individual recipe builds via Make fail when appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ $(RCPDIR)/.dirstamp: .FORCE
 ## Recipe rules
 $(RCPDIR)/%: .FORCE
 	@echo " • Building package $(@F) ..."
-	@- exec 2>&1; exec &> >(tee $(PKGDIR)/$(@F).log); \
+	@exec 2>&1; exec &> >(tee $(PKGDIR)/$(@F).log); \
 	  $(TIMEOUT) $(EVAL) "(package-build-archive \"$(@F)\")" \
 	  && echo " ✓ Success:" \
 	  && ls -lsh $(PKGDIR)/$(@F)-*

--- a/docker/builder/parallel_build_all
+++ b/docker/builder/parallel_build_all
@@ -15,7 +15,7 @@ function build_all {
 
     ## run the script
     cd "/mnt/store/melpa"
-    make -j8 $(grep --files-without-match ':fetcher\s*wiki' $(find recipes/ -type f -not -name python-info -and -not -name python3-info | sort)) &
+    make -k -j8 $(grep --files-without-match ':fetcher\s*wiki' $(find recipes/ -type f -not -name python-info -and -not -name python3-info | sort)) &
     wait
 
     # python-info and python3-info are too big to run while other are


### PR DESCRIPTION
Requires a docker image rebuild, due to related changes in the
parallel_build_all script.

See https://github.com/melpa/package-build/pull/50
