### PR TITLE
Use release branch for tree-sitter repo's

### DIFF
--- a/recipes/tree-sitter
+++ b/recipes/tree-sitter
@@ -1,4 +1,5 @@
 (tree-sitter :repo "emacs-tree-sitter/elisp-tree-sitter"
              :fetcher github
+             :branch "release"
              :files ("lisp/*.el"
                      (:exclude "lisp/tree-sitter-tests.el")))

--- a/recipes/tree-sitter-langs
+++ b/recipes/tree-sitter-langs
@@ -1,4 +1,5 @@
 (tree-sitter-langs :repo "emacs-tree-sitter/tree-sitter-langs"
                    :fetcher github
+                   :branch "release"
                    :files (:defaults
                            "queries"))

--- a/recipes/tsc
+++ b/recipes/tsc
@@ -1,5 +1,6 @@
 (tsc :repo "emacs-tree-sitter/elisp-tree-sitter"
      :fetcher github
+     :branch "release"
      :files ("core/*.el"
              "core/Cargo.toml"
              "core/Cargo.lock"


### PR DESCRIPTION
Tree-sitter repositories use GitHub releases to distribute binaries. These take time to build and publish, during which the main branch wouldn't work because the code would try to download the binaries.

We will use `release` branch instead, which will be updated after binaries are properly published.

https://github.com/emacs-tree-sitter/tree-sitter-langs
