### PR TITLE
Remove go-capf

### DIFF
--- a/recipes/go-capf
+++ b/recipes/go-capf
@@ -1,1 +1,0 @@
-(go-capf :url "https://git.sr.ht/~zge/go-capf" :fetcher git)


### PR DESCRIPTION
As mentioned in https://github.com/melpa/melpa/issues/7305#issuecomment-751285079, broken packages should be removed.

As `go-capf` depends on [gocode](https://github.com/nsf/gocode#an-autocompletion-daemon-for-the-go-programming-language), that has been repeatedly broken by the last few releases of Go, and the [newest version suggest using LSP](https://github.com/stamblerre/gocode#important-this-fork-of-gocode-is-currently-in-maintenance-mode-for-a-better-development-experience-with-go-modules-we-suggest-you-use-the-go-language-server-gopls) instead, keeping this package in the archive does not seem to make much sense, and will probably just confuse a users.