### PR TITLE
Add recipe for kubedoc

### DIFF
--- a/recipes/kubedoc
+++ b/recipes/kubedoc
@@ -1,0 +1,1 @@
+(kubedoc :fetcher github :repo "r0bobo/kubedoc.el")


### PR DESCRIPTION
### Brief summary of what the package does

kubedoc.el provides Kubernetes API documentation in Emacs.

### Direct link to the package repository

https://github.com/r0bobo/kubedoc.el/

### Your association with the package

I am the maintainer,

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
