### PR TITLE
Add recipe for unmodified-buffer

### DIFF
--- a/recipes/unmodified-buffer
+++ b/recipes/unmodified-buffer
@@ -1,0 +1,3 @@
+(unmodified-buffer
+ :fetcher github
+ :repo "arthurcgusmao/unmodified-buffer")


### PR DESCRIPTION
### Brief summary of what the package does

`unmodified-buffer` is a minor mode that automatically restores an Emacs
buffer modified state in case its contents match the original file it is
visiting.

### Direct link to the package repository

https://github.com/arthurcgusmao/unmodified-buffer

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
