### PR TITLE
Fix/flycheck grammalecte

### DIFF
--- a/recipes/flycheck-grammalecte
+++ b/recipes/flycheck-grammalecte
@@ -1,4 +1,4 @@
 (flycheck-grammalecte
  :fetcher git
  :url "https://git.umaneti.net/flycheck-grammalecte/"
- :files (:defaults "*.py"))
+ :files (:defaults "*.py" (:exclude "test-profile.el")))

--- a/recipes/flycheck-grammalecte
+++ b/recipes/flycheck-grammalecte
@@ -1,4 +1,4 @@
 (flycheck-grammalecte
  :fetcher git
  :url "https://git.umaneti.net/flycheck-grammalecte/"
- :files (:defaults "flycheck-grammalecte.py" "conjugueur.py"))
+ :files (:defaults "*.py"))


### PR DESCRIPTION
This MR replace the specific python file list by a wildcard on python file in order to prepare this package to the upstream renaming of one of the required python files. Using a glob instead of the current list will not change the content of the package as the result of the glob is the same thing as the current list. It will only make evolution of this package more flexible if the python file name change again, are removed, etc.

This MR also remove a test related lisp files from the package.

### Brief summary of what the package does

French grammar checker

### Direct link to the package repository

https://git.umaneti.net/flycheck-grammalecte/

### Your association with the package

I’m the current maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them