### PR TITLE
Added org-visibility recipe

### DIFF
--- a/recipes/org-visibility
+++ b/recipes/org-visibility
@@ -1,3 +1,2 @@
 (org-visibility :repo "nullman/emacs-org-visibility"
-                :fetcher github
-                :files ("org-visibility.el"))
+                :fetcher github)

--- a/recipes/org-visibility
+++ b/recipes/org-visibility
@@ -1,0 +1,3 @@
+(org-visibility :repo "nullman/emacs-org-visibility"
+                :fetcher github
+                :files ("org-visibility.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Org Visibility is an Emacs package that adds the ability to persist (save and load) the state of the visible sections of `org-mode' files.

### Direct link to the package repository

https://github.com/nullman/emacs-org-visibility

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

This is my first MELPA package request.  I believe I have followed all of the instructions.

I'm concerned about my use of save and load hooks.  Please let me know if there is a better way to handle that.  See **org-visibility-enable-hooks** and **org-visibility-disable-hooks**.

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
