### PR TITLE
Update `eldev` recipe to include scripts in `bin/`

### DIFF
--- a/recipes/eldev
+++ b/recipes/eldev
@@ -1,2 +1,3 @@
 (eldev :repo "doublep/eldev"
-       :fetcher github)
+       :fetcher github
+       :files (:defaults ("bin" "bin/*") (:exclude "bin/*.in" "bin/*.part")))


### PR DESCRIPTION
This updates package recipe for Eldev to include the scripts in its `bin/` directory. The changes are written in such a way as to hopefully not require further changes if even more scripts are added.

Originally this wasn't needed since the script was supposed to be installed manually and then pull the package from MELPA; the script wouldn't change later. However, as of 0.9 we have added scripts for Windows (along the shell script), which got later tweaked in 0.9.1, and at the same time the shell script was also subtly modified.

In short, Eldev's self-upgrading procedure must now also upgrade the binary scripts if necessary, but this is not robustly possible if the scripts are not included into the package. I feel that bundling them with the package is much better than downloading separately from an "unrelated" URL in the internet (i.e. from GitHub).