### PR TITLE
Add recipe for display-wttr

### DIFF
--- a/recipes/display-wttr
+++ b/recipes/display-wttr
@@ -1,0 +1,3 @@
+(display-wttr
+ :fetcher github
+ :repo "josegpt/display-wttr")


### PR DESCRIPTION
### Brief summary of what the package does

Display wttr(weather) in the mode line.

### Direct link to the package repository

https://github.com/josegpt/display-wttr

### Your association with the package

I am the author of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
