### PR TITLE
Added morgentau-theme

### DIFF
--- a/recipes/morgentau-theme
+++ b/recipes/morgentau-theme
@@ -1,0 +1,1 @@
+(morgentau-theme :fetcher github :repo "Melchizedek6809/morgentau-theme")


### PR DESCRIPTION
### Brief summary of what the package does

A simple, dark theme for Emacs.

### Direct link to the package repository

https://github.com/Melchizedek6809/morgentau-theme

### Your association with the package

My personal theme i've been using/customizing for over a year.

### Relevant communications with the upstream package maintainer

I guess **None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
