### PR TITLE
Add recipe for org-arbeitszeit

### DIFF
--- a/recipes/org-arbeitszeit
+++ b/recipes/org-arbeitszeit
@@ -1,0 +1,1 @@
+(org-arbeitszeit :fetcher github :repo "bkaestner/org-arbeitszeit")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a new dynamic block for Org mode, namely "arbeitszeit" (German for _working time_ or _working hours_, depending on the context). The dynamic block automatically sums up the times in the given file and provides a table with your target time, actual time, and a weekly difference (as well as your current total).

### Direct link to the package repository

https://github.com/bkaestner/org-arbeitszeit

### Your association with the package

I'm the author, maintainer, and currently the package's main user (I use it to track my under- and overtime).

### Relevant communications with the upstream package maintainer

I looked into the mirror and said "publish it" ;)

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (see https://github.com/bkaestner/org-arbeitszeit/actions/runs/1755060985)
- [x] My elisp byte-compiles cleanly (see https://github.com/bkaestner/org-arbeitszeit/runs/4963046223?check_suite_focus=true)
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org) (via `C-c C-c` in the recipe, no `make` available on my machine atm)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
