### PR TITLE
migrate mastodon repo to codeberg

### DIFF
--- a/recipes/mastodon
+++ b/recipes/mastodon
@@ -1,1 +1,1 @@
-(mastodon :fetcher github :repo "mooseyboots/mastodon.el" :files ("lisp/*.el"))
+(mastodon :fetcher git :url "https://codeberg.org/martianh/mastodon.el" :files ("lisp/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

mastodon social media client for emacs, already in melpa, is being undeadified somewhat.

### Direct link to the package repository

https://codeberg.org/martianh/mastodon.el

(current gh location: https://github.com/mooseyboots/mastodon.el.)

### Your association with the package

maintainer, de-abandonware-er

### Relevant communications with the upstream package maintainer

 **None needed** 

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->

i just wanted to migrate this project, which is already on melpa, off gh to codeberg. i've been resurrecting it for a while after it was abandoned. orig author recently transferred ownership to me here on gh. hopefully the changes/updates made since (by me and a few others), are a-okay-di-dokey.
