### PR TITLE
Add read-only-cfg recipe

### DIFF
--- a/recipes/read-only-cf
+++ b/recipes/read-only-cf
@@ -1,0 +1,1 @@
+(read-only-cf :fetcher github :repo "pfchen/read-only-cf")

--- a/recipes/read-only-cf
+++ b/recipes/read-only-cf
@@ -1,1 +1,0 @@
-(read-only-cf :fetcher github :repo "pfchen/read-only-cf")

--- a/recipes/read-only-cfg
+++ b/recipes/read-only-cfg
@@ -1,0 +1,1 @@
+(read-only-cfg :fetcher github :repo "pfchen/read-only-cfg")


### PR DESCRIPTION
### Brief summary of what the package does

`read-only-cf` is a GNU Emacs minor mode which can automatically make files read-only based on user configuration. `read-only-cf` is more flexible than the currently available package `auto-read-only`. Compared with `auto-read-only`, it supports the following features:

- User configuration can be not only regex patterns, but also prefix directories.
- Support interactively adding new configuration.
- Support dynamically updating the read-only state of all existing file buffers when this mode is enabled or disabled.

### Direct link to the package repository

https://github.com/pfchen/read-only-cf

### Your association with the package

I am the author of the package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->