### PR TITLE
Remove markdown-mode+ recipe.

### DIFF
--- a/recipes/markdown-mode+
+++ b/recipes/markdown-mode+
@@ -1,5 +1,0 @@
-(markdown-mode+ :repo "milkypostman/markdown-mode-plus"
-                :fetcher github
-                :files ("markdown-mode+.el"
-                        "HTML as Markdown in Emacs.applescript"))
-


### PR DESCRIPTION
I have decided to deprecate this package because there an existing issue (see https://github.com/milkypostman/markdown-mode-plus/issues/4) with using old functions.

Since I don't actively maintain the package and I don't see a huge amount of use, I've decided to just deprecated the package and remove it from MELPA. It's broke as far as I've been told, I'm not sure how beneficial it is for other users. If people *need* it they can easily install manually or help maintain it and then it can be added back to MELPA.
