### PR TITLE
Add async-backup

### DIFF
--- a/recipes/async-backup
+++ b/recipes/async-backup
@@ -1,0 +1,4 @@
+(async-backup
+ :fetcher git
+ :url "https://tildegit.org/contrapunctus/async-backup.git"
+ :branch "development")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a function to make backups of the current file asynchronously.

### Direct link to the package repository

https://tildegit.org/contrapunctus/async-backup

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
