### PR TITLE
Update recipe for pdf-tools

### DIFF
--- a/recipes/pdf-tools
+++ b/recipes/pdf-tools
@@ -1,6 +1,6 @@
 (pdf-tools
  :fetcher github
- :repo "politza/pdf-tools"
+ :repo "vedang/pdf-tools"
  :files ("lisp/*.el"
          "README"
          ("build" "Makefile")


### PR DESCRIPTION
Hello all,

I've taken over maintainership of the `pdf-tools` package, as
described in politza/pdf-tools#659. This commit changes the MELPA
recipe to use my fork of the package.

Thanks!
Vedang

Closes vedang/pdf-tools#10

### Brief summary of what the package does
Emacs support library for PDF files. 

### Direct link to the package repository
https://github.com/vedang/pdf-tools

### Your association with the package
- Package Maintainer

### Relevant communications with the upstream package maintainer
politza/pdf-tools#659

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly - There is 1 warning that needs to be fixed, I'll need to look into the suggested change to do it. Skipping it for now.
- [X] `M-x checkdoc` is happy with my docstrings - It is not, but fixing this is non-trivial. I will track this in a separate task.
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I have confirmed some of these without doing them - I've added notes  in all these cases
<!-- After submitting, please fix any problems the CI reports. -->
