### PR TITLE
Renamed due to name space clash with existing 'matrix-theme.el'

### DIFF
--- a/recipes/the-matrix-theme
+++ b/recipes/the-matrix-theme
@@ -1,3 +1,3 @@
-(matrix-theme
+(the-matrix-theme
  :fetcher github
  :repo "monkeyjunglejuice/matrix-emacs-theme")


### PR DESCRIPTION
### Brief summary of what the package does

Green-on-black theme inspired by "The Matrix" movie.

### Direct link to the package repository

https://github.com/monkeyjunglejuice/matrix-emacs-theme

### Your association with the package

Maintainer and author

### Relevant communications with the upstream package maintainer

The package is already in Melpa. I renamed the package according to our previous conversation:
https://github.com/melpa/melpa/pull/7832

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
