### PR TITLE
Add recipe for edit-as-format

### DIFF
--- a/recipes/edit-as-format
+++ b/recipes/edit-as-format
@@ -1,0 +1,1 @@
+(edit-as-format :repo "etern/edit-as-format" :fetcher github :files (:defaults "filters"))


### PR DESCRIPTION
### Brief summary of what the package does

Edit document as other format, in Emacs, using Pandoc

### Direct link to the package repository

https://github.com/etern/edit-as-format

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] ~My elisp byte-compiles cleanly~ there's `assignment to free variable` warning and I think it's fine
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
