### PR TITLE
Add a recipe for prettier-rc

### DIFF
--- a/recipes/prettier-rc
+++ b/recipes/prettier-rc
@@ -1,0 +1,1 @@
+(prettier-rc :repo "jjuliano/prettier-rc-emacs" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

prettier-rc is a function that searches for local rc rules and editorconfig rules per project and use it to format the current buffer using prettier. The package also exports a minor mode that applies (prettier-rc) on save.

### Direct link to the package repository

https://github.com/jjuliano/prettier-rc-emacs

### Your association with the package

Author, Maintainer

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
