### PR TITLE
Add justl mode

### DIFF
--- a/recipes/justl
+++ b/recipes/justl
@@ -1,0 +1,3 @@
+(justl
+ :repo "psibi/justl.el"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

justl.el mode is a major mode for driving [justfiles](https://github.com/casey/just). As compared to
the [https://melpa.org/#/just-mode](just-mode), this mode is built for listing and executing the
recipes in the justfile via the [https://magit.vc/manual/transient](transient) keymaps.

### Direct link to the package repository

https://github.com/psibi/justl.el

### Your association with the package

Package author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
