### PR TITLE
add session-async to melpa

### DIFF
--- a/recipes/session-async
+++ b/recipes/session-async
@@ -1,0 +1,2 @@
+(session-async :fetcher git
+               :url "https://codeberg.org/FelipeLema/session-async.el.git")


### PR DESCRIPTION
### Brief summary of what the package does

Package for doing asynchronous processing in Emacs, just like [`async.el`](https://github.com/jwiegley/emacs-async)

Unlike `async.el`, the API for this package provides a separate Emacs session that can stay alive across async calls.

### Direct link to the package repository

https://codeberg.org/FelipeLema/session-async.el

### Your association with the package

Maintainer and owner 

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->

People in https://github.com/astahlman/ob-async/issues/1 are probably interested in this package.