### PR TITLE
Add recipe for project-tab-groups

### DIFF
--- a/recipes/project-tab-groups
+++ b/recipes/project-tab-groups
@@ -1,0 +1,1 @@
+(project-tab-groups :fetcher github :repo "fritzgrabo/project-tab-groups")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a global minor mode that enhances the Emacs built-in project.el library to support keeping projects isolated in named tab groups.

### Direct link to the package repository

https://github.com/fritzgrabo/project-tab-groups

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback, **BUT SEE BELOW**
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Please note that `package-lint` reports the following warning for the package's requirements of `;; Package-Requires: ((emacs "28"))`:

```
project-tab-groups.el:8:23: warning: This makes the package uninstallable in all released Emacs versions.
```

That's expected; this package _does_ require Emacs 28 for its native support of tab bar groups. There's a related note in the 
package's README.

Please also note that I've kept the requirement at `((emacs "28"))` (vs. a more orthodox `"28.1"`) to make sure that users of the current Emacs 28.0.50 can install this package. Once Emacs 28.1 is released, I'll update the requirement accordingly.

Thank you!




