### PR TITLE
Revert "migrated those packages to Org-mode contrib/ now (#5299)"

### DIFF
--- a/recipes/ob-php
+++ b/recipes/ob-php
@@ -1,0 +1,1 @@
+(ob-php :fetcher github :repo "stardiviner/ob-php")

--- a/recipes/ob-redis
+++ b/recipes/ob-redis
@@ -1,0 +1,1 @@
+(ob-redis :fetcher github :repo "stardiviner/ob-redis")

--- a/recipes/ob-smiles
+++ b/recipes/ob-smiles
@@ -1,0 +1,3 @@
+(ob-smiles
+ :fetcher github
+ :repo "stardiviner/ob-smiles")

--- a/recipes/ob-spice
+++ b/recipes/ob-spice
@@ -1,0 +1,3 @@
+(ob-spice
+ :fetcher github
+ :repo "stardiviner/ob-spice")


### PR DESCRIPTION
This reverts commit c13401d9553dec3472f40210d8a26fd561e3acb6.

Those packages originally have submitted to MELPA, they are now separated out from org-mode/contrib.