### PR TITLE
Add counsel-at-point package.

### DIFF
--- a/recipes/counsel-at-point
+++ b/recipes/counsel-at-point
@@ -1,0 +1,3 @@
+(counsel-at-point
+  :repo "ideasman42/emacs-counsel-at-point"
+  :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Improved ergonomics for file searching in counsel.

This package provides commands that behave slightly differently from counsel's default commands in ways that save time in my experience.

- Search using the thing-at-point (or selection).
- Search from the projects root-directly.
- Pre-select the current item.

These are exposed via alternative commands instead of modifying any of counsels behavior.

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-counsel-at-point

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
