### PR TITLE
Add graphql-doc package recipe

### DIFF
--- a/recipes/graphql-doc
+++ b/recipes/graphql-doc
@@ -1,0 +1,1 @@
+(graphql-doc :repo "ifitzpatrick/graphql-doc.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Uses the GraphQL introspection API to provide clickable documentation inside Emacs for GraphQL endpoints.

### Direct link to the package repository

https://github.com/ifitzpatrick/graphql-doc.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
