### PR TITLE
Add ox-beamer

### DIFF
--- a/recipes/ox-beamer
+++ b/recipes/ox-beamer
@@ -1,0 +1,1 @@
+(ox-beamer :fetcher github :repo "aartaka/ox-beamer")


### PR DESCRIPTION
### Brief summary of what the package does

This is an Org Mode back-end that creates Beamer (a widespread slide-making LaTeX library) presentations out of Org Mode files.

### Direct link to the package repository

https://github.com/aartaka/ox-beamer

### Your association with the package

I'm the author and the maintainer of ox-beamer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
  - GPL-3.0, in fact.
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - The only warning that I haven't addressed is `39:0: error: "org-export-beamer" doesn't start with package's prefix "ox-beamer".`, but that's typical for Org Mode export back-ends, it seems.
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
  - The package version is not fetched from Github tag, but that's not critical.
- [ ] I have confirmed some of these without doing them

Thank you!