### PR TITLE
Add recipe for org-journal-tags

### DIFF
--- a/recipes/org-journal-tags
+++ b/recipes/org-journal-tags
@@ -1,0 +1,1 @@
+(org-journal-tags :fetcher github :repo "SqrtMinusOne/org-journal-tags")


### PR DESCRIPTION
### Brief summary of what the package does

A package that adds "tags" to [org-journal](https://github.com/bastibe/org-journal), and an interface to work with these tags

Not making this a PR to the original package because it turned out to be larger than org-journal itself.

### Direct link to the package repository

https://github.com/SqrtMinusOne/org-journal-tags

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings (_some false positives_)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
