### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Enable installation of packages from MELPA by adding an entry to
 
 ```elisp
 (require 'package)
-(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/#/") t)
 ;; Comment/uncomment this line to enable MELPA Stable if desired.  See `package-archive-priorities`
 ;; and `package-pinned-packages`. Most users will not need or want to do this.
-;;(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/packages/") t)
+;;(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/#/") t)
 (package-initialize)
 ```
 


### PR DESCRIPTION
I just noticed that the URL for melpa is now `https://melpa.org/#/` instead of `https://melpa.org/packages/`. I'm sure this probably doesn't change anything but is also probably not a bad idea to have the new URL in the readme.
