### PR TITLE
Add recipe devdocs-browser

### DIFF
--- a/recipes/devdocs-browser
+++ b/recipes/devdocs-browser
@@ -1,0 +1,2 @@
+(devdocs-browser :fetcher github
+                 :repo "blahgeek/emacs-devdocs-browser")


### PR DESCRIPTION
### Brief summary of what the package does

This package allows browsing devdocs.io documents inside Emacs using EWW

### Direct link to the package repository

https://github.com/blahgeek/emacs-devdocs-browser

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
