### PR TITLE
Get cg from upstream + get the actual file

### DIFF
--- a/recipes/cg
+++ b/recipes/cg
@@ -1,1 +1,1 @@
-(cg :fetcher github :repo "emacsmirror/cg")
+(cg :fetcher github :repo "GrammarSoft/cg3" :files ("emacs/*.el"))


### PR DESCRIPTION
-------

### Brief summary of what the package does

Syntax highlighting, testing, flymake, xref support for editing
Constraint Grammar rule files.

### Direct link to the package repository

https://github.com/GrammarSoft/cg3

### Your association with the package

Creator of emacs package, minor contributor to repo

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings (mostly happy, it does still want me to document non-interactive and internal stuff)
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->