### PR TITLE
Adjust repo name to reflect new organization

### DIFF
--- a/recipes/circe
+++ b/recipes/circe
@@ -1,1 +1,1 @@
-(circe :repo "jorgenschaefer/circe" :fetcher github)
+(circe :repo "emacs-circe/circe" :fetcher github)


### PR DESCRIPTION
Circe has moved from https://github.com/jorgenschaefer/circe to https://github.com/emacs-circe/circe. I'm a contributor and have been granted maintainer access for the new organization.