### PR TITLE
Add recipe for zk

### DIFF
--- a/recipes/zk
+++ b/recipes/zk
@@ -1,0 +1,3 @@
+(zk :repo "localauthor/zk"
+    :fetcher github
+    :files ("zk.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A straightforward, feature-rich package for dealing with link-connected notes, tailored for use with the Zettelkasten method. It has no dependencies outside of Emacs and is fully compliant with the default 'completing-read' functions. Deals only in plaintext --- uses no backend, database, or cache.

Includes optional extensions for seamless integration with Embark, Consult, Link-Hint, and Org-mode.

### Direct link to the package repository

https://github.com/localauthor/zk

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
