### PR TITLE
Fix again helm package install with straight

### DIFF
--- a/recipes/helm
+++ b/recipes/helm
@@ -2,8 +2,7 @@
       :fetcher github
       :files ("*.el"
               "emacs-helm.sh"
-              (:exclude "helm.el"
-                        "helm-lib.el"
+              (:exclude "helm-lib.el"
                         "helm-source.el"
                         "helm-multi-match.el"
                         "helm-core.el")))

--- a/recipes/helm-core
+++ b/recipes/helm-core
@@ -1,3 +1,3 @@
 (helm-core :repo "emacs-helm/helm" 
            :fetcher github 
-           :files ("helm-core.el" "helm.el" "helm-lib.el" "helm-source.el" "helm-multi-match.el"))
+           :files ("helm-core.el" "helm-lib.el" "helm-source.el" "helm-multi-match.el"))


### PR DESCRIPTION
Now Helm and Helm-core packages, have their own file, respectively
helm.el and helm-core.el, all the code is now in helm-core.el, helm.el
beeing just a wrapper for helm-core.el.

See issues https://github.com/emacs-helm/helm/issues/2481 and https://github.com/raxod502/straight.el/issues/929