### PR TITLE
Add recipe for earthfile-mode 

### DIFF
--- a/recipes/earthfile-mode
+++ b/recipes/earthfile-mode
@@ -1,0 +1,1 @@
+(earthfile-mode :fetcher github :repo "earthly/earthly-emacs" :files ("earthfile-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for editing Earthly file.

### Direct link to the package repository

https://github.com/earthly/earthly-emacs.

### Your association with the package

I'm maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
