### PR TITLE
Add recipes for islisp-mode and inferior-islisp

### DIFF
--- a/recipes/inferior-islisp
+++ b/recipes/inferior-islisp
@@ -1,0 +1,3 @@
+(inferior-islisp :repo "sasanidas/islisp-mode"
+	         :fetcher gitlab
+	         :files ("inferior-islisp.el"))

--- a/recipes/inferior-islisp
+++ b/recipes/inferior-islisp
@@ -1,3 +1,3 @@
 (inferior-islisp :repo "sasanidas/islisp-mode"
-	         :fetcher gitlab
-	         :files ("inferior-islisp.el"))
+                 :fetcher gitlab
+                 :files ("inferior-islisp.el"))

--- a/recipes/islisp-mode
+++ b/recipes/islisp-mode
@@ -1,0 +1,7 @@
+(islisp-mode :repo "sasanidas/islisp-mode"
+	     :fetcher gitlab
+	     :files ("inferior-islisp.el"
+		     "islisp-mode.el"
+		     "islisp-hyperdraft.el"
+		     ("advance" "advance/*")
+		     ("implementations" "implementations/*")))

--- a/recipes/islisp-mode
+++ b/recipes/islisp-mode
@@ -1,6 +1,6 @@
 (islisp-mode :repo "sasanidas/islisp-mode"
-	     :fetcher gitlab
-	     :files ("islisp-mode.el"
-		     "islisp-hyperdraft.el"
-		     ("advance" "advance/*")
-		     ("implementations" "implementations/*")))
+             :fetcher gitlab
+             :files ("islisp-mode.el"
+                     "islisp-hyperdraft.el"
+                     ("advance" "advance/*")
+                     ("implementations" "implementations/*")))

--- a/recipes/islisp-mode
+++ b/recipes/islisp-mode
@@ -1,7 +1,6 @@
 (islisp-mode :repo "sasanidas/islisp-mode"
 	     :fetcher gitlab
-	     :files ("inferior-islisp.el"
-		     "islisp-mode.el"
+	     :files ("islisp-mode.el"
 		     "islisp-hyperdraft.el"
 		     ("advance" "advance/*")
 		     ("implementations" "implementations/*")))


### PR DESCRIPTION
### Brief summary of what the package does

It's a major mode and inferior mode for the [ISLisp programming language](https://en.wikipedia.org/wiki/ISLISP).

It also include some "advance" and non enable by default features (such as etags integration).

### Direct link to the package repository

https://gitlab.com/sasanidas/islisp-mode

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
