### PR TITLE
Fetch archive-rpm from nbarrientos' namespace

### DIFF
--- a/recipes/archive-rpm
+++ b/recipes/archive-rpm
@@ -1,1 +1,1 @@
-(archive-rpm :repo "legoscia/archive-rpm" :fetcher github)
+(archive-rpm :repo "nbarrientos/archive-rpm" :fetcher github)


### PR DESCRIPTION
I'm not using the PR template as this isn't a new package request but a fork request.

I'd like to temporarily request pointing `archive-rpm` to my fork as:

* The maintainer is unresponsive (see [emacsorphanage/p/discussions/3](https://github.com/emacsorphanage/p/discussions/3))
* The package does not work on Emacs 28.
* The package which is meant to help visiting RPMs cannot currently handle zstd compression which is [the default](https://fedoraproject.org/wiki/Changes/Switch_RPMs_to_zstd_compression) since Fedora 31.
* There are [outstanding merge requests](https://github.com/legoscia/archive-rpm/pulls) fixing both issues in the repository currently MELPA points to that have not been acknowledged.

I've already sent the first ping to the maintainer (`magnus.henoch@gmail.com`) 15 days ago as described in [the rules](https://github.com/melpa/melpa/wiki/Unmaintained-Packages-and-Forks). I'm sending today another one and I'll be switching this PR from draft to ready if I don't get any reply in two weeks.

My fork contains both patches already merged. I'm also happy to maintain the package for the time being and hand it back to Magnus if he shows interest in taking care of it again in the future.