### PR TITLE
Transfer repository for tramp-term.el

### DIFF
--- a/recipes/tramp-term
+++ b/recipes/tramp-term
@@ -1,1 +1,1 @@
-(tramp-term :fetcher github :repo "randymorris/tramp-term.el")
+(tramp-term :fetcher github :repo "cuspymd/tramp-term.el")


### PR DESCRIPTION
### Brief summary of what the package does

Transfer repository from randymorris/tramp-term.el to cuspymd/tramp-term.el

### Direct link to the package repository

https://github.com/cuspymd/tramp-term.el

### Your association with the package

I am new maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist


- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
