### PR TITLE
Remove auth-source-pass as it is in Emacs core

### DIFF
--- a/recipes/auth-source-pass
+++ b/recipes/auth-source-pass
@@ -1,4 +1,0 @@
-(auth-source-pass
- :fetcher github
- :repo "DamienCassou/auth-source-pass"
- :old-names (auth-password-store))


### PR DESCRIPTION
By this patch, I'm removing auth-source-pass from melpa. I prefer people to use the version from Emacs core instead. I plan to delete the github repository at some point.