### PR TITLE
Add recipe for buffer-env

### DIFF
--- a/recipes/buffer-env
+++ b/recipes/buffer-env
@@ -1,0 +1,1 @@
+(buffer-env :fetcher github :repo "astoff/buffer-env")


### PR DESCRIPTION
### Brief summary of what the package does

This package is a low-end knockoff of the envrc package which doesn't depend on the direnv program. It relies entirely on ordinary shell scripts.

If this seems like a futile thing to do, I will not insist on having it on MELPA. That said, some people might enjoy having one less dependency. Moreover, in some situations this package can be a bit more flexible than envrc. For instance, one can activate a Python virtualenv directly, either interactively or by setting some dir-local variables. This is a task for which there is already a dozen packages on MELPA, yes, but AFAICT none does it buffer locallly.

### Direct link to the package repository

https://github.com/astoff/buffer-env

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
