### PR TITLE
Add recipe for 'doc-show-inline'

### DIFF
--- a/recipes/doc-show-inline
+++ b/recipes/doc-show-inline
@@ -1,0 +1,3 @@
+(doc-show-inline
+  :repo "ideasman42/emacs-doc-show-inline"
+  :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Show public (external) doc-strings inline (see before/after screenshot).
This can give useful context when reading/editing public functions.
Tested with C/C++ although this would work for any language that stores it's doc-strings in external declarations.

See: [before/after screenshot](https://gitlab.com/ideasman42/emacs-doc-show-inline/uploads/167d42282f4150c95850c40784deb25b/doc-show-inline.png)

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-doc-show-inline

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
