### PR TITLE
Add create-link recipe

### DIFF
--- a/recipes/create-link
+++ b/recipes/create-link
@@ -1,0 +1,1 @@
+(create-link :repo "kijimaD/create-link" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A package to generate easily format links on browser(eww, w3m).

If you at Google page, `M-x create-link` save below:
- `<a href="https://www.google.com/">Google</a>`(html)
- `[Google](https://www.google.com/)`(markdown)
- `[https://www.google.com/ Google]`(wiki)

It would be very useful to be able to get these named links easily!

### Direct link to the package repository

https://github.com/kijimaD/create-link

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
