### PR TITLE
Add recipes for org-zettelkasten and zettelkasten

### DIFF
--- a/recipes/org-zettelkasten
+++ b/recipes/org-zettelkasten
@@ -1,0 +1,1 @@
+(org-zettelkasten :repo "ymherklotz/emacs-zettelkasten" :fetcher github :files ("org-zettelkasten.el"))

--- a/recipes/zettelkasten
+++ b/recipes/zettelkasten
@@ -1,0 +1,1 @@
+(zettelkasten :repo "ymherklotz/emacs-zettelkasten" :fetcher github :files ("zettelkasten.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a very simple and minimal implementation of the Zettelkasten method, either using org-mode as a base (`org-zettelkasten`), or an implementation from scratch without any large dependencies (`zettelkasten`).

### Direct link to the package repository

https://github.com/ymherklotz/emacs-zettelkasten

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
