### PR TITLE
Update idle-highlight-mode (point to new repository)

### DIFF
--- a/recipes/idle-highlight-mode
+++ b/recipes/idle-highlight-mode
@@ -1,2 +1,3 @@
-(idle-highlight-mode :repo "nonsequitur/idle-highlight-mode" :fetcher github)
-
+(idle-highlight-mode
+ :repo "ideasman42/emacs-idle-highlight-mode"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This package highlights the word under the cursor.

This package has been updated to resolve warnings, fix deprecation messages, pass checkdoc, package-lint, etc.
Also added a readme.

Note, after looking at other popular highlighting packages ([auto-highlight-symbol](https://github.com/jcs-elpa/auto-highlight-symbol) & [highlight-symbol](https://github.com/nschum/highlight-symbol.el) ) I found this the simplest & the fastest, so I would like to make sure it's working without problems. 

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-idle-highlight-mode/

### Your association with the package

Proposing myself to be the new maintainer.

See: [commit history](https://gitlab.com/ideasman42/emacs-idle-highlight-mode/-/commits/master/)

### Relevant communications with the upstream package maintainer

Current repository seems unmaintained, was not updated in 9 years.

Posted [this issue](https://github.com/nonsequitur/idle-highlight-mode/issues/11) to check if the current maintainer is still active.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
