### PR TITLE
Add recipe for consult-org-roam

### DIFF
--- a/recipes/consult-org-roam
+++ b/recipes/consult-org-roam
@@ -1,0 +1,3 @@
+(consult-org-roam
+ :repo "jgru/consult-org-roam"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`consult-org-roam` is a collection of functions to operate [org-roam](https://github.com/org-roam/org-roam) with the help of [consult](https://github.com/minad/consult) and its live preview feature.

### Direct link to the package repository

https://github.com/jgru/consult-org-roam

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback 
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
