### PR TITLE
Add recipe for ob-dsq

### DIFF
--- a/recipes/ob-dsq
+++ b/recipes/ob-dsq
@@ -1,0 +1,1 @@
+(ob-dsq :fetcher github :repo "fritzgrabo/ob-dsq")


### PR DESCRIPTION
### Brief summary of what the package does

Babel functions for the [dsq CLI tool](https://github.com/multiprocessio/dsq) by [Multiprocess Labs.](https://multiprocess.io/) ❤️

`dsq` is a command-line tool for running SQL queries against JSON, CSV, Excel, Parquet, and more.

This package adds Org tables, Org quotes and Org source block results to this list.

The package repository has a screenshot and a lot of examples.

### Direct link to the package repository

https://github.com/fritzgrabo/ob-dsq

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback, **BUT SEE BELOW**
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

Please note that `package-lint` (and by proxy, `melpazoid`) reports 19 errors, all of which fall into these 2 categories:

- `"org-babel-header-args:dsq" doesn't start with package's prefix "ob-dsq".` That's expected; Org-babel packages are prefixed with `ob-` rather than `org-babel-`, while the function names expected by Org-babel begin with `org-babel-`.
- `'org-babel-header-args:dsq' contains a non-standard separator ':', use hyphens instead.` Similar to the above, that's expected; Org-babel looks for functions with that name.

Thank you!
