### PR TITLE
add org-clock-reminder

### DIFF
--- a/recipes/org-clock-reminder
+++ b/recipes/org-clock-reminder
@@ -1,0 +1,3 @@
+(org-clock-reminder
+ :fetcher github
+ :repo "inickey/org-clock-reminder")


### PR DESCRIPTION
### Brief summary of what the package does

Simple reminder for org-clock time-tracker. Sends periodically desktop notifications to remind current task or its absence. Worked to minimize distraction for me.

### Direct link to the package repository

https://github.com/inickey/org-clock-reminder

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
