### PR TITLE
Add `electric-cursor`

### DIFF
--- a/recipes/electric-cursor
+++ b/recipes/electric-cursor
@@ -1,0 +1,3 @@
+(electric-cursor
+ :fetcher github
+ :repo "duckwork/electric-cursor")


### PR DESCRIPTION
### Brief summary of what the package does

This package contains a global minor mode, `electric-cursor-mode`, which automatically sets the cursor-type depending on what mode the user is in.  `electric-cursor-mode` is more flexible than the currently available package, [bar-cursor](https://melpa.org/#/bar-cursor).

### Direct link to the package repository

https://github.com/duckwork/electric-cursor

### Your association with the package

I am the author of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
