### PR TITLE
add theme-anchor

### DIFF
--- a/recipes/theme-anchor
+++ b/recipes/theme-anchor
@@ -1,0 +1,4 @@
+(theme-anchor :repo "GongYiLiao/theme-anchor"
+	      :fetcher github
+	      :files (:defaults "theme-anchor"))
+


### PR DESCRIPTION
### Brief summary of what the package does

This package provides functions to apply an emacs custom theme to current buffer only

This pull request is created to replace [#7476](https://github.com/melpa/melpa/pull/7476) with a shorter package name and improved documentation/license informaiton 

### Direct link to the package repository

https://github.com/GongYiLiao/theme-anchor

### Your association with the package

I am the orginal author and maintainer 

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
