### PR TITLE
add recipe for polybar-sesman

### DIFF
--- a/recipes/polybar-clj
+++ b/recipes/polybar-clj
@@ -1,2 +1,2 @@
 (polybar-clj :fetcher github
-             :repo "markgdawson/polybar-clj-emacs")
+             :repo "markgdawson/polybar-clj.el")

--- a/recipes/polybar-clj
+++ b/recipes/polybar-clj
@@ -1,2 +1,0 @@
-(polybar-clj :fetcher github
-             :repo "markgdawson/polybar-clj.el")

--- a/recipes/polybar-clj
+++ b/recipes/polybar-clj
@@ -1,0 +1,2 @@
+(polybar-clj :fetcher github
+             :repo "markgdawson/polybar-clj-emacs")

--- a/recipes/polybar-sesman
+++ b/recipes/polybar-sesman
@@ -1,0 +1,2 @@
+(polybar-sesman :fetcher github
+             :repo "markgdawson/polybar-sesman.el")


### PR DESCRIPTION
# Brief summary of what the package does

Polybar-clj adds a global minor mode which tracks the currently active Clojure REPL used by CIDER and exposes this to Polybar to show the current repl and the status of the currently available REPLs. This also works for any other future package that uses sesman to manage sessions.

This is useful to see at a glance if there are long-running processes, and to which REPL an eval would currently get sent.

# Direct link to the package repository

https://github.com/markgdawson/polybar-clj.el

# Your association with the package

I am the author.

# Relevant communications with the upstream package maintainer

None needed

# Checklist

- [x] The package is released under a GPL-Compatible Free Software License
- [x] I've read CONTRIBUTING.org
- [x] I've used the latest version of package-lint to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] M-x checkdoc is happy with my docstrings
- [x] I've built and installed the package using the instructions in CONTRIBUTING.org
- [ ] I have confirmed some of these without doing them