### PR TITLE
Add recipe for filldent

### DIFF
--- a/recipes/filldent
+++ b/recipes/filldent
@@ -1,0 +1,3 @@
+(filldent
+ :fetcher github
+ :repo "duckwork/filldent.el")


### PR DESCRIPTION
### Brief summary of what the package does

Filldent is a package that smartly fills or indents the current paragraph or defun, depending on mode and current point. I wrote this after a discussion in #emacs on libera.chat in which someone had confusion between when to use `fill-paragraph` and `indent-region`.  I realized that usually, you want to do one or the other, and both functions serve basically the same purpose: they prettify the region around the point in some way relevant to the current mode.  Thus, `filldent` was born.

### Direct link to the package repository

https://github.com/duckwork/filldent.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
