### PR TITLE
Create alectryon

### DIFF
--- a/recipes/alectryon
+++ b/recipes/alectryon
@@ -3,4 +3,4 @@
  :repo "cpitclaudel/alectryon"
  :commit "55fc849cdb7a05bbaab6f9359386d8830bdcfb87"
  :branch "master"
- :files ("etc/elisp/*.el"))
+ :files ("etc/elisp/"))

--- a/recipes/alectryon
+++ b/recipes/alectryon
@@ -1,6 +1,1 @@
-(alectryon
- :fetcher github
- :repo "cpitclaudel/alectryon"
- :commit "55fc849cdb7a05bbaab6f9359386d8830bdcfb87"
- :branch "master"
- :files ("etc/elisp/*"))
+(alectryon :fetcher github :repo "cpitclaudel/alectryon" :files ("etc/elisp/*"))

--- a/recipes/alectryon
+++ b/recipes/alectryon
@@ -3,4 +3,4 @@
  :repo "cpitclaudel/alectryon"
  :commit "55fc849cdb7a05bbaab6f9359386d8830bdcfb87"
  :branch "master"
- :files ("etc/elisp/alectryon.el"))
+ :files ("etc/elisp/*.el"))

--- a/recipes/alectryon
+++ b/recipes/alectryon
@@ -1,0 +1,6 @@
+(alectryon
+ :fetcher github
+ :repo "cpitclaudel/alectryon"
+ :commit "55fc849cdb7a05bbaab6f9359386d8830bdcfb87"
+ :branch "master"
+ :files ("etc/elisp/alectryon.el"))

--- a/recipes/alectryon
+++ b/recipes/alectryon
@@ -3,4 +3,4 @@
  :repo "cpitclaudel/alectryon"
  :commit "55fc849cdb7a05bbaab6f9359386d8830bdcfb87"
  :branch "master"
- :files ("etc/elisp/"))
+ :files ("etc/elisp/*"))


### PR DESCRIPTION
### Brief summary of what the package does

This package is a thin wrapper around Alectryon's editor support
(https://github.com/cpitclaudel/alectryon). The idea is to easily switch
between a code-first and a text-first view of a literate file.

### Direct link to the package repository

https://github.com/cpitclaudel/alectryon/tree/master

### Your association with the package

I am an enthusiastic user

### Relevant communications with the upstream package maintainer

**None needed**
upstream package maintainer: @cpitclaudel 

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
