### PR TITLE
Adding ob-swiftui recipe

### DIFF
--- a/recipes/ob-swiftui
+++ b/recipes/ob-swiftui
@@ -1,0 +1,3 @@
+(ob-swiftui
+ :fetcher github
+ :repo "xenodium/ob-swiftui")


### PR DESCRIPTION
### Brief summary of what the package does

Evaluate SwiftUI snippets using Emacs org babel.

### Direct link to the package repository

https://github.com/xenodium/ob-swiftui

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
