### PR TITLE
Add `minibuffer-modifier-keys` recipe

### DIFF
--- a/recipes/minibuffer-keypad-mode
+++ b/recipes/minibuffer-keypad-mode
@@ -1,0 +1,1 @@
+(minibuffer-keypad-mode :fetcher github :repo "SpringHan/minibuffer-keypad-mode")

--- a/recipes/minibuffer-keypad-mode
+++ b/recipes/minibuffer-keypad-mode
@@ -1,1 +1,0 @@
-(minibuffer-keypad-mode :fetcher github :repo "SpringHan/minibuffer-keypad-mode")

--- a/recipes/minibuffer-modifier-keys
+++ b/recipes/minibuffer-modifier-keys
@@ -1,0 +1,1 @@
+(minibuffer-modifier-keys :fetcher github :repo "SpringHan/minibuffer-modifier-keys")


### PR DESCRIPTION
### Brief summary of what the package does

Minibuffer-modifier-keys is a package that allows you to avoid using Ctrl, Meta in Emacs minibuffer.

### Direct link to the package repository

https://github.com/SpringHan/minibuffer-modifier-keys

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
