### PR TITLE
Delete sos

### DIFF
--- a/recipes/pointback
+++ b/recipes/pointback
@@ -1,1 +1,0 @@
-(pointback :fetcher github :repo "emacsorphanage/pointback")

--- a/recipes/sos
+++ b/recipes/sos
@@ -1,1 +1,0 @@
-(sos :fetcher github :repo "emacsattic/sos")


### PR DESCRIPTION
Post questions to stackexchange, and present answers

ERROR: 404: https://github.com/omouse/emacs-sos

https://github.com/emacsattic/sos/tree/1573adca912b88b5010d99a25c83a5b2313bd39c

1) in my testing in emacs 27, the requests it makes return an error responses indicating that it's not sending information in a way upstream can parse.
2) It seems last updated in 2014
3) The homepage returns a 404 error
4) It's already in the emacs attic
5) MELPA package 'howdoyou' seems to cover all the functionality, is currently maintained, and it works.

### Your association with the package

None.

### Relevant communications with the upstream package maintainer

None.

