### PR TITLE
Add recipe for cilk-mode

### DIFF
--- a/recipes/cilk-mode
+++ b/recipes/cilk-mode
@@ -1,0 +1,1 @@
+(cilk-mode :repo "ailiop/cilk-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs minor mode for [Cilk](https://en.wikipedia.org/wiki/Cilk) source code editing.

Provides a few functions for easily toggling the following features in buffers with major mode `c-mode` or `c++-mode`:

1. Correct indentation of Cilk keywords in CC Mode
2. Custom highlighting of Cilk keywords with font-lock
3. Syntax checking with the [OpenCilk](https://opencilk.org/) compiler (if flycheck is loaded)

All features are enabled via buffer-local bindings of relevant variables in the underlying packages.

### Direct link to the package repository

https://github.com/ailiop/cilk-mode

### Your association with the package

Developer & maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
