### PR TITLE
Update default branch for hack-mode

### DIFF
--- a/recipes/hack-mode
+++ b/recipes/hack-mode
@@ -1,2 +1,3 @@
 (hack-mode :repo "hhvm/hack-mode"
+           :branch "main"
            :fetcher github)


### PR DESCRIPTION
The repository has changed its default branch, so update the recipe to match.

### Brief summary of what the package does

Syntax highlighting for the Hack programming language

### Direct link to the package repository

https://github.com/hhvm/hack-mode

### Your association with the package

I'm a maintainer.

### Relevant communications with the upstream package maintainer

None needed.
