### PR TITLE
org-roam: fix "extensions" directory

### DIFF
--- a/recipes/org-roam
+++ b/recipes/org-roam
@@ -1,3 +1,3 @@
 (org-roam :fetcher github
           :repo "org-roam/org-roam"
-          :files (:defaults "extensions"))
+          :files (:defaults "extensions/*"))


### PR DESCRIPTION
Just specifying the directory isn't enough to add Elisp files under this directory to the load-path and to generate autoloads from it. This causes issues like this https://github.com/org-roam/org-roam/issues/1748. Explicitly adding the wildcard should fix that, e.g. see https://github.com/org-roam/org-roam/pull/1724#issuecomment-894799473.

### Direct link to the package repository

https://github.com/org-roam/org-roam

### Your association with the package

A contributor / part time minor maintainer.

### Relevant communications with the upstream package maintainer
 **None needed** 

### Checklist
- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
