### PR TITLE
Add recipe for uci-mode

### DIFF
--- a/recipes/uci-mode
+++ b/recipes/uci-mode
@@ -1,0 +1,3 @@
+(uci-mode
+ :fetcher github
+ :repo "dwcoates/uci-mode")


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs major-mode for chess engine interaction.  This is a dependency for the more interesting library [pygn-mode](https://github.com/dwcoates/pygn-mode), to be submitted separately.

### Direct link to the package repository

https://github.com/dwcoates/uci-mode

### Your association with the package

A contributor, on behalf of @dwcoates .

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
