### PR TITLE
Update edts-mode recipe

### DIFF
--- a/recipes/edts
+++ b/recipes/edts
@@ -8,6 +8,10 @@
           "README.md"
           "start"
           "start.bat"
+          "edts-escript"
+          "edts-release.config"
+
+          ;; to be removed
           "rebar.config"
           ("config"                     "config/*")
 

--- a/recipes/edts
+++ b/recipes/edts
@@ -13,23 +13,31 @@
 
           ;; to be removed
           "rebar.config"
-          ("config"                     "config/*")
+          ("config"       "config/*")
 
-          ("elisp/edts"                 "elisp/edts/*.el")
-          (:exclude                     "elisp/edts/*-test.el")
+          ("elisp/edts"   "elisp/edts/*.el")
+          (:exclude       "elisp/edts/*-test.el")
 
-          ("lib/edts/include"           "lib/edts/include/*")
-          ("lib/edts/priv"              "lib/edts/priv/dispatch.conf")
-          ("lib/edts/src"               "lib/edts/src/*")
+          ("lib/edts"
+           "lib/edts/Makefile"
+           ("include"     "lib/edts/include/*")
+           ("priv"        "lib/edts/priv/dispatch.conf")
+           ("src"         "lib/edts/src/*"))
 
-          ("lib/edts_debug"             "lib/edts_debug/*.el")
-          (:exclude                     "lib/edts_debug/*-test.el")
-          ("lib/edts_debug/src"         "lib/edts_debug/src/*")
+          ("lib/edts_debug"
+           "lib/edts_debug/*.el"
+           "lib/edts_debug/Makefile"
+           ("src"         "lib/edts_debug/src/*"))
+          (:exclude       "lib/edts_debug/*-test.el")
 
-          ("lib/edts_dialyzer"          "lib/edts_dialyzer/*.el")
-          (:exclude                     "lib/edts_dialyzer/*-test.el")
-          ("lib/edts_dialyzer/src"      "lib/edts_dialyzer/src/*")
+          ("lib/edts_dialyzer"
+           "lib/edts_dialyzer/*.el"
+           "lib/edts_dialyzer/Makefile"
+           ("src"         "lib/edts_dialyzer/src/*"))
+          (:exclude       "lib/edts_dialyzer/*-test.el")
 
-          ("lib/edts_xref"              "lib/edts_xref/*.el")
-          (:exclude                     "lib/edts_xref/*-test.el")
-          ("lib/edts_xref/src"          "lib/edts_xref/src/*")))
+          ("lib/edts_xref"
+           "lib/edts_xref/*.el"
+           "lib/edts_xref/Makefile"
+           ("src"         "lib/edts_xref/src/*"))
+          (:exclude       "lib/edts_xref/*-test.el")))


### PR DESCRIPTION
Hi,
I'm about to merge a [PR](https://github.com/sebastiw/edts/pull/270) to the edts package, which will need some recipe changes in order to be properly built.
There are almost no changes to elisp files in this PR, so I've disregarded some of the checks below.

Best regards

### Brief summary of what the package does

Minor mode for compiling, testing and debugging Erlang code.

### Direct link to the package repository

https://github.com/sebastiw/edts

https://github.com/sebastiw/edts/pull/270

### Your association with the package

I'm the maintainer of edts

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
