### PR TITLE
rename pyim-cangjie5dict because of adding cangjie6

### DIFF
--- a/recipes/pyim-cangjie5dict
+++ b/recipes/pyim-cangjie5dict
@@ -1,3 +1,0 @@
-(pyim-cangjie5dict :repo "p1uxtar/pyim-cangjie5dict"
-                   :fetcher github
-                   :files (:defaults "*.pyim"))

--- a/recipes/pyim-cangjiedict
+++ b/recipes/pyim-cangjiedict
@@ -1,0 +1,3 @@
+(pyim-cangjiedict :repo "p1uxtar/pyim-cangjiedict"
+                  :fetcher github
+                  :files (:defaults "*.pyim"))


### PR DESCRIPTION
### Brief summary of what the package does

This project contains the dict/thesaurus files of the Chinese character input scheme Cangjie on the engine [pyim](https://github.com/tumashu/pyim). In the previous version (PR #4881 ), only the most popular Changjie5 was supported. Now I've added the six-generation version (Cangjie Jianzifa, also called Cangjie6). So I renamed the project.

### Direct link to the package repository

https://github.com/p1uxtar/pyim-cangjiedict

### Your association with the package

I am the maintainer & author.

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
