### PR TITLE
Add chronometrist-spark recipe

### DIFF
--- a/recipes/chronometrist-spark
+++ b/recipes/chronometrist-spark
@@ -1,0 +1,5 @@
+(chronometrist-spark
+ :url "https://tildegit.org/contrapunctus/chronometrist.git"
+ :fetcher git
+ :branch "dev"
+ :files ("elisp/chronometrist-spark.el" "elisp/chronometrist-spark.org"))


### PR DESCRIPTION
### Brief summary of what the package does
Adds sparklines to Chronometrist buffers

### Direct link to the package repository
https://tildegit.org/contrapunctus/chronometrist

### Your association with the package
Author and maintainer

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist
- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
