### PR TITLE
Add battery-notifier recipe

### DIFF
--- a/recipes/battery-notifier
+++ b/recipes/battery-notifier
@@ -1,0 +1,1 @@
+(battery-notifier :repo "jasonmj/battery-notifier" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This global minor mode sends notifications when battery capacity is low and suspends the computer when battery capacity is critically low.

### Direct link to the package repository

https://github.com/jasonmj/battery-notifier

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

This is a new package.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
