### PR TITLE
Add recipe for run-command-recipes

### DIFF
--- a/recipes/run-command-recipes
+++ b/recipes/run-command-recipes
@@ -1,5 +1,3 @@
 (run-command-recipes
  :repo "semenInRussia/emacs-run-command-recipes"
- :fetcher github
- :url "https://github.com/semenInRussia/emacs-run-command-recipes"
- :branch "main")
+ :fetcher github)

--- a/recipes/run-command-recipes
+++ b/recipes/run-command-recipes
@@ -1,0 +1,5 @@
+(run-command-recipes
+ :repo "semenInRussia/emacs-run-command-recipes"
+ :fetcher github
+ :url "https://github.com/semenInRussia/emacs-run-command-recipes"
+ :branch "main")


### PR DESCRIPTION
### Brief summary of what the package does

This is collection of recipes to [run-command](https://github.com/bard/emacs-run-command).


### Direct link to the package repository

https://github.com/semenInRussia/emacs-run-command-recipes

### Your association with the package

I am the creator and maintainer of this package.

### Relevant communications with the upstream package maintainer
**None needed** 

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
