### PR TITLE
Add `catppuccin-theme`

### DIFF
--- a/recipes/catppuccin-theme
+++ b/recipes/catppuccin-theme
@@ -1,0 +1,1 @@
+(catppuccin-theme :fetcher github :repo "pspiagicw/catppuccin-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

Provides `catppuccin` theme for Emacs.

### Direct link to the package repository

https://github.com/pspiagicw/catppuccin-emacs

### Your association with the package

A maintainer. 

A little note. Currently  repository is in `pspiagicw`(my) ownership. After package is merged into MELPA the repository will be transferred to `catppuccin`(github.com/catppuccin) while I still will be maintainer and contributor.

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
