### PR TITLE
Add recipe side-hustle

### DIFF
--- a/recipes/side-hustle
+++ b/recipes/side-hustle
@@ -1,0 +1,1 @@
+(side-hustle :fetcher github :repo "rnkn/side-hustle")


### PR DESCRIPTION
### Brief summary of what the package does

Navigate Imenu as a list in a side window. Press RET to go to an item, SPC to show. Items with child items can be collapsed/expanded.

This package achieves a very similar thing as [Imenu-list](https://github.com/bmag/imenu-list) but takes a different approach, permitting navigation of multiple buffers, doesn't require a global minor mode, or timers, or hide-show, and uses dedicated side-windows

### Direct link to the package repository

https://github.com/rnkn/side-hustle

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

n.b. I include a convenience alias `toggle-side-hustle` for command `side-hustle-toggle`.

- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
