### PR TITLE
Add `hl-prog-extra` package

### DIFF
--- a/recipes/hl-prog-extra
+++ b/recipes/hl-prog-extra
@@ -1,0 +1,3 @@
+(hl-prog-extra
+ :repo "ideasman42/emacs-hl-prog-extra"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Easily customize highlighting for programming modes (as a setting).
Without having to write custom font-locking code.

RFC on reddit: https://www.reddit.com/r/emacs/comments/mqjdow/

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-hl-prog-extra

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
