### PR TITLE
add vunit-mode

### DIFF
--- a/recipes/vunit-mode
+++ b/recipes/vunit-mode
@@ -1,0 +1,1 @@
+(vunit-mode :fetcher github :repo "embed-me/vunit-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`vunit-mode` is an Emacs minor mode to interface with VUnit, an open-source testing framework for VHDL/SystemVerilog.

### Direct link to the package repository

https://github.com/embed-me/vunit-mode

### Your association with the package

I am the author and the maintainer.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
