### PR TITLE
Add nix-modeline recipe

### DIFF
--- a/recipes/nix-modeline
+++ b/recipes/nix-modeline
@@ -1,0 +1,1 @@
+(nix-modeline :repo "ocelot-project/nix-modeline" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`nix-modeline` is a global minor mode that shows how many [Nix](https://nixos.org/) package manager builds (or evaluations) are running in the background, updated live using the [entr](http://eradman.com/entrproject/) utility. This comes especially in handy if you combine Nix with an asynchronous project build tool like [lorri](https://github.com/target/lorri) or [nix-direnv](https://github.com/nix-community/nix-direnv), as is common for Nix core maintainers and heavy users, since without `nix-modeline` there is no obvious way to tell when a background build has completed. To my knowledge, this package does not replicate any functionality in an existing Emacs package.

### Direct link to the package repository

https://github.com/ocelot-project/nix-modeline

### Your association with the package

I created this package.

### Relevant communications with the upstream package maintainer

I deprived him of sleep until he agreed to finish this package and submit it to MELPA.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
