### PR TITLE
Add `netease-cloud-music` recipe

### DIFF
--- a/recipes/netease-cloud-music
+++ b/recipes/netease-cloud-music
@@ -1,0 +1,1 @@
+(netease-cloud-music :repo "SpringHan/netease-cloud-music.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`netease-cloud-music.el` is a client for Netease Cloud Music.

### Direct link to the package repository

https://github.com/SpringHan/netease-cloud-music.el

### Your association with the package

I'm maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
