### PR TITLE
Delete pointback

### DIFF
--- a/recipes/pointback
+++ b/recipes/pointback
@@ -1,1 +1,0 @@
-(pointback :fetcher github :repo "emacsorphanage/pointback")


### PR DESCRIPTION
Per its description, its function is part of standard emacs. I don't know how many versions ago this has been the case...

ref: https://github.com/melpa/emacsattic/pointback

### Brief summary of what the package does

Maintains window-specific values of point, mark, and "view port" (my term) for any buffer appearing in more than one window.

