### PR TITLE
add Citre

### DIFF
--- a/recipes/citre
+++ b/recipes/citre
@@ -1,0 +1,1 @@
+(citre :repo "universal-ctags/citre" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Citre is an advanced Ctags (or actually, readtags) frontend for Emacs.

### Direct link to the package repository

https://github.com/universal-ctags/citre

### Your association with the package

I'm the head maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)

- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

    (NOTE: I leave some of the "symbol doesn't start with prefix" errors. My naming convention is user options and private symbols starts with `citre-`, but `package-lint` thinks like "if it's in `citre-core.el`, it should start with `citre-core-`".)

- [x] My elisp byte-compiles cleanly

- [x] `M-x checkdoc` is happy with my docstrings

    (My CI runs `checkdoc`)

- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
