### PR TITLE
Add rescript-mode recipe

### DIFF
--- a/recipes/rescript-mode
+++ b/recipes/rescript-mode
@@ -1,4 +1,3 @@
 (rescript-mode
  :fetcher github
- :repo "jjlee/rescript-mode"
- :branch "master")
+ :repo "jjlee/rescript-mode")

--- a/recipes/rescript-mode
+++ b/recipes/rescript-mode
@@ -1,0 +1,4 @@
+(rescript-mode
+ :fetcher github
+ :repo "jjlee/rescript-mode"
+ :branch "master")


### PR DESCRIPTION
### Brief summary of what the package does

This is a new major mode for the ReScript language (https://rescript-lang.org/).

### Direct link to the package repository

https://github.com/jjlee/rescript-mode

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

Re checkdoc and the single-file advice:

The indentation code in rescript-indent.el is derived from js.el in Emacs (it's just that code cut down, currently), so I've kept that in a separate file -- it does not pass checkdoc, but it probably wouldn't benefit anybody for me to go filling in docstrings for a lot of details that I'll get wrong because I don't know the code in that much detail (not yet anyway).  I don't think rescript-indent.el is much use separate from rescript-mode.el, but it's pretty separate from it in implementation, so because of that and the checkdoc issue I kept them as two files despite the advice in the MELPA contributors guide.

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings (see caveat above)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
