### PR TITLE
Add recipe for preview-dvisvgm.

### DIFF
--- a/recipes/preview-dvisvgm
+++ b/recipes/preview-dvisvgm
@@ -1,0 +1,1 @@
+(preview-dvisvgm :repo "TobiasZawada/preview-dvisvgm" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
This package adds SVG support to the preview-latex package of AucTeX.
It uses dvisvgm for converting the LaTeX-generated dvi to svg.

### Direct link to the package repository

http://github.com/TobiasZawada/preview-dvisvgm

### Your association with the package
Maintainer: Tobias Zawada


### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
