### PR TITLE
Add recipe for `why-this`

### DIFF
--- a/recipes/why-this
+++ b/recipes/why-this
@@ -1,0 +1,4 @@
+(why-this
+ :fetcher git
+ :repo "https://codeberg.org/akib/emacs-why-this.git")
+ 

--- a/recipes/why-this
+++ b/recipes/why-this
@@ -1,4 +1,3 @@
 (why-this
  :fetcher git
- :repo "https://codeberg.org/akib/emacs-why-this.git")
- 
+ :url "https://codeberg.org/akib/emacs-why-this.git")


### PR DESCRIPTION
### Brief summary of what the package does

`why-this` shows why the current line was changed on the right side of the line.  It can also show editing history with heat map.  It supports multiple version control systems.

### Direct link to the package repository

https://codeberg.org/akib/emacs-why-this

### Your association with the package

I'm the author and the maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

#### Notes

`M-x checkdoc` is unhappy with following, but I think it's a false positive:

```emacs-lisp
(defun why-this ()
  "Show why the current line contains this." ; Probably "contains" should be imperative "contain"
  (interactive)
  ;; ...
  )
```

<!-- After submitting, please fix any problems the CI reports. -->
