### PR TITLE
Add recipe for filenotify-recursive

### DIFF
--- a/recipes/filenotify-recursive
+++ b/recipes/filenotify-recursive
@@ -1,0 +1,1 @@
+(filenotify-recursive :fetcher github :repo "jethrokuan/filenotify-recursive")


### PR DESCRIPTION
### Brief summary of what the package does

This package is like the in-built `filenotify`, but watches directories recursively. Whenever directories are created or destroyed, watchers are spawned and stopped appropriately.

This package was created to be used within `org-roam`: the database can then be kept up-to-date, tracking changes to the filesystem not directly caused by Emacs.

### Direct link to the package repository

https://github.com/jethrokuan/filenotify-recursive

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
