### PR TITLE
Move cl-format to new repository

### DIFF
--- a/recipes/cl-format
+++ b/recipes/cl-format
@@ -1,1 +1,1 @@
-(cl-format :fetcher github :repo "alvinfrancis/cl-format")
+(cl-format :fetcher gitlab :repo "akater/elisp-cl-format" :branch "release")


### PR DESCRIPTION
The package has changed its maintainer;
update all entries in the recipe.

### Brief summary of what the package does

A port of Common Lisp's `format` to Emacs Lisp.

### Direct link to the package repository

https://gitlab.com/akater/elisp-cl-format

### Your association with the package

I'm the new maintainer.

### Relevant communications with the upstream package maintainer

Conversation about the transfer: https://github.com/alvinfrancis/cl-format/pull/3#issuecomment-910591764

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
