### PR TITLE
Update recipe for doom-themes

### DIFF
--- a/recipes/doom-themes
+++ b/recipes/doom-themes
@@ -1,1 +1,7 @@
-(doom-themes :repo "hlissner/emacs-doom-themes" :fetcher github :files (:defaults "themes/*.el"))
+(doom-themes 
+ :fetcher github 
+ :repo "doomemacs/themes"
+ :files (:defaults 
+         "themes/*.el"
+         "themes/*/*.el"
+         "extensions/*.el"))


### PR DESCRIPTION
I'm updating the [doom-themes](https://github.com/hlissner/emacs-doom-themes) recipe because a) it was moved to https://github.com/doomemacs/themes, and b) in preparation for structural changes to the project that will break backwards compatibility with its recipe.

There are some minor package-lint and checkdoc issues that I address within these upcoming changes, but they're a little difficult to untangle from my unpushed work, so I'd like to update the recipe first. I hope that isn't a blocker for this PR.

### Brief summary of what the package does

A megapack of Emacs themes.

### Direct link to the package repository

https://github.com/doomemacs/themes

### Your association with the package

The author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback _**(see above)**_
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings _**(see above)**_
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
