### PR TITLE
slurm mode in emacs

### DIFF
--- a/recipes/slurm-mode
+++ b/recipes/slurm-mode
@@ -1,0 +1,1 @@
+(slurm-mode :fetcher github :repo "ffevotte/slurm.el")


### PR DESCRIPTION
### Brief summary of what the package does

slurm-mode is an Emacs extension allowing to work more easily with the [SLURM](https://github.com/SchedMD/slurm) job scheduling system. It provides an interface to directly monitor/interact with the jobs in the slum-based server. Moreover, It uses the tramp to simultaneously work with multiple servers.

### Direct link to the package repository

https://github.com/ffevotte/slurm.el

### Your association with the package
I am a contributor and an enthusiastic user

### Relevant communications with the upstream package maintainer

https://github.com/ffevotte/slurm.el/issues/2

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
