### PR TITLE
Add recipe for magit-commit-mark

### DIFF
--- a/recipes/magit-commit-mark
+++ b/recipes/magit-commit-mark
@@ -1,0 +1,3 @@
+(magit-commit-mark
+  :repo "ideasman42/emacs-magit-commit-mark"
+  :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Support persistent email-style marking (read/unread) of commits in git-log (stored between sessions).

See screenshot: https://gitlab.com/uploads/-/system/project/avatar/30681128/magit-commit-mark_indexed.png

As far as I could see there are no packages to do this: https://emacs.stackexchange.com/q/68972/2418

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-magit-commit-mark

### Your association with the package

Author / Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
