### PR TITLE
Recipe: Add org-auto-expand

### DIFF
--- a/recipes/org-auto-expand
+++ b/recipes/org-auto-expand
@@ -1,0 +1,1 @@
+(org-auto-expand :fetcher github :repo "alphapapa/org-auto-expand")


### PR DESCRIPTION
### Brief summary of what the package does

This package automatically expands certain headings in an Org file depending on properties set, making it easy to always get the same initial view when finding a file.

### Direct link to the package repository

https://github.com/alphapapa/org-auto-expand

### Your association with the package

Author, maintainer, user.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
