### PR TITLE
Add recipe for rails-i18n

### DIFF
--- a/recipes/rails-i18n
+++ b/recipes/rails-i18n
@@ -1,0 +1,1 @@
+(rails-i18n :repo "otavioschwanck/rails-i18n.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a package to help you find and insert rails i18n into your code.
Instead of going to the yaml files and copy i18n by i18n, you just call 'rails-i18n-insert-with-cache',
It will fetch and save on cache all i18n used by your application, so you have a reliable and easy way to search
and insert your i18ns.

### Direct link to the package repository

https://github.com/otavioschwanck/rails-i18n.el

### Your association with the package

maintainer 

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
