### PR TITLE
Add elforth recipe

### DIFF
--- a/recipes/elforth
+++ b/recipes/elforth
@@ -1,0 +1,1 @@
+(elforth :fetcher github :repo "lassik/elforth")


### PR DESCRIPTION
### Brief summary of what the package does

It's well established that Real Programmers use Emacs, and equally well known that the determined Real Programmer can write Forth in any language. This package is the logical conclusion. Those who know what is right and true are now liberated to program the One True Editor in the One True Language.

### Direct link to the package repository

https://github.com/lassik/elforth

### Your association with the package

Just wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them