### PR TITLE
added private-comments-mode recipe

### DIFF
--- a/recipes/private-comments-mode
+++ b/recipes/private-comments-mode
@@ -1,0 +1,1 @@
+(private-comments-mode :fetcher github :repo "masukomi/private-comments-mode")


### PR DESCRIPTION
### Brief summary of what the package does

a minor-mode client for [Private Comments](https://github.com/masukomi/private_comments#readme) that enables users to leave private comments on git controlled files. Comments are displayed inline and associated with the commits that introduced/last modified them and only visible in files that currently contain the relevant commit lines.

### Direct link to the package repository

[private-comments-mode repository](https://github.com/masukomi/private-comments-mode)

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

This is my first melpa package so please let me know if anything isn't quite right. Please note the comment re checkdoc below. 

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) - MIT license. 
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
  - It liked "Buffer comments and tags" but hung on "Documentation style: Checking..." I don't know enough about checkdoc to know what to make of that.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
