### PR TITLE
Add pzel/weblio package from github

### DIFF
--- a/recipes/weblio
+++ b/recipes/weblio
@@ -1,0 +1,1 @@
+(weblio :repo "pzel/weblio" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a small utility package that looks up Japanese words on the online weblio.jp dictionary. It provides no modes, just two functions which the user can call directly or bind to keys.

### Direct link to the package repository

https://github.com/pzel/weblio

### Your association with the package

I am the author of this package.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

- [x ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [ x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
