### PR TITLE
Change repo for visual-fill-column

### DIFF
--- a/recipes/visual-fill-column
+++ b/recipes/visual-fill-column
@@ -1,3 +1,3 @@
 (visual-fill-column
- :fetcher github
- :repo "joostkremers/visual-fill-column")
+ :fetcher git
+ :url "https://codeberg.org/joostkremers/visual-fill-column")


### PR DESCRIPTION
### Brief summary of what the package does

`visual-fill-column` can wrap text with long lines at `fill-column` instead of at the window edge.

### Direct link to the package repository

https://codeberg.org/joostkremers/visual-fill-column

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->

Note: `package-lint` finds two issues that I find acceptable:

    1:0: warning: The package summary should start with an uppercase letter or a digit.

The first word of the package summary is `fill-column`, the Emacs variable, which IMHO should not be uppercased.

    148:0: error: "turn-on-visual-fill-column-mode" doesn't start with package's prefix     "visual-fill-column".

AFAIK this naming conforms to the naming convention for this type of function. (It is used in the definition of the globalised minor mode.)

Note also: `checkdoc` complains about four instances of `visual-fill-column-mode` in doc strings, which aren't prefixed with `function,command,variable,option or symbol`. IMHO the doc strings read better without such a qualifier.