### PR TITLE
Create math-mode

### DIFF
--- a/recipes/math-mode
+++ b/recipes/math-mode
@@ -1,0 +1,3 @@
+(helm-mypackage :repo "ashok-khanna/math-mode"
+                :fetcher github
+                :files ("math-mode.el"))

--- a/recipes/math-mode
+++ b/recipes/math-mode
@@ -1,3 +1,1 @@
-(math-mode :repo "ashok-khanna/math-mode"
-                :fetcher github
-                :files ("math-mode.el"))
+(math-mode :repo "ashok-khanna/math-mode" :fetcher github)

--- a/recipes/math-mode
+++ b/recipes/math-mode
@@ -1,3 +1,3 @@
-(helm-mypackage :repo "ashok-khanna/math-mode"
+(math-mode :repo "ashok-khanna/math-mode"
                 :fetcher github
                 :files ("math-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Easy access to 80 math symbols via a Hydra popup menu. Symbol keybindings are carefully thought through to be sensible and mnemonic (as much as possible). Covers most requirements in Math.

### Direct link to the package repository

https://github.com/ashok-khanna/math-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

package-lint giving me the error "This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)". However I want to stick to C-c m and C-c n as the purpose is for easy math shortcuts and thus a more cumbersome keybindings defeats the purpose of the whole package.

### Checklist

<!-- Please confirm with `x`: -->

- [ x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [ x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [ x] `M-x checkdoc` is happy with my docstrings
- [ x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
