### PR TITLE
Add `all-the-icons-completion` recipe

### DIFF
--- a/recipes/all-the-icons-completion
+++ b/recipes/all-the-icons-completion
@@ -1,0 +1,2 @@
+(all-the-icons-completion :repo "iyefrat/all-the-icons-completion"
+                   :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package adds icons to completing read sessions when applicable. Basically does what `all-the-icons-ivy` does but for the Vertico/Selectrum/the built in completions buffer (see the repo for screenshots).

### Direct link to the package repository

https://github.com/iyefrat/all-the-icons-completion

### Your association with the package

I'm the maintainer and author.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
