### PR TITLE
Add rbs-mode recipe

### DIFF
--- a/recipes/rbs-mode
+++ b/recipes/rbs-mode
@@ -1,0 +1,1 @@
+(rbs-mode :fetcher github :repo "ybiquitous/rbs-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`rbs-mode` is a major mode for RBS (a type signature language for Ruby).

### Direct link to the package repository

https://github.com/ybiquitous/rbs-mode

### Your association with the package

I am the:

- package author
- package maintainer
- MELPA recipe author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
