### PR TITLE
Add recipe for magit-smerge

### DIFF
--- a/recipes/magit-smerge
+++ b/recipes/magit-smerge
@@ -1,0 +1,2 @@
+(magit-smerge :fetcher github
+              :repo "markgdawson/magit-smerge.el")


### PR DESCRIPTION
### Brief summary of what the package does

Adds magit smerge keybindings to the magit-status buffer hunk section.

### Direct link to the package repository

https://github.com/markgdawson/magit-smerge.el

### Your association with the package

Maintainer/author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
