### PR TITLE
Add recipe for flymake-rest

### DIFF
--- a/recipes/flymake-rest
+++ b/recipes/flymake-rest
@@ -1,0 +1,4 @@
+(flymake-rest
+ :fetcher github
+ :repo "mohkale/flymake-rest"
+ :files ("*.el" "checkers/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Provide helpers for replacing flycheck with flymake including a flycheck like error parser and several builtin checker definitions.

### Direct link to the package repository

https://github.com/mohkale/flymake-rest

### Your association with the package

Package Author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

**Note**: I plan to complete these soon.

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
