### PR TITLE
Update tsc to use the new URL for tree-sitter's repo

### DIFF
--- a/recipes/tsc
+++ b/recipes/tsc
@@ -1,4 +1,4 @@
-(tsc :repo "ubolonton/emacs-tree-sitter"
+(tsc :repo "emacs-tree-sitter/elisp-tree-sitter"
      :fetcher github
      :files ("core/*.el"
              "core/Cargo.toml"


### PR DESCRIPTION
The URL was updated for tree-sitter in commit 315cccb. This updates tsc to match.