### PR TITLE
Add new recipe for flymake-swi-prolog

### DIFF
--- a/recipes/flymake-swi-prolog
+++ b/recipes/flymake-swi-prolog
@@ -1,0 +1,1 @@
+(flymake-swi-prolog :url "https://git.sr.ht/~eshel/flymake-swi-prolog" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

This package implements a simple Flymake backend for [SWI-Prolog](https://www.swi-prolog.org/), providing diagnostics about Prolog source code in `prolog-mode` buffers.
Under the hood, `flymake-swi-prolog` uses [diagnostics.pl](https://git.sr.ht/~eshel/diagnostics.pl), which is a tiny Prolog package I've written to expose the diagnosis performed by the SWI-Prolog built-in IDE.

### Direct link to the package repository

https://git.sr.ht/~eshel/flymake-swi-prolog

### Your association with the package

I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
