### PR TITLE
Add conventional-commit

### DIFF
--- a/recipes/conventional-commit
+++ b/recipes/conventional-commit
@@ -1,0 +1,1 @@
+(conventional-commit :fetcher github :repo "akirak/conventional-commit.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a completion function for writing [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

### Direct link to the package repository

https://github.com/akirak/conventional-commit.el

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->

This is a tiny package (probably the smallest I've ever published to MELPA), but I didn't find any existing package that does the job, so I think it is still *innovative*. It can be a companion to conventional-changelog (#7744).