### PR TITLE
Fix find-dupes-dired

### DIFF
--- a/recipes/find-dupes-dired
+++ b/recipes/find-dupes-dired
@@ -1,3 +1,4 @@
 (find-dupes-dired
  :repo "ShuguangSun/find-dupes-dired"
- :fetcher github)
+ :fetcher github
+ :branch "main")


### PR DESCRIPTION
The source repo changed the default branch to `main`, but the recipe didn’t get updated.
