### PR TITLE
Update recipe for proof-general: Add "qrhl" directory

### DIFF
--- a/recipes/proof-general
+++ b/recipes/proof-general
@@ -5,5 +5,5 @@
  :files (:defaults "CHANGES" "AUTHORS" "COPYING"
                    "generic" "images" "lib"
                    ("coq" "coq/*.el")
-                   "easycrypt" "phox"
+                   "easycrypt" "phox" "qrhl"
                    "pghaskell" "pgocaml" "pgshell"))


### PR DESCRIPTION
### Brief summary of what the package does

* Update the recipe for `proof-general`
* Follow-up of: https://github.com/ProofGeneral/PG/pull/636

### Direct link to the package repository

https://github.com/ProofGeneral/PG

### Your association with the package

I'm one of the co-maintainers.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] ~I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback~
- [x] My elisp byte-compiles cleanly
- [ ] ~`M-x checkdoc` is happy with my docstrings~
- [ ] ~I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)~
- [ ] I have confirmed some of these without doing them

> Note: I didn't check everything above again because it is just a small update of an existing recipe.

<!-- After submitting, please fix any problems the CI reports. -->