### PR TITLE
Build tree-sitter packages on MELPA Stable only from certain tags

### DIFF
--- a/recipes/tree-sitter
+++ b/recipes/tree-sitter
@@ -1,5 +1,6 @@
 (tree-sitter :repo "emacs-tree-sitter/elisp-tree-sitter"
              :fetcher github
              :branch "release"
+             :version-regexp "melpa-stable/v\\(.*\\)"
              :files ("lisp/*.el"
                      (:exclude "lisp/tree-sitter-tests.el")))

--- a/recipes/tree-sitter-langs
+++ b/recipes/tree-sitter-langs
@@ -1,5 +1,6 @@
 (tree-sitter-langs :repo "emacs-tree-sitter/tree-sitter-langs"
                    :fetcher github
                    :branch "release"
+                   :version-regexp "melpa-stable/v\\(.*\\)"
                    :files (:defaults
                            "queries"))

--- a/recipes/tsc
+++ b/recipes/tsc
@@ -1,6 +1,7 @@
 (tsc :repo "emacs-tree-sitter/elisp-tree-sitter"
      :fetcher github
      :branch "release"
+     :version-regexp "melpa-stable/v\\(.*\\)"
      :files ("core/*.el"
              "core/Cargo.toml"
              "core/Cargo.lock"


### PR DESCRIPTION
This is to restrict builds on MELPA Stable, since binaries are published after tags are pushed, and some tags are used for troubleshooting purposes (draft). It is similar to #7716.

Reference: https://github.com/emacs-tree-sitter/elisp-tree-sitter/issues/177.
