### PR TITLE
Rename "bibtex-actions" to "citar"

### DIFF
--- a/recipes/bibtex-actions
+++ b/recipes/bibtex-actions
@@ -1,1 +1,0 @@
-(bibtex-actions :repo "bdarcus/bibtex-actions" :fetcher github)

--- a/recipes/citar
+++ b/recipes/citar
@@ -1,0 +1,3 @@
+(citar :repo "bdarcus/citar"
+       :fetcher github
+       :old-names (bibtex-actions))


### PR DESCRIPTION
This is followup to https://github.com/melpa/melpa/issues/7773, and will replace the "bibtex-actions" recipe.

The primary reason for the change is that while the project originally started as a frontend to bibtex-completion, and so exclusively focused also on bibtex, it now also works with JSON bibliographic files, with greater focus on org. 

Also, in time, we will remove the bibtex-completion dependency.

I decided only to implement the name change for now (the separate recipes shouldn't be needed, but if they are, I can do that as a separate step later).

Finally, I have a branch where I am working on the name change; it's almost done.

https://github.com/bdarcus/bibtex-actions/tree/project-name-change

I was also wondering about adding a commit here to pin the "bibtex-actions" recipe before it gets removed. Is that possible, and does that make sense?  Am not 100% on what the ideal sequence of steps here is to minimize user disruption.