### PR TITLE
Add company-org-block

### DIFF
--- a/recipes/company-org-block
+++ b/recipes/company-org-block
@@ -1,0 +1,3 @@
+(company-org-block
+ :fetcher github
+ :repo "xenodium/company-org-block")


### PR DESCRIPTION
### Brief summary of what the package does

A company completion backend for org blocks.

### Direct link to the package repository

https://github.com/xenodium/company-org-block

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
