### PR TITLE
Cursor flash

### DIFF
--- a/recipes/cursor-flash
+++ b/recipes/cursor-flash
@@ -1,0 +1,3 @@
+(cursor-flash
+ :fetcher github
+ :repo "Boruch-Baum/emacs-cursor-flash")

--- a/recipes/pointback
+++ b/recipes/pointback
@@ -1,1 +1,0 @@
-(pointback :fetcher github :repo "emacsorphanage/pointback")


### PR DESCRIPTION
### Brief summary of what the package does

* Highlights the cursor on buffer/window-switch

* Flashes a square of positions around POINT for a customizable interval.

This package temporarily highlights the area immediately surrounding POINT when navigating amongst buffers and windows. It is intended to assist in visually identifying the current POINT and the current window when many windows are on the same frame or when windows are very large (related (stackexchange question)[https://unix.stackexchange.com/questions/83167/emacs-finding-the-cursor-in-multiple-windows]).

NOTE: checkdoc complains about the package keywords I've chosen, but they come directly from the Emacs 27 info list

### Direct link to the package repository

https://github.com/Boruch-Baum/emacs-cursor-flash

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
