### PR TITLE
Add recipe for pardef

### DIFF
--- a/recipes/pardef
+++ b/recipes/pardef
@@ -1,0 +1,1 @@
+(pardef :fetcher github :repo "FloatingLion/pardef.el")


### PR DESCRIPTION
### Brief summary of what the package does

A python docstring generator, like https://github.com/naiquevin/sphinx-doc.el but it's

- more functionality (placeholders, `__init__`, ..)
- more robust (backslash multiline, comment, ..)
- and more extensible.

### Direct link to the package repository

https://github.com/FloatingLion/pardef.el

### Your association with the package

I'm the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
