### PR TITLE
fix(webpaste): Force use of new default branch

### DIFF
--- a/recipes/webpaste
+++ b/recipes/webpaste
@@ -1,1 +1,1 @@
-(webpaste :repo "etu/webpaste.el" :fetcher github)
+(webpaste :repo "etu/webpaste.el" :fetcher github :branch "main")


### PR DESCRIPTION
A couple of weeks ago I've decided to switch the default branch, mostly because many of my other projects have done so so it's kinda convenient to have something similar here.

But melpa doesn't seem to have picked up the change of the default branch.

So I'm hoping that this would fix that. 

https://github.com/etu/webpaste.el/issues/54