### PR TITLE
Add package for restclient jq support

### DIFF
--- a/recipes/restclient-jq
+++ b/recipes/restclient-jq
@@ -1,0 +1,3 @@
+(restclient-jq :repo "pashky/restclient.el"
+               :fetcher github
+               :files ("restclient-jq.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Support for setting restclient vars from jq expressions.

### Direct link to the package repository

https://github.com/pashky/restclient.el

### Your association with the package

I'm a user of the restclient package and saw that it supports parsing JSON responses with `jq`. I wondered why I couldn't use this functionality with my MELPA installed package and figured out that a `restclient-jq` package is missing. As I'm not the original author and didn't contribute to restclient.el yet, I didn't run any quality checks on the original code. I see that package-lint, `M-x checkdoc` and byte-compilation yield some warnings. I'm willing to tackle these and submit a PR to the original repository, if necessary.

### Relevant communications with the upstream package maintainer

There is an open issue over at https://github.com/pashky/restclient.el/issues/257 discussing that this package is missing. I asked the maintainer for permission to submit the package and they agreed. 

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
