### PR TITLE
Add c-eval recipe

### DIFF
--- a/recipes/c-eval
+++ b/recipes/c-eval
@@ -1,0 +1,1 @@
+(c-eval :fetcher github :repo "lassik/emacs-c-eval")


### PR DESCRIPTION
### Brief summary of what the package does

By analogy with the Lisp Interaction mode that comes with Emacs, this package provides commands to instantly compile and run C code.

Use `c-eval-scratch` to get a buffer in which to write code. You can also evaluate code from other buffers.

The following commands execute a C program from the current buffer:

* `c-eval-buffer`
* `c-eval-region`

The following commands evaluate C code from the minibuffer:

* `c-eval-expression`
* `c-eval-sizeof`

### Direct link to the package repository

https://github.com/lassik/emacs-c-eval

### Your association with the package

Just wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them