### PR TITLE
org-roam: add "extensions" directory

### DIFF
--- a/recipes/org-roam
+++ b/recipes/org-roam
@@ -1,2 +1,3 @@
 (org-roam :fetcher github
-          :repo "org-roam/org-roam")
+          :repo "org-roam/org-roam"
+          :files (:defaults "extensions"))


### PR DESCRIPTION
### Brief summary of the change

Org-roam is undergoing a refactoring (see org-roam/org-roam#1724), which
will separate the package into 2 distinct components: the core (db,
capture etc.), and extensions which depend on the core (dailies,
graphing, protocol etc.). For clarity, these extensions will be placed
in the "extensions" directory.

This PR prepares the package for this change, including all lisp files
within the "extensions" directory.

### Direct link to the package repository

https://github.com/org-roam/org-roam

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
