### PR TITLE
Add recipe for persp-mode-project-bridge

### DIFF
--- a/recipes/persp-mode-project-bridge
+++ b/recipes/persp-mode-project-bridge
@@ -1,0 +1,2 @@
+(persp-mode-project-bridge :repo "CIAvash/persp-mode-project-bridge"
+                           :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Integration of `persp-mode` and `project.el`.

### Direct link to the package repository

https://github.com/CIAvash/persp-mode-project-bridge

### Your association with the package

maintainer, contributer

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Additional notes

This project is a fork of [Bad-ptr/persp-mode-projectile-bridge.el](https://github.com/Bad-ptr/persp-mode-projectile-bridge.el). But I changed it to work with `project.el`.