### PR TITLE
Add README.md to elfeed recipe.

### DIFF
--- a/recipes/elfeed
+++ b/recipes/elfeed
@@ -1,2 +1,3 @@
 (elfeed :repo "skeeto/elfeed"
-        :fetcher github)
+        :fetcher github
+        :files (:defaults "README.md"))


### PR DESCRIPTION
### Direct link to the package repository

https://github.com/skeeto/elfeed

### Your association with the package

None.

### Relevant communications with the upstream package maintainer

In an email with Christopher Wellons (package maintainer) I asked why the documentation (README.md) mentioned in the package description of Elfeed wasn't included with the package itself. The reply was because of the MELPA recipe submitted years ago, and by default recipes don't include README files, but that Elfeed could be an exception given all the documentation is to be found there, and not in the commentary or elsewhere.