### PR TITLE
Added `dired-file-preview` recipe

### DIFF
--- a/recipes/dired-file-preview
+++ b/recipes/dired-file-preview
@@ -1,0 +1,1 @@
+(dired-file-preview :repo "SpringHan/dired-file-preview" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`dired-file-preview` is a package that allows users to use `dired` with preview support.

### Direct link to the package repository

https://github.com/SpringHan/dired-file-preview

### Your association with the package

I'm maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
