### PR TITLE
Add cowsay recipe

### DIFF
--- a/recipes/cowsay
+++ b/recipes/cowsay
@@ -1,0 +1,1 @@
+(cowsay :fetcher github :repo "lassik/emacs-cowsay")


### PR DESCRIPTION
### Brief summary of what the package does

This is a workalike of the popular `cowsay` amusement program that runs directly in Emacs and does not require any external programs. This port is not written by the original author of `cowsay`, but can load cartoon characters from the same files as the original.

### Direct link to the package repository

https://github.com/lassik/emacs-cowsay

### Your association with the package

Just wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them