### PR TITLE
Add norns recipe

### DIFF
--- a/recipes/norns
+++ b/recipes/norns
@@ -1,0 +1,2 @@
+(norns :repo "p3r7/norns.el"
+       :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package allows to interact with one or several [monome norns](https://monome.org/norns/), allowing Emacs to completely replace its [default web-based development environment](https://monome.org/docs/norns/maiden/).

norns support interactive (REPL-based) development w/ Lua and SuperCollider though websocket-based REPLs.

These REPL are represented in Emacs w/ `comint` buffers, using the same technique as `ielm` to have them bind to a dummy process and handling (async) command output manually.

### Direct link to the package repository

https://github.com/p3r7/norns.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

I've got a few items failing with my `checkdoc`.

I didn't find it there is an equivalent command to `fill-paragraph` that also applies to first line of function comments.

Some comment blocs start with a lowercase character voluntarily. Indeed by convention "norns" and "maiden" are always spelled in lowercase.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
