### PR TITLE
Add recipe for org-re-reveal-citeproc

### DIFF
--- a/recipes/org-re-reveal-citeproc
+++ b/recipes/org-re-reveal-citeproc
@@ -1,4 +1,4 @@
 (org-re-reveal-citeproc
  :repo "oer/org-re-reveal-citeproc"
  :fetcher gitlab
- :files (:defaults "LICENSES" "README.org" "local.css" "references.bib"))
+ :files (:defaults "README.org" "local.css" "references.bib"))


### PR DESCRIPTION
### Brief summary of what the package does

This package extends `org-re-reveal` with support for a bibliography slide based on package `citeproc` with citation support of Org mode 9.5.  Thus, Org `cite` links are translated into hyperlinks to the bibliography slide upon export by `org-re-reveal`.  Also, export to PDF via LaTeX and export to HTML with Org's usual export functionality work.

The included README is a sample Org file, to be exported as presentation with bibliography.

### Direct link to the package repository

https://gitlab.com/oer/org-re-reveal-citeproc

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
