### PR TITLE
Update scratch to point at `main`.

### DIFF
--- a/recipes/scratch
+++ b/recipes/scratch
@@ -1,1 +1,5 @@
-(scratch :fetcher github :repo "ieure/scratch-el" :files ("scratch.el"))
+(scratch
+ :fetcher github
+ :repo "ieure/scratch-el"
+ :branch "main"
+ :files ("scratch.el"))


### PR DESCRIPTION
I renamed the default branch on scratch to `main`.  This PR updates the existing MELPA recipe to specify it.

### Direct link to the package repository

https://github.com/ieure/scratch-el

### Your association with the package

I'm the package maintainer.