### PR TITLE
Update recipe for devdocs

### DIFF
--- a/recipes/devdocs
+++ b/recipes/devdocs
@@ -1,2 +1,1 @@
-(devdocs :fetcher github
-         :repo "xuchunyang/DevDocs.el")
+(devdocs :fetcher github :repo "astoff/devdocs.el")


### PR DESCRIPTION
### Brief summary of what the package does

devdocs.el is a documentation viewer similar to the built-in Info browser, but geared towards documentation obtained from the DevDocs website. This package subsumes the existing devdocs package, which wasn't actively maintained anymore.

The package has already been included in GNU ELPA. In fact, I would have a slight preference for removing it from MELPA; this is purely due to the version numbering scheme (I'm fine with either system, but I'd rather have just one version of the package widely available at any given time). In any case, I have included an updated recipe; you can decide whether to merge it or simply remove the recipe.

### Direct link to the package repository

https://github.com/astoff/devdocs.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

Communication with the author of the old version of the package, where maintainership is handed over: https://github.com/xuchunyang/DevDocs.el/issues/4

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
