### PR TITLE
Add recipe for quarto-mode

### DIFF
--- a/recipes/quarto-mode
+++ b/recipes/quarto-mode
@@ -1,0 +1,3 @@
+(quarto-mode
+ :fetcher github
+ :repo "quarto-dev/quarto-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a mode for editing Quarto documents: https://quarto.org

### Direct link to the package repository

https://github.com/quarto-dev/quarto-emacs/

### Your association with the package

I'm the developer and maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->

There _are_ two warnings on byte-compilation, but I believe them to be spurious. Specifically:

```
quarto-mode.el:59:20:Warning: ‘make-variable-buffer-local’ not called at
    toplevel
quarto-mode.el:63:20:Warning: ‘make-variable-buffer-local’ not called at
    toplevel
```

These come up because I'm calling a macro that eventually uses make-variable-buffer-local from inside a conditional. I don't know a way around this. I'm trying hard to to avoid requiring ESS, a large optional dependency that won't be necessary for some of our users. At the same time, if the user _has_ ESS installed, we want to support it.
