### PR TITLE
New package: pifc

### DIFF
--- a/recipes/pifc
+++ b/recipes/pifc
@@ -1,0 +1,1 @@
+(pifc :repo "w3bdev1/pifc" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
- This package allows users to save clipboard image to org and markdown file.

### Direct link to the package repository
- [pifc repo](https://github.com/w3bdev1/pifc/)

### Your association with the package
- I am **author** and **maintainer**

### Relevant communications with the upstream package maintainer
- **None needed**

### Checklist
- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
