### PR TITLE
add lsp-docker+ recipe

### DIFF
--- a/recipes/lsp-docker+
+++ b/recipes/lsp-docker+
@@ -1,0 +1,3 @@
+(lsp-docker+
+ :repo "y-kitamu/emacs-lsp-docker-plus"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`lsp-docker+` is convenient wrapper for `lsp-docker`.
This package make it easier to switch language server via settings in `.dir-locals.el`.  
One can easily use an actual development environment (docker image) as language server.

### Direct link to the package repository

https://github.com/y-kitamu/emacs-lsp-docker-plus

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
