### PR TITLE
Add oblivion theme

### DIFF
--- a/recipes/oblivion-theme
+++ b/recipes/oblivion-theme
@@ -1,0 +1,3 @@
+(oblivion-theme
+ :repo "ideasman42/emacs-oblivion-theme"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Oblivion theme for emacs, following the GEdit theme,[(see screenshot)](https://gitlab.com/ideasman42/emacs-oblivion-theme/uploads/2af77faa0b50f4efdb2f85eb05bdf967/oblivion_screenshot.png)

The same theme for other editors:

- [atom](https://github.com/robertfoss/atom_gedit_oblivion)
- [eclipse](http://www.eclipsecolorthemes.org/?view=theme&id=115)
- [qt-creator](https://github.com/fatalhalt/qt-creator-gedit-oblivion-theme)
- [sublime text](https://github.com/jbrooksuk/Oblivion)
- [vim](https://github.com/veloce/vim-aldmeris)
- [vs-code](https://marketplace.visualstudio.com/items?itemName=gerane.Theme-Oblivion)

### Direct link to the package repository

https://gitlab.com/ideasman42/emacs-oblivion-theme

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
