### PR TITLE
Add recipe for consult-company

### DIFF
--- a/recipes/consult-company
+++ b/recipes/consult-company
@@ -1,0 +1,2 @@
+(consult-company :fetcher github
+                 :repo "mohkale/consult-company")


### PR DESCRIPTION
### Brief summary of what the package does

Provides an alternative for `completion-in-region` for `company-mode` buffers. Essentially lets you select a company completion candidate through a completing-read interface.

### Direct link to the package repository

https://github.com/mohkale/consult-company

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
