### PR TITLE
Add recipie  for org-ros

### DIFF
--- a/recipes/org-ros
+++ b/recipes/org-ros
@@ -1,0 +1,3 @@
+(org-ros
+  :repo "LionyxML/ros"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

When using org-mode, this package provides a function (M-x org-ros) which invokes an external screenshot capture software (defaults to scrot and screencapture), and after selecting part of the screen, saves this screenshot picture in the same folder as the opened .org file, links it to the document and turns on "display-in-line-images". (short gif of this working here: https://github.com/LionyxML/ros/blob/master/images/ros.gif ).

### Direct link to the package repository

https://github.com/LionyxML/ros

### Your association with the package

Both Maintainer and enthusiastic user.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
