### PR TITLE
Add recipe for python-insert-docstring

### DIFF
--- a/recipes/python-insert-docstring
+++ b/recipes/python-insert-docstring
@@ -1,0 +1,1 @@
+(python-insert-docstring :fetcher github :repo "macurovc/insert-docstring")


### PR DESCRIPTION
### Brief summary of what the package does

The package `python-insert-docstring` allows the automatic generation of function docstrings in Python according to the Google style guide.

### Direct link to the package repository

https://github.com/macurovc/insert-docstring

### Your association with the package

Author and Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
