### PR TITLE
El secretario

### DIFF
--- a/recipes/el-secretario
+++ b/recipes/el-secretario
@@ -1,0 +1,7 @@
+(el-secretario
+ :fetcher git
+ :url "https://git.sr.ht/~zetagon/el-secretario"
+ :files ("el-secretario.el"
+         "el-secretario-source.el"
+         "el-secretario-message.el"
+         "el-secretario-function.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This is essentially a glue package that glues several other packages (such as org-mode, elfeed or notmuch). Because different parts depend on different things I have provided several recipes. It provides a unified interface for managing inboxes of different types. For a more complete description see https://sr.ht/~zetagon/el-secretario/#introducing-my-secretary



### Direct link to the package repository

https://sr.ht/~zetagon/el-secretario/

### Your association with the package

I am the package author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly

I don't know how to check this.

- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

There is one issue here. `el-secretario` depends on a version of `which-key` that is newer than the elpa version so if a user uses the elpa version some issues may occur.

- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
