### PR TITLE
Add titlecase.el

### DIFF
--- a/recipes/titlecase
+++ b/recipes/titlecase
@@ -1,0 +1,3 @@
+(titlecase
+ :fetcher github
+ :repo "duckwork/titlecase.el")


### PR DESCRIPTION
### Brief summary of what the package does

Titlecase.el provides facilities for capitalizing titles using a variety of styles in Emacs. It aims to be comprehensive and as accurate as possible given computer constraints and language complexity.

### Direct link to the package repository

<https://github.com/duckwork/titlecase.el>

### Your association with the package

I am the creator and maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback **NOTE that titlecase-data.el makes package-lint angry, but mostly due to naming issues; please let me know if I need to change the variables in titlecase-data.el to titlecase-data-*.**
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
