### PR TITLE
Add recipe for consult-dir

### DIFF
--- a/recipes/consult-dir
+++ b/recipes/consult-dir
@@ -1,0 +1,1 @@
+(consult-dir :fetcher github :repo "karthink/consult-dir")


### PR DESCRIPTION
### Brief summary of what the package does

Consult-dir implements commands to jump to/switch directories easily in Emacs, including when using other Emacs commands.

The user can switch to any directory they've visited recently, or to a project or bookmarked directory. They can do this at any time, including when using the minibuffer. The minibuffer prompt is then replaced with the chosen directory.

The readme has demos showing how this works and some applications.

There is a discussion/review of this package [here](https://github.com/minad/consult/issues/373) with @minad, the author of the Consult package which this builds on.

### Direct link to the package repository

https://github.com/karthink/consult-dir

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
