### PR TITLE
add recipe: org-roam-v1

### DIFF
--- a/recipes/org-roam-v1
+++ b/recipes/org-roam-v1
@@ -1,0 +1,2 @@
+(org-roam-v1 :fetcher github
+             :repo "org-roam/org-roam-v1")


### PR DESCRIPTION
### Brief summary of what the package does

This is just the current version of Org-roam, which will soon be superceded by a large breaking (conceptual) change. To facilitate people staying on the current version, I created a new repo that's pinned to that version.

The current upgrade plan is:

1. Merge v2 branch into master for `org-roam`. The implication is that those who run upgrade to a new version by pulling from MELPA will have their configs break.
2. Point people who don't wish to make the migration yet to just use `org-roam-v1` from MELPA.

I'm doing it this way around because I want v2 to be the original repository, so it inherits all the issues etc. that it had in GitHub.

If someone has another suggestion I'm all ears.

### Direct link to the package repository

https://github.com/org-roam/org-roam-v1

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
