### PR TITLE
Add recipe for frontside-windowing

### DIFF
--- a/recipes/frontside-windowing
+++ b/recipes/frontside-windowing
@@ -1,0 +1,5 @@
+(frontside-windowing
+ :fetcher github
+ :repo "thefrontside/frontmacs"
+ :files ("packages/windowing/*.el"
+         (:exclude "packages/windowing/*-test.el")))


### PR DESCRIPTION
### Brief summary of what the package does

When using compilation buffers or other commands that split windows vertically or horizontally, the way in which Emacs splits windows can vary greatly depending on the frame size. This adds some consistency on how the windows split by making a preference to splitting the window evenly in half, and keeping it to two splits.

This is the technique we've been using for years, and so wanted to make it generally available as we try and break out our monolithic configuration into a bunch of loosely coupled packages.

### Direct link to the package repository

https://github.com/thefrontside/frontmacs/tree/release/packages/windowing

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist


- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)