### PR TITLE
Add nxml-uxml

### DIFF
--- a/recipes/nxml-uxml
+++ b/recipes/nxml-uxml
@@ -1,0 +1,2 @@
+(nxml-uxml :fetcher gitlab
+           :repo "dpk/nxml-uxml")


### PR DESCRIPTION
### Brief summary of what the package does

[MicroXML](https://dvcs.w3.org/hg/microxml/raw-file/tip/spec/microxml.html) is a delightful tiny subset of XML, removing everything that
makes XML a nightmare to deal with in practice. `nxml-uxml-mode` is a
minor mode for Emacs that slightly modifies the XML parser of
`nxml-mode` to forbid most (though, at present, not quite all)
constructs which are allowed in XML 1.0 but disallowed in MicroXML.


### Direct link to the package repository

https://gitlab.com/dpk/nxml-uxml

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - It complains about the function names starting with `uxmltok-` because they don’t match the package name. Since these actually patch the `xmltok` library, I think this is probably a reasonable exception to this rule, but I’ll change it if the MELPA maintainers disagree.
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
