### PR TITLE
Add additional files to with-editor to allow building in stable.

### DIFF
--- a/recipes/with-editor
+++ b/recipes/with-editor
@@ -1,3 +1,4 @@
 (with-editor :fetcher github
-             :repo "magit/with-editor"
-             :files ("lisp/with-editor.el" "docs/with-editor.texi"))
+	     :repo "magit/with-editor"
+	     :files ("with-editor.el" "with-editor.texi"
+		     "lisp/with-editor.el" "docs/with-editor.texi"))


### PR DESCRIPTION
The tagged version of with-editor and the version at HEAD have a different
directory structure. If no files are found then the build fails and currently
this is causing the stable build to fail. Temporarily adding the extra files
will solve this problem and won't hurt anything if we do end up forgetting to
clean things up.

Sending this to @tarsius for review since it is their package.