### PR TITLE
Fix helm by not excluding helm-lib

### DIFF
--- a/recipes/helm
+++ b/recipes/helm
@@ -3,7 +3,6 @@
       :files ("*.el"
               "emacs-helm.sh"
               (:exclude "helm.el"
-                        "helm-lib.el"
                         "helm-source.el"
                         "helm-multi-match.el"
                         "helm-core-pkg.el")))


### PR DESCRIPTION
Helm requires inline functions defined in helm-lib, which is not provided by the compiled package of helm-core.

Without this change, `M-x helm-mini` fails with `helm-highlight-files: Symbol’s function definition is void: helm-file-name-extension`.  cf. https://github.com/emacs-helm/helm/commit/4fcb36f1b9ecb540422223479aa81579139e0b95