### PR TITLE
Add recipe for org-modern

### DIFF
--- a/recipes/org-modern
+++ b/recipes/org-modern
@@ -1,0 +1,3 @@
+(org-modern
+ :repo "minad/org-modern"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Package which applies styling to Org elements via font-locking:

![image](https://raw.githubusercontent.com/minad/org-modern/screenshots/example.gif)

Popular alternatives are [org-bullets](https://github.com/sabof/org-bullets) and [org-superstar](https://github.com/integral-dw/org-superstar-mode), which apply styling to fewer elements (only lists and headlines). Both org-bullets and org-superstar rely on character composition, while org-modern uses only display properties which are supposedly more future-proof.

The styling applied by this package is inspired by Nicholas Rougier's beautiful [svg-tag-mode](https://github.com/rougier/svg-tag-mode) package. In contrast to that package, we avoid svg images here. The tags are styled using cheap display `:box` attributes.

### Direct link to the package repository

https://github.com/minad/org-modern

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
