### PR TITLE
add ivy-nixos-options

### DIFF
--- a/recipes/ivy-nixos-options
+++ b/recipes/ivy-nixos-options
@@ -1,0 +1,3 @@
+(ivy-nixos-options :fetcher github
+                    :repo "travisbhartwell/nix-emacs"
+                    :files ("ivy-nixos-options.el"))


### PR DESCRIPTION
This is similar to helm-nixos-options, which is in the same repo as
ivy-nixos-options and already in melpa. There are two issues here I
should point out:

- none of the files in the upstream repo have lexical binding enabled.
Since there are already recipes for all the other files in melpa
anyway, I wouldn't expect this to be a blocker. I have opened a PR
to fix this.
- This recipe doesn't build for stable melpa. The only upstream tag
is before the file was included in the repo, so make STABLE=t fails
with

Updating /home/rski/Code/melpa/working/ivy-nixos-options/ Debugger
entered--Lisp error: (error "No matching file(s) found in
/home/rski/Code/melpa...") error("No matching file(s) found in %s: %s"
"/home/rski/Code/melpa/working/ivy-nixos-options/" ("ivy-nixos-options.el"))

I can ask for a new tag upstream, but what is of most interest to me
is whether this problem is a blocker for merging the recipe or not.

### Brief summary of what the package does

Browse though NixOS options using ivy.

### Direct link to the package repository

https://github.com/travisbhartwell/nix-emacs

### Your association with the package

enthusiastic user

### Relevant communications with the upstream package maintainer

https://github.com/travisbhartwell/nix-emacs/pull/54
https://github.com/travisbhartwell/nix-emacs/pull/55

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
