### PR TITLE
Add recipe for xwiki-mode

### DIFF
--- a/recipes/xwiki-mode
+++ b/recipes/xwiki-mode
@@ -1,0 +1,1 @@
+(xwiki-mode :fetcher github :repo "ackerleytng/xwiki-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`xwiki-mode` is a major mode for xwiki-formatted files. It is a major mode for this syntax: https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/XWikiSyntax/

### Direct link to the package repository

https://github.com/ackerleytng/xwiki-mode

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them