### PR TITLE
Add python-coverage package

### DIFF
--- a/recipes/python-coverage
+++ b/recipes/python-coverage
@@ -1,0 +1,3 @@
+(python-coverage
+ :fetcher github
+ :repo "wbolster/emacs-python-coverage")


### PR DESCRIPTION
### Brief summary of what the package does

show python coverage information directly in emacs

### Direct link to the package repository

https://github.com/wbolster/emacs-python-coverage
### Your association with the package

author/maintainer

### Relevant communications with the upstream package maintainer

none needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
