### PR TITLE
Update bazel-mode

### DIFF
--- a/recipes/bazel-mode
+++ b/recipes/bazel-mode
@@ -1,2 +1,1 @@
-(bazel-mode :repo "bazelbuild/emacs-bazel-mode" :fetcher github
-  :files ("lisp/*.el" (:exclude "lisp/*-test.el")))
+(bazel-mode :repo "bazelbuild/emacs-bazel-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`bazel-mode` merges all `*.el` into one single file since https://github.com/bazelbuild/emacs-bazel-mode/commit/1144974663f2ff03322ee6d91c6de5e2ca275892

### Direct link to the package repository

https://github.com/bazelbuild/emacs-bazel-mode

### Your association with the package

A contributor

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
