### PR TITLE
Add recipe for rails-routes

### DIFF
--- a/recipes/rails-routes
+++ b/recipes/rails-routes
@@ -1,0 +1,1 @@
+(rails-routes :repo "otavioschwanck/rails-routes.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a package to help you find and insert rails routes into your code.
Instead of going to the terminal or loading the path in the browser, you just call 'rails-routes-insert',
It will fetch and save on cache all routes used by your application, so you have a reliable and easy way to search
and insert your routes.

### Direct link to the package repository

https://github.com/otavioschwanck/rails-routes.el

### Your association with the package

maintainer

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
