### PR TITLE
Add recipe for wordreference

### DIFF
--- a/recipes/wordreference
+++ b/recipes/wordreference
@@ -1,0 +1,1 @@
+(wordreference :fetcher git :url  "https://codeberg.org/martianh/wordreference.el" :files ("wordreference.el"))

--- a/recipes/wordreference
+++ b/recipes/wordreference
@@ -1,1 +1,1 @@
-(wordreference :fetcher git :url  "https://codeberg.org/martianh/wordreference.el" :files ("wordreference.el"))
+(wordreference :url "https://codeberg.org/martianh/wordreference.el" :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

An interface to the wordreference.com dictionaries.

### Direct link to the package repository

https://codeberg.org/martianh/wordreference.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

re linting, i just have one issue (which i also had with another package and never worked out a solution for):

my package depends on `s`, which has an entry in `Package-Requires:`, but flycheck baulks at the `require` statement for it, saying `Cannot open load file: No such file or directory, s`. 

this only happens for dependencies that would also need to be installed by `package.el`. i figured this is a common issue and i'm just missing something basic that other MELPA/package ppl would know.

if i build and install the package, it pulls in the dependency, and the require statement has no issues. i figure it also requires it, but then if i remove my require statement flycheck thinks the functions i use from that library are undefined.