### PR TITLE
gh-notify v0.1: a magit/forge veneer for github notifications

### DIFF
--- a/recipes/gh-notify
+++ b/recipes/gh-notify
@@ -1,0 +1,3 @@
+(gh-notify :fetcher github
+           :repo "anticomputer/gh-notify"
+           :files ("gh-notify.el"))

--- a/recipes/gh-notify
+++ b/recipes/gh-notify
@@ -1,3 +1,1 @@
-(gh-notify :fetcher github
-           :repo "anticomputer/gh-notify"
-           :files ("gh-notify.el"))
+(gh-notify :fetcher github :repo "anticomputer/gh-notify")


### PR DESCRIPTION
### Brief summary of what the package does

gh-notify is a thin ui veneer on top of magit/forge porcelain for juggling large amounts of GitHub notifications at speed.

### Direct link to the package repository

https://github.com/anticomputer/gh-notify

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
