### PR TITLE
Add recipe for counsel-chrome-bm

### DIFF
--- a/recipes/counsel-chrome-bm
+++ b/recipes/counsel-chrome-bm
@@ -1,0 +1,1 @@
+(counsel-chrome-bm :fetcher github :repo "BlueBoxWare/counsel-chrome-bm")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a command to browse your Chrom(e/ium) bookmarks with Ivy.

### Direct link to the package repository

https://github.com/BlueBoxWare/counsel-chrome-bm

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

https://github.com/BlueBoxWare/counsel-chrome-bm/runs/3846734047

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
