### PR TITLE
Add bookmark-in-project

### DIFF
--- a/recipes/bookmark-in-project
+++ b/recipes/bookmark-in-project
@@ -1,0 +1,3 @@
+(bookmark-in-project
+ :repo "ideasman42/emacs-bookmark-in-project"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This package exposes functions that make it convenient to use Emacs built-in bookmarks
for the project currently being developed.

The key features provided are:

- Limit bookmark switching to other bookmarks in the same project.
- Support for toggling a bookmark (with automatic naming based on the context).
- Jump next/previous bookmark within the project.

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-bookmark-in-project

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
