### PR TITLE
Add package-loading-notifier

### DIFF
--- a/recipes/package-loading-notifier
+++ b/recipes/package-loading-notifier
@@ -1,0 +1,1 @@
+(package-loading-notifier :fetcher github :repo "tttuuu888/package-loading-notifier")


### PR DESCRIPTION
### Brief summary of what the package does

`package-loading-notifier` is to notify user that a specific package is being loaded. The loading time of some packages are relatively longer than small packages and it make Emacs seems freezing for a second or less. `package-loading-notifier` is for those situation.

### Direct link to the package repository

https://github.com/tttuuu888/package-loading-notifier

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
