### PR TITLE
Update repository and included files for package geiser

### DIFF
--- a/recipes/geiser
+++ b/recipes/geiser
@@ -1,8 +1,4 @@
 (geiser
  :fetcher gitlab
- :repo "jaor/geiser"
- :files ("elisp/*.el"
-         "elisp/geiser-version.el.in"
-         "doc/*.texi"
-         ("bin" "bin/*") (:exclude "bin/Makefile.am")
-         ("scheme" "scheme/*") (:exclude "scheme/Makefile.am")))
+ :repo "emacs-geiser/geiser"
+ :files ("elisp/*.el" "doc/dir" "doc/geiser.texi"))


### PR DESCRIPTION
This is the final step in the geiser collection split.  It simply
changes the location of the main repo, which is a copy of the state of
current one, minus unused stuff, and removes unneeded includes.

I've noticed that when one has a main texi file that includes some
others, only the main one needs to be listed in the recipe (and, in
fact, explicitly including others produces non-fatal errors because
install-info is invoked also on them), so i've simplified very
significantly the list of files in the recipe (also because other
source directories are now simply gone).

Thanks for you patience! :)