### PR TITLE
Add recipe for ox-gist

### DIFF
--- a/recipes/ox-gist
+++ b/recipes/ox-gist
@@ -1,0 +1,2 @@
+(ox-gist :repo "punchagan/ox-gist"
+         :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

The package makes it easy to share a sub-tree from an `org` file as a `gist` on GitHub. A published `gist` can be easily updated when the contents of the local `org` sub-tree are changed. It uses `defunkt/gist.el` to do the heavy lifting of posting and updating gists on GitHub.

### Direct link to the package repository

https://github.com/punchagan/org2gist

### Your association with the package

I'm the creator/maintainer of this package

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
