### PR TITLE
feat: adds github-dark-vscode-theme

### DIFF
--- a/recipes/github-dark-vscode-theme
+++ b/recipes/github-dark-vscode-theme
@@ -1,3 +1,1 @@
-(github-dark-vscode-theme :repo "justintime50/github-dark-vscode-emacs-theme" 
-                          :fetcher github
-                          :files ("src/github-dark-vscode-theme.el"))
+(github-dark-vscode-theme :repo "justintime50/github-dark-vscode-emacs-theme" :fetcher github)

--- a/recipes/github-dark-vscode-theme
+++ b/recipes/github-dark-vscode-theme
@@ -1,0 +1,3 @@
+(github-dark-vscode-theme :repo "justintime50/github-dark-vscode-emacs-theme" 
+                          :fetcher github
+                          :files ("src/github-dark-vscode-theme.el"))


### PR DESCRIPTION
### Brief summary of what the package does

The [GitHub Dark Theme](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) from Visual Studio Code ported to Emacs.

### Direct link to the package repository

https://github.com/Justintime50/github-dark-vscode-emacs-theme

### Your association with the package

Package author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly (**does, however, per other themes I've elected to not byte compile**)
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
