### PR TITLE
Add recipe for notink-theme

### DIFF
--- a/recipes/notink-theme
+++ b/recipes/notink-theme
@@ -1,0 +1,3 @@
+(notink-theme
+ :fetcher github
+ :repo "MetroWind/notink-theme")


### PR DESCRIPTION
### Brief summary of what the package does

Notink theme is a custom theme for Emacs. Inspired by e-ink displays, it aims to be a comfortable grey-scale theme.

### Direct link to the package repository

https://github.com/MetroWind/notink-theme

### Your association with the package

Author, maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them. ;; Ahem… I see what you did here

<!-- After submitting, please fix any problems the CI reports. -->
