### PR TITLE
Add gmsh-mode

### DIFF
--- a/recipes/gmsh-mode
+++ b/recipes/gmsh-mode
@@ -1,0 +1,1 @@
+(gmsh-mode :repo "matsievskiysv/gmsh-mode" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Add [GMSH](https://gmsh.info/) major mode. Syntax highlighting was tested using [gmsh tutorial scripts](https://gitlab.onelab.info/gmsh/gmsh/-/tree/master/tutorial).

### Direct link to the package repository

https://gitlab.com/matsievskiysv/gmsh-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
