### PR TITLE
Moved consult-flycheck to separate repository

### DIFF
--- a/recipes/consult
+++ b/recipes/consult
@@ -1,4 +1,3 @@
 (consult
  :repo "minad/consult"
- :fetcher github
- :files (:defaults (:exclude "consult-flycheck.el")))
+ :fetcher github)

--- a/recipes/consult-flycheck
+++ b/recipes/consult-flycheck
@@ -1,4 +1,4 @@
 (consult-flycheck
- :repo "minad/consult"
+ :repo "minad/consult-flycheck"
  :fetcher github
  :files ("consult-flycheck.el"))


### PR DESCRIPTION
Consult will be submitted to ELPA, excluding consult-flycheck.el. Therefore I am
maintaing the supplementary package consult-flycheck.el in a separate repository
now. This makes it more straightforward to synchronize the Consult repository with the ELPA repository.

Can this be merged soon, since it just adjusts the repository location and I would like to not break the distribution channel?

Thanks!

cc @purcell

---

Regarding the question if Consult should be moved off from MELPA - there has been some discussion regarding that in the case of the modus-themes. I would also like to distribute Consult via both channels if possible. MELPA can be used for nightly installs, ELPA for stable releases.