### PR TITLE
Add langtool-ignore-fonts recipe

### DIFF
--- a/recipes/langtool-ignore-fonts
+++ b/recipes/langtool-ignore-fonts
@@ -1,0 +1,1 @@
+(langtool-ignore-fonts :fetcher github :repo "cjl8zf/langtool-ignore-fonts" :files ("langtool-ignore-fonts.el"))

--- a/recipes/langtool-ignore-fonts
+++ b/recipes/langtool-ignore-fonts
@@ -1,1 +1,1 @@
-(langtool-ignore-fonts :fetcher github :repo "cjl8zf/langtool-ignore-fonts" :files ("langtool-ignore-fonts.el"))
+(langtool-ignore-fonts :fetcher github :repo "cjl8zf/langtool-ignore-fonts" :files (:defaults (:exclude "doc/*")))


### PR DESCRIPTION
### Brief summary of what the package does

When running Emacs-Langtool on a buffer containing a markup language, Langtool will highlight many false positives. This is especially true for documents written in LaTeX. This packages adds the option to force the Emacs-Langtool package to ignore certain fonts. For example, this can be used to stop Langtool from highlighting LaTeX in math-mode. The idea here is that the major mode should have put in a lot of thought to identifying the various parts of the document.

This package extends the features of the Emacs-langtool package found at  https://github.com/mhayashi1120/Emacs-langtool A few months ago I reached out to the maintainer of that package about incorporating these changes, but never heard back from them. I believe this package is worth adding to MELPA, because it drastically increases the usability of the langtool-package. 

### Direct link to the package repository

https://github.com/cjl8zf/langtool-ignore-fonts

### Your association with the package

I am the maintainer and creator. 

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
