### PR TITLE
Add recipe for project-mode-line-tag

### DIFF
--- a/recipes/project-mode-line-tag
+++ b/recipes/project-mode-line-tag
@@ -1,0 +1,1 @@
+(project-mode-line-tag :fetcher github :repo "fritzgrabo/project-mode-line-tag")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a global minor mode to display information about a buffer's project (a "project tag") in its mode line.

A buffer's project tag is derived from either its `project.el` project's root directory (e.g. `bar` for `/code/foo/bar`) or, if present, a [dir-local variable](https://www.gnu.org/software/emacs/manual/html_node/elisp/Directory-Local-Variables.html) named `project-mode-line-tag` or `project-name`.

The face applied to the project tag and the format of how to display it in the mode line are fully customizable.

![project-mode-line-tag](https://user-images.githubusercontent.com/592734/122107158-11065a80-ce1b-11eb-889f-8423a5d42759.png)

### Direct link to the package repository

https://github.com/fritzgrabo/project-mode-line-tag

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly, **BUT SEE BELOW**
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Compiling under Emacs 28 yields this warning:

```
In project-mode-line-tag--project-tag:
project-mode-line-tag.el:87:60: Warning: ‘project-roots’ is an obsolete
    function (as of 0.3.0); use ‘project-root’ instead.
```

Please note that I'm using the obsolete function `project-roots` (vs. its replacement `project-root`) on purpose here to maintain support for Emacs versions down to 25.1.