### PR TITLE
add recipe for clingo-mode

### DIFF
--- a/recipes/clingo-mode
+++ b/recipes/clingo-mode
@@ -1,0 +1,1 @@
+(clingo-mode :fetcher github :repo "llaisdy/clingo-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for working with clingo Answer Set Programming files (see https://potassco.org/).

Differences from the similar pasp-mode (see below) are due partly to my use of the mode to help my learning of answer set programming (eg examples directory; ability to call clingo on a selected region of the buffer, not just the whole file), partly to my discussions with the Potassco community (eg aim for feature parity with the [vim clingo mode](https://github.com/rkaminsk/vim-syntax-clingo/blob/master/syntax/gringo.vim), which is maintained by the Potassco people themselves).

If/when the package is accepted I shall add an installation from melpa section to the README.

### Direct link to the package repository

https://github.com/llaisdy/clingo-mode

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

This package is based on [pasp-mode](https://github.com/santifa/pasp-mode) which seems to have been abandoned.  I have discussed the best way to proceed on the Potassco mailing list (archive links available on request).

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
