### PR TITLE
Add recipe for help-find

### DIFF
--- a/recipes/help-find
+++ b/recipes/help-find
@@ -1,0 +1,1 @@
+(help-find :fetcher github :repo "duncanburke/help-find")


### PR DESCRIPTION
### Brief summary of what the package does

Additional help functions for working with keymaps.

This is especially useful when working with a highly customized set of keybindings. It is common both in Emacs itself and in external packages for assumptions to be made about keybinding defaults. This package provides functions to find which keymaps contain bindings for a particular key sequence or to a particular function.

### Direct link to the package repository

https://github.com/duncanburke/help-find

### Your association with the package

Creator

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
