### PR TITLE
Rename kmacro-mc to kmacro-x

### DIFF
--- a/recipes/kmacro-mc
+++ b/recipes/kmacro-mc
@@ -1,3 +1,0 @@
-(kmacro-mc
- :fetcher github
- :repo "vifon/kmacro-mc.el")

--- a/recipes/kmacro-x
+++ b/recipes/kmacro-x
@@ -1,0 +1,2 @@
+(kmacro-x :repo "vifon/kmacro-x.el" :fetcher github
+          :old-names (kmacro-mc))


### PR DESCRIPTION
### Brief summary of what the package does

A collection of commands, modes and functions building on top of the keyboard macros (kmacros) system. Rename caused by the project scope growing past only multiple-cursors emulation.

### Direct link to the package repository

https://github.com/vifon/kmacro-x.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
