### PR TITLE
Add recipe for elfeed-summary

### DIFF
--- a/recipes/elfeed-summary
+++ b/recipes/elfeed-summary
@@ -1,0 +1,1 @@
+(elfeed-summary :fetcher github :repo "SqrtMinusOne/elfeed-summary")


### PR DESCRIPTION
### Brief summary of what the package does

The package provides a tree-based feed summary interface for [elfeed](https://github.com/skeeto/elfeed).

The default interface is just a list of all entries, and it gets hard to navigate when there are a lot of sources with varying post frequencies. This is my attempt to make the navigation easier.

### Direct link to the package repository

https://github.com/SqrtMinusOne/elfeed-summary

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings (A few false positives. I mean `lisp` and `emacs` to be lowercase, and `magit-section` is a reference to a class).
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
