### PR TITLE
Move languagetool repository

### DIFF
--- a/recipes/languagetool
+++ b/recipes/languagetool
@@ -1,4 +1,3 @@
 (languagetool
- :repo "PillFall/Emacs-LanguageTool.el"
+ :repo "PillFall/languagetool.el"
  :fetcher github)
- 


### PR DESCRIPTION
### Brief summary of what the package does

Use LanguageTool as an Emacs grammar checker

### Direct link to the package repository

https://github.com/PillFall/languagetool.el

### Your association with the package

The maintainer and author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->

languagetool, which is already on MELPA, repository move from PillFall/Emacs-LanguageTool.el to PillFall/languagetool.el following suggestions from @riscy in the previous Pull Request (#6655).