### PR TITLE
Add auxiliary packages for el secretario 

### DIFF
--- a/recipes/el-secretario-elfeed
+++ b/recipes/el-secretario-elfeed
@@ -1,0 +1,4 @@
+(el-secretario-elfeed
+ :fetcher git
+ :url "https://git.sr.ht/~zetagon/el-secretario"
+ :files ("el-secretario-elfeed.el"))

--- a/recipes/el-secretario-mu4e
+++ b/recipes/el-secretario-mu4e
@@ -1,0 +1,4 @@
+(el-secretario-mu4e
+ :fetcher git
+ :url "https://git.sr.ht/~zetagon/el-secretario"
+ :files ("el-secretario-mu4e.el"))

--- a/recipes/el-secretario-notmuch
+++ b/recipes/el-secretario-notmuch
@@ -1,0 +1,4 @@
+(el-secretario-notmuch
+ :fetcher git
+ :url "https://git.sr.ht/~zetagon/el-secretario"
+ :files ("el-secretario-notmuch.el"))

--- a/recipes/el-secretario-org
+++ b/recipes/el-secretario-org
@@ -1,0 +1,4 @@
+(el-secretario-org
+ :fetcher git
+ :url "https://git.sr.ht/~zetagon/el-secretario"
+ :files ("el-secretario-org.el" "el-secretario-space.el"))


### PR DESCRIPTION
### Brief summary of what the package does

These are auxiliary packages for el secretario (which I've already submitted a PR for #7796). These all require external dependencies so they are submitted as separate packages.

The main thing I'm unsure about is `el-secretario-keybindings.el`. It contains default keybindings for the package. I'm hesitant to put it into a separate package, but it depends on `general.el` which I didn't want to impose. Mu4e and notmuch have to be installed separately (even the elisp files) so they aren't listed explicitly as dependencies.

### Direct link to the package repository

https://sr.ht/~zetagon/el-secretario/

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
