### PR TITLE
Add consult-lsp recipe

### DIFF
--- a/recipes/consult-lsp
+++ b/recipes/consult-lsp
@@ -1,0 +1,3 @@
+(consult-lsp 
+  :fetcher github
+  :repo "gagbo/consult-lsp")


### PR DESCRIPTION
### Brief summary of what the package does

This package adds [LSP-mode](https://github.com/emacs-lsp/lsp-mode) related commands to use with [consult](https://github.com/minad/consult)

### Direct link to the package repository

https://github.com/gagbo/consult-lsp

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist


- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) — Package is MIT, need to check if that's compatible of if using consult infects the package.
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback — ran through `flycheck-package`, it only complains about "non installable packages" in dependencies but my `package.el` is uninitialsed so it is to be expected
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org) — Tested with a straight recipe pointing to my local repo instead of gh.
- [ ] I have confirmed some of these without doing them

