### PR TITLE
Add ancient-one-dark-theme recipe

### DIFF
--- a/recipes/ancient-one-dark-theme
+++ b/recipes/ancient-one-dark-theme
@@ -1,0 +1,3 @@
+(ancient-one-dark-theme
+ :fetcher github
+ :repo "holodata/ancient-one-dark-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

This package adds a new theme `ancient-one-dark-theme` for Emacs (both terminal and GUI). It is based off the theme of the same name for other editors, and an Emacs-specific port was encouraged.

### Direct link to the package repository

https://github.com/holodata/ancient-one-dark-emacs

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
