### PR TITLE
Add apheleia

### DIFF
--- a/recipes/apheleia
+++ b/recipes/apheleia
@@ -1,0 +1,1 @@
+(apheleia :fetcher github :repo "raxod502/apheleia")


### PR DESCRIPTION
### Brief summary of what the package does

Apheleia is an Emacs Lisp package which allows you to reformat a buffer without moving point. This solves the usual problem of
running a tool like Prettier or Black on `before-save-hook', namely that it resets point to the beginning of the buffer. Apheleia maintains the position of point relative to its surrounding text even if the buffer is modified by the reformatting.

### Direct link to the package repository

https://github.com/raxod502/apheleia

### Your association with the package

None, found it through purcell/emacs-reformatter#20, adding it to MELPA seems to be a first step towards incorporating diff-based  formatters as discussed in purcell/emacs-reformatter#24.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
  The package refers to the license as "MIT", while the GNU project page refers to it as Expat.
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
