### PR TITLE
Remove bang

### DIFF
--- a/recipes/bang
+++ b/recipes/bang
@@ -1,1 +1,0 @@
-(bang :url "https://git.sr.ht/~zge/bang" :fetcher git)


### PR DESCRIPTION
As first brought up in  #7305, I was thinking about removing a few of my packages from MELPA. The package `bang` has been informally deprecated for a while now, replaced by [shell-command+](http://elpa.gnu.org/packages/shell-command+.html). Until now I have kept both versions, but seeing that I was [requested to tag releases](https://lists.sr.ht/~zge/public-inbox/%3C87a6ojkx28.fsf%40yoctocell.xyz%3E), I am afraid that this might confuse the MELPA version, as I am still hosting both versions in the same repository, just using two different branches.

So this pull request just deletes the recipe for bang, officially deprecating the package.