### PR TITLE
Add recipe for textsize

### DIFF
--- a/recipes/textsize
+++ b/recipes/textsize
@@ -1,0 +1,1 @@
+(textsize :repo "WJCFerguson/textsize" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package automatically calculates and adjusts the default text size for the size and pixel pitch of the display.

### Direct link to the package repository

https://github.com/WJCFerguson/textsize/

### Your association with the package

I am the maintainer / author.

### Relevant communications with the upstream package maintainer

n/a

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
