### PR TITLE
Delete agda2-mode

### DIFF
--- a/recipes/agda2-mode
+++ b/recipes/agda2-mode
@@ -1,2 +1,0 @@
-(agda2-mode :fetcher github :repo "agda/agda"
-            :files ("src/data/emacs-mode/agda*.el"))


### PR DESCRIPTION
`agda` and `agda-mode` are always released together and `agda-mode` needs the exactly same version of `agda` to run. For example,  a newer `agda-mode` on the `master` branch of agda/agda does not work with a stable version of `agda` from Hackage. So, `agda2-mode` simply should not be installed via `melpa`.

### Brief summary of what the package does

An interactive environment for Agda 2

### Direct link to the package repository

https://github.com/agda/agda

### Your association with the package

One of the maintainers.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

I am asking to remove the receipt instead.
<!-- After submitting, please fix any problems the CI reports. -->
