### PR TITLE
Fix :files entry in both helm-core and helm recipes

### DIFF
--- a/recipes/helm
+++ b/recipes/helm
@@ -6,4 +6,4 @@
                         "helm-lib.el"
                         "helm-source.el"
                         "helm-multi-match.el"
-                        "helm-core-pkg.el")))
+                        "helm-core.el")))

--- a/recipes/helm-core
+++ b/recipes/helm-core
@@ -1,3 +1,3 @@
 (helm-core :repo "emacs-helm/helm" 
            :fetcher github 
-           :files ("helm-core-pkg.el" "helm.el" "helm-lib.el" "helm-source.el" "helm-multi-match.el"))
+           :files ("helm-core.el" "helm.el" "helm-lib.el" "helm-source.el" "helm-multi-match.el"))


### PR DESCRIPTION
Helm is now on NonGnu Elpa and its *.pkg.el files have been removed, so this is an update of the helm-core and helm recipes.

Thanks.