### PR TITLE
add clhs - common lisp hyperspec interface

### DIFF
--- a/recipes/clhs
+++ b/recipes/clhs
@@ -1,0 +1,1 @@
+(clhs :repo "sam-s/clhs" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Access the Common Lisp HyperSpec (CLHS)

### Direct link to the package repository

https://gitlab.com/sam-s/clhs

### Your association with the package

author/maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
