### PR TITLE
update fennel-mode repo url

### DIFF
--- a/recipes/fennel-mode
+++ b/recipes/fennel-mode
@@ -1,2 +1,2 @@
-(fennel-mode :repo "technomancy/fennel-mode"
-             :fetcher gitlab)
+(fennel-mode :url "https://git.sr.ht/~technomancy/fennel-mode"
+             :fetcher git)


### PR DESCRIPTION
Fennel mode was moved to sourcehut and the Gitlab repo is no longer updated. I'm a co-maintainer of this package, so I've thought that the change in the recipe is needed.

Commit that confirms the move https://gitlab.com/technomancy/fennel-mode/-/commit/55c3fdc6ab8e919636c35176348046f6c80cf9e7