### PR TITLE
Add recipe for consult-yasnippet

### DIFF
--- a/recipes/consult-yasnippet
+++ b/recipes/consult-yasnippet
@@ -1,0 +1,2 @@
+(consult-yasnippet :fetcher github
+                   :repo "mohkale/consult-yasnippet")


### PR DESCRIPTION
### Brief summary of what the package does

An consulting-read interface for yasnippet. Presents you with a list of all the snippets available in the current buffer through `completing-read` and lets you select one to expand (with previews).

### Direct link to the package repository

https://github.com/mohkale/consult-yasnippet

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
