### PR TITLE
Add zk-index recipe

### DIFF
--- a/recipes/zk-index
+++ b/recipes/zk-index
@@ -1,0 +1,3 @@
+(zk-index :repo "localauthor/zk"
+         :fetcher github
+         :files ("zk-index.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds two interfaces for use with the `zk` package:

ZK-Index: A sortable, searchable, narrowable, semi-persistent selection of notes titles.

ZK-Desktop: An place (or places) for collecting, grouping, arranging, and saving selections of note titles.

### Direct link to the package repository

https://github.com/localauthor/zk

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
