### PR TITLE
Include images for the Company Info manual

### DIFF
--- a/recipes/company
+++ b/recipes/company
@@ -1,1 +1,3 @@
-(company :repo "company-mode/company-mode" :fetcher github :files (:defaults "icons"))
+(company :repo "company-mode/company-mode"
+         :fetcher github
+         :files (:defaults "icons" ("images/small" "doc/images/small/*.png")))


### PR DESCRIPTION
The goal of this change is to include images for the Company Info manual.
 
The suggested change was tested locally and [approved by the maintainer](https://github.com/company-mode/company-mode/pull/1228#issuecomment-1035843726).

[This update is similar to the [PR #6879](https://github.com/melpa/melpa/pull/6879).]