### PR TITLE
add eshell-vterm

### DIFF
--- a/recipes/eshell-vterm
+++ b/recipes/eshell-vterm
@@ -1,0 +1,1 @@
+(eshell-vterm :repo "iostapyshyn/eshell-vterm" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a global minor mode allowing `eshell` to use `vterm` for visual commands.

### Direct link to the package repository

https://github.com/iostapyshyn/eshell-vterm

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
