### PR TITLE
Add recipe for `topspace`

### DIFF
--- a/recipes/topspace
+++ b/recipes/topspace
@@ -1,0 +1,3 @@
+(topspace :fetcher github
+          :repo "trevorpogue/topspace"
+          :files ("topspace.el"))

--- a/recipes/topspace
+++ b/recipes/topspace
@@ -1,3 +1,1 @@
-(topspace :fetcher github
-          :repo "trevorpogue/topspace"
-          :files ("topspace.el"))
+(topspace :fetcher github :repo "trevorpogue/topspace")


### PR DESCRIPTION
### Brief summary of what the package does

Scroll above the top line to vertically center top text.

### Direct link to the package repository

https://github.com/trevorpogue/topspace

### Your association with the package

Author & maintainer

### Relevant communications with the upstream package maintainer

I am submitting a request for new minor mode `topspace-mode` that I created

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them