### PR TITLE
adds recipe for auto-dark

### DIFF
--- a/recipes/auto-dark
+++ b/recipes/auto-dark
@@ -1,0 +1,3 @@
+(auto-dark
+  :repo "LionyxML/auto-dark-emacs"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

 Auto-Dark is an auto-changer between 2 themes, dark/light, following the overall settings of MacOS.  

### Direct link to the package repository

https://github.com/LionyxML/auto-dark-emacs

### Your association with the package

Author and Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
