### PR TITLE
Add librera-sync

### DIFF
--- a/recipes/librera-sync
+++ b/recipes/librera-sync
@@ -1,0 +1,2 @@
+(librera-sync :fetcher github
+              :repo "jumper047/librera-sync")


### PR DESCRIPTION
### Brief summary of what the package does
Synchronize current page in document with Librera Reader (book reading app for Android) and other Emacs instances.

### Direct link to the package repository

https://github.com/jumper047/librera-sync

### Your association with the package

I am a mantainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
