### PR TITLE
Add recipe for python-blue

### DIFF
--- a/recipes/python-blue
+++ b/recipes/python-blue
@@ -1,0 +1,1 @@
+(python-blue :fetcher github :repo "grantjenks/emacs-python-blue")


### PR DESCRIPTION
### Brief summary of what the package does

Use the Python [Blue](https://pypi.org/project/blue/) package to reformat Python buffers.

### Direct link to the package repository

https://github.com/grantjenks/emacs-python-blue

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
