### PR TITLE
Add recipe for Hyperbole

### DIFF
--- a/recipes/hyperbole
+++ b/recipes/hyperbole
@@ -1,0 +1,5 @@
+(hyperbole
+ :url "https://git.savannah.gnu.org/git/hyperbole.git"
+ :fetcher git
+ :files (:defaults "kotl" "man" "HY-TALK" "test"))
+

--- a/recipes/hyperbole
+++ b/recipes/hyperbole
@@ -1,5 +1,16 @@
 (hyperbole
- :url "https://git.savannah.gnu.org/git/hyperbole.git"
- :fetcher git
- :files (:defaults "kotl" "man" "HY-TALK" "test"))
-
+    :url "https://git.savannah.gnu.org/git/hyperbole.git"
+    :fetcher git
+    :files ("*.el" "MANIFEST" "dir" ".mailmap" "ChangeLog" "COPYING" "Makefile"
+            "HY-ABOUT" "HY-ANNOUNCE" "HY-CONCEPTS.kotl" "HY-NEWS"
+            "HY-WHY.kotl" "INSTALL" "DEMO" "DEMO-ROLO.otl" "FAST-DEMO"
+            "README.md" "TAGS" "_hypb" ".hypb" "smart-clib-sym" "topwin.py"
+            "hyperbole-banner.png"
+            ("kotl" "MANIFEST" "EXAMPLE.kotl" "kotl/*.el")
+            ("man" "man/hyperbole.texi" "man/version.texi" "man/hyperbole.css"
+             "man/hkey-help.txt" "man/hyperbole.info" "man/hyperbole.html"
+             "man/hyperbole.pdf")
+            ("man/im" "man/im/*.png")
+            ("HY-TALK" "HY-TALK/.hypb" "HY-TALK/HYPB" "HY-TALK/HY-TALK.org"
+             "HY-TALK/HYPERAMP.org" "HY-TALK/HYPERORG.org")
+            ("test" "MANIFEST" "test/*tests.el" "test/hy-test-*.el")))

--- a/recipes/hyperbole
+++ b/recipes/hyperbole
@@ -1,7 +1,7 @@
 (hyperbole
     :url "https://git.savannah.gnu.org/git/hyperbole.git"
     :fetcher git
-    :files ("*.el" "MANIFEST" "dir" ".mailmap" "ChangeLog" "COPYING" "Makefile"
+    :files ("*.el" "MANIFEST" "dir" "ChangeLog" "Makefile"
             "HY-ABOUT" "HY-ANNOUNCE" "HY-CONCEPTS.kotl" "HY-NEWS"
             "HY-WHY.kotl" "INSTALL" "DEMO" "DEMO-ROLO.otl" "FAST-DEMO"
             "README.md" "TAGS" "_hypb" ".hypb" "smart-clib-sym" "topwin.py"


### PR DESCRIPTION
### Brief summary of what the package does

GNU Hyperbole -. The Everyday Hypertextual Information Manager - an efficient and programmable hypertextual information management system. See https://www.gnu.org/software/hyperbole/

### Direct link to the package repository

https://savannah.gnu.org/git/?group=hyperbole 
https://git.savannah.gnu.org/cgit/hyperbole.git

### Your association with the package

I'm co-maintaining Hyperbole with the author Bob Weiner, @rswgnu.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback -- **We have issues. We have not been working actively yet on reducing package prefixes nor using colons in identifiers causing a lot of package-lint warnings.**
- [x] My elisp byte-compiles cleanly -- **Most have been fixed. There should be a minimal number of byte compile errors.**
- [x] `M-x checkdoc` is happy with my docstrings -- **There should be only a few docstrings now longer than 80 chars. Most other docstrings with warnings have been fixed. (~200 warnings left for the whole package.)**
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org) -- **We have a subdirectory, `kotl`, for which the autoload generation seems to require a restart of Emacs. Is it possible to work around that?** 
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
