### PR TITLE
Add fortune-mode recipe

### DIFF
--- a/recipes/fortune-mode
+++ b/recipes/fortune-mode
@@ -1,0 +1,1 @@
+(fortune-mode :fetcher github :repo "lassik/emacs-fortune-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This major mode helps you edit collections of fortune cookies. The file format is the one used by the Unix `fortune` program. A line with a single '%' separates each pair of adjacent fortunes.

### Direct link to the package repository

https://github.com/lassik/emacs-fortune-mode

### Your association with the package

Just wrote it

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
