### PR TITLE
Adding dyncloze, a tool to help test you on language choices.

### DIFF
--- a/recipes/dyncloze
+++ b/recipes/dyncloze
@@ -1,0 +1,1 @@
+(dyncloze :repo "ahyatt/emacs-dyncloze" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
Dyncloze is for testing yourself on possible string alternatives, especially
useful for language learning.  Users input two or more alternatives, and each
occurence in the buffer is blanked out and the user is quizzed which of the
alternatives fits.


### Direct link to the package repository

 https://github.com/ahyatt/emacs-dyncloze.

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
