### PR TITLE
Create everlasting-scratch

### DIFF
--- a/recipes/everlasting-scratch
+++ b/recipes/everlasting-scratch
@@ -1,0 +1,1 @@
+(everlasting-scratch :repo "beacoder/everlasting-scratch" :fetcher github)


### PR DESCRIPTION
The scratch buffer that lasts forever.

### Brief summary of what the package does
This package provides a global minor mode `everlasting-scratch-mode' that causes the scratch to respawn after it's killed and with its content restored, the scratch could survive manual kill and emacs restart (with help of desktop.el)

### Direct link to the package repository

https://github.com/beacoder/everlasting-scratch

### Your association with the package

author

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
