### PR TITLE
Add org-view-mode recipe

### DIFF
--- a/recipes/org-view-mode
+++ b/recipes/org-view-mode
@@ -1,0 +1,1 @@
+(org-view-mode :repo "amno1/org-view-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

[Please write a quick summary of the package.]

Implements a markup-free, read-only viewing mode for buffers in org-mode.

### Direct link to the package repository

https://github.com/amno1/org-view-mode

### Your association with the package

I am currently the enthusiastic author, maintainer and user :).

### Relevant communications with the upstream package maintainer

Either on GitHub issues or via email as included in the package header.

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

**None needed**

(I am not really sure what you mean here, so please have understanding if I am wrong here.)

### Checklist

<!-- Please confirm with `x`: -->

- [X ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [ X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ X] My elisp byte-compiles cleanly
- [ X] `M-x checkdoc` is happy with my docstrings
- [ X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
