### PR TITLE
Add recipe for ruby-json-to-hash

### DIFF
--- a/recipes/ruby-json-to-hash
+++ b/recipes/ruby-json-to-hash
@@ -1,0 +1,1 @@
+(ruby-json-to-hash :repo "otavioschwanck/ruby-json-to-hash.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Convert JSON to Hash and play with the keys

### Direct link to the package repository

https://github.com/otavioschwanck/ruby-json-to-hash.el

### Your association with the package

maintainer


### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
