### PR TITLE
Add seriestracker

### DIFF
--- a/recipes/seriesTracker
+++ b/recipes/seriesTracker
@@ -1,2 +1,0 @@
-(seriesTracker :fetcher github
-               :repo "maximewack/seriesTracker")

--- a/recipes/seriesTracker
+++ b/recipes/seriesTracker
@@ -1,0 +1,2 @@
+(seriesTracker :fetcher github
+               :repo "maximewack/seriesTracker")

--- a/recipes/seriestracker
+++ b/recipes/seriestracker
@@ -1,3 +1,2 @@
 (seriestracker :fetcher github
-               :repo "MaximeWack/seriestracker"
-               :branch "develop")
+               :repo "MaximeWack/seriestracker")

--- a/recipes/seriestracker
+++ b/recipes/seriestracker
@@ -1,0 +1,3 @@
+(seriestracker :fetcher github
+               :repo "MaximeWack/seriestracker"
+               :branch "develop")


### PR DESCRIPTION
Upstream is github:maximewack/seriestracker

### Brief summary of what the package does

seriestracker implements a major mode for tracking TV shows.
TV shows data (episode list, release dates, etc.)
are sourced from the free database hosted at episodate.com
The mode presents an outlined list of tracked shows,
their episodes and release dates, and enables the user
to see when new episodes for their favorite shows get released,
and track their progress in watching a series.

### Direct link to the package repository

https://github.com/MaximeWack/seriestracker

### Your association with the package

I am the author and maintainer of this package

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
