### PR TITLE
Rename evil-textobj-treesitter to evil-textobj-tree-sitter

### DIFF
--- a/recipes/evil-textobj-tree-sitter
+++ b/recipes/evil-textobj-tree-sitter
@@ -1,0 +1,5 @@
+(evil-textobj-tree-sitter
+  :fetcher github
+  :repo "meain/evil-textobj-tree-sitter"
+  :files (:defaults "queries")
+  :old-names (evil-textobj-treesitter))

--- a/recipes/evil-textobj-treesitter
+++ b/recipes/evil-textobj-treesitter
@@ -1,4 +1,0 @@
-(evil-textobj-treesitter
-  :fetcher github
-  :repo "meain/evil-textobj-tree-sitter"
-  :files (:defaults "queries"))


### PR DESCRIPTION
### Why the rename?

It was pointed out to me that the original library and all the other packages which depend on `tree-sitter` has the name spelt with the `-` in between and it would be better to keep it consistent:

- https://melpa.org/#/tree-sitter
- https://melpa.org/#/tree-sitter-langs
- https://melpa.org/#/tree-sitter-indent

So far from the mepla and github stats the actual number of users who will be affected will be low and I thought I would go ahead with the transition before more people start using the package. I have some [updates](https://github.com/meain/evil-textobj-tree-sitter/pull/6) scheduled to be done along with the change which I can merge in as soon as this gets merged in(Let me know if I should merge the package changes first).

> Discussion on Github https://github.com/meain/evil-textobj-tree-sitter/issues/3

---

### Brief summary of what the package does

Evil text-objects using treesitter

### Direct link to the package repository

https://github.com/meain/evil-textobj-tree-sitter

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
