### PR TITLE
Add recipe for demap

### DIFF
--- a/recipes/demap
+++ b/recipes/demap
@@ -1,0 +1,1 @@
+(demap :fetcher gitlab :repo "sawyerjgardner/demap.el")


### PR DESCRIPTION
### Brief summary of what the package does

lets you make a minimap that shows a zoomed out view of the current window. The difference between this and other minimap packages is that the minimap is in its own buffer that can be moved and detached like any other emacs buffer. It supports having multiple minimaps with there own configurations. I made this package because I wanted a minimap in a different frame then the window I'm editing in.

### Direct link to the package repository

https://gitlab.com/sawyerjgardner/demap.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them