### PR TITLE
Add Cap'n Proto mode.

### DIFF
--- a/recipes/capnp-mode
+++ b/recipes/capnp-mode
@@ -1,0 +1,4 @@
+(capnp-mode
+ :repo "capnproto/capnproto"
+ :fetcher github
+ :files ("highlighting/emacs/capnp-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for editing Capn' Proto Files.
Cap'n Proto is an insanely fast data interchange format and capability-based RPC system.

### Direct link to the package repository

https://github.com/capnproto/capnproto

### Your association with the package

An enthusiastic user?

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
