### PR TITLE
Update `catppuccin-theme` recipe.

### DIFF
--- a/recipes/catppuccin-theme
+++ b/recipes/catppuccin-theme
@@ -1,1 +1,1 @@
-(catppuccin-theme :fetcher github :repo "pspiagicw/catppuccin-emacs")
+(catppuccin-theme :fetcher github :repo "catppuccin/emacs")

--- a/recipes/catppuccin-theme
+++ b/recipes/catppuccin-theme
@@ -1,0 +1,1 @@
+(catppuccin-theme :fetcher github :repo "pspiagicw/catppuccin-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

Provides Catppuccin-theme to emacs. Update of recipe for #7973.

Repository `github.com/pspiagicw/catppuccin-emacs` was transferred to `github.com/catppuccin/emacs` as planned and discussed in #7973 .

### Direct link to the package repository

https://github.com/catppuccin/emacs

### Your association with the package

A maintainer

This is a update to the PR #7973 where it was mentioned that repository will be transferred to `https://github.com/catppuccin` after package was uploaded to  MELPA.Due to this transfer the GitHub URL mentioned in the recipe has to be updated , which is the purpose of this PR.

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
