### PR TITLE
Add recipe for geiser-guile

### DIFF
--- a/recipes/geiser-guile
+++ b/recipes/geiser-guile
@@ -1,0 +1,4 @@
+(geiser-guile
+ :fetcher gitlab
+ :repo "emacs-geiser/guile"
+ :files (:defaults ("src" "src/*")))


### PR DESCRIPTION
### Brief summary of what the package does

I finally thought it best to not make any exception and here's the
latest package extracted from Geiser.  Once they're in, i'll push a
new version of `geiser` that will declare as deprecated all those
exported functions not using their package prefix, and removing all
the extracted code.  I'll finally change the repo in the geiser recipe
(another PR here), which now points to my personal repo in GitLab to
point instead to the copy in the emacs-geiser organisation.

Thanks for your patience!

### Direct link to the package repository

https://gitlab.com/emacs-geiser/guile

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->