### PR TITLE
Update geiser-kawa recipe to point to new repo location

### DIFF
--- a/recipes/geiser-kawa
+++ b/recipes/geiser-kawa
@@ -1,6 +1,6 @@
 (geiser-kawa
  :fetcher gitlab
- :repo "spellcard199/geiser-kawa"
+ :repo "emacs-geiser/kawa"
  :files ("elisp/*.el"
          "pom.xml"
          ".mvn" "mvnw" "mvnw.cmd"


### PR DESCRIPTION
Hello. "geiser-kawa" is moving from a [repo](https://gitlab.com/spellcard199/geiser-kawa) under my account to a [repo](https://gitlab.com/emacs-geiser/kawa) under the [emacs-geiser](https://gitlab.com/emacs-geiser) group.

Related issue in emacs-geiser: https://gitlab.com/emacs-geiser/kawa/-/issues/3