### PR TITLE
Add recipe for diff-ansi

### DIFF
--- a/recipes/diff-ansi
+++ b/recipes/diff-ansi
@@ -1,0 +1,3 @@
+(diff-ansi
+ :repo "ideasman42/emacs-diff-ansi"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Provides much improved display for diff's inside Emacs,
through external diff utilities.
Current supported external diffing tools are:
- delta
- diff-so-fancy
- ydiff


![See screenshot showing output from delta:](https://user-images.githubusercontent.com/1869379/149704903-ba6397de-bc44-461c-9724-14eda4782863.png)


This addresses the question asked here: https://www.reddit.com/r/emacs/comments/qb3ett/how_to_override_magits_diff_view_for_syntax/

NOTE: there is a delta diff package already on melpa, however it is quite different to this pacakge, as it uses delta to assign color for emacs existing diff buffer, instead of allowing delta's side-by-side output to be loaded into Emacs.

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-diff-ansi

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
