### PR TITLE
Add Siri shortcuts recipe

### DIFF
--- a/recipes/siri-shortcuts
+++ b/recipes/siri-shortcuts
@@ -1,0 +1,1 @@
+(siri-shortcuts :fetcher github :repo "DaniruKun/siri-shortcuts.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package wraps the `shortcuts` command line tool, as well as the [Shortcuts URL scheme API.](https://support.apple.com/en-gb/guide/shortcuts-mac/apd621a1ad7a/5.0/mac/12.0)

It enables interactions with Siri Shortcuts on macOS Monterey and later.

### Direct link to the package repository

https://github.com/DaniruKun/siri-shortcuts.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

***None needed***

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
