### PR TITLE
lua-mode: Do not distribute init-tryout.el

### DIFF
--- a/recipes/lua-mode
+++ b/recipes/lua-mode
@@ -1,4 +1,4 @@
 (lua-mode
  :repo "immerrr/lua-mode"
  :fetcher github
- :files (:defaults "scripts"))
+ :files (:defaults (:exclude "init-tryout.el")))


### PR DESCRIPTION
init-tryout.el is accidentially distributed with lua-mode.el.

### Direct link to the package repository

https://github.com/immerrr/lua-mode/issues/198

### Your association with the package

User

### Relevant communications with the upstream package maintainer

May require upstream communication. See https://github.com/immerrr/lua-mode/issues/198. However it is a simple packaging mistake which could also be fixed here at the discretion of the MELPA maintainers.