### PR TITLE
Add recipe for conventional-changelog

### DIFF
--- a/recipes/conventional-changelog
+++ b/recipes/conventional-changelog
@@ -1,0 +1,3 @@
+(conventional-changelog
+ :fetcher github
+ :repo "liuyinz/emacs-conventional-changelog")


### PR DESCRIPTION
### Brief summary of what the package does
Generate and update CHANGELOG file with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) style in emacs.
This package provides the interface `conventional-changelog-menu`, which is
built with [transient](https://github.com/magit/transient), between command-line tool [standard-version](https://github.com/conventional-changelog/standard-version#as-global-bin) and emacs.

### Direct link to the package repository

https://github.com/liuyinz/emacs-conventional-changelog

### Your association with the package

maintainer 
contributor

### Relevant communications with the upstream package maintainer

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
