### PR TITLE
Add recipe for pygn-mode

### DIFF
--- a/recipes/pygn-mode
+++ b/recipes/pygn-mode
@@ -1,0 +1,6 @@
+(pygn-mode
+ :fetcher github
+ :repo "dwcoates/pygn-mode"
+ :files (:defaults
+         "pygn_server.py"
+         "lib"))


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs major mode for viewing and editing chess games in Portable Game Notation (PGN).  Followup to #7617.

The package includes Python files as well as Elisp.

### Direct link to the package repository

https://github.com/dwcoates/pygn-mode

### Your association with the package

A contributor, on behalf of @dwcoates  .

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback ~~[one issue remaining]~~ fixed
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->

### Issues

1. ~~`package-lint` is still reporting `error: Package uci-mode is not installable`.  After #7617 was merged, why should that be true? (Same issue when trying to install from the recipe.)~~ Fixed.
2. I want to make sure the licensing is perfectly clear to every user.  Pygn-mode is BSD licensed, but it bundles the complete source of the Python [chess](https://pypi.org/project/chess/) library, which is GLP3.  The `chess` library's license is included along with its source under the `lib` directory.  Are there any other recommendations to keep the two licenses straight?