### PR TITLE
Add recipe for ob-bitfield

### DIFF
--- a/recipes/ob-bitfield
+++ b/recipes/ob-bitfield
@@ -1,0 +1,2 @@
+(ob-bitfield :repo "gsingh93/ob-bitfield"
+             :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Adds `org-babel` support for generating bitfield diagrams from source blocks using https://github.com/Arth-ur/bitfield.

### Direct link to the package repository

https://github.com/gsingh93/ob-bitfield

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
