### PR TITLE
Add a recipe for liblouis mode

### DIFF
--- a/recipes/liblouis
+++ b/recipes/liblouis
@@ -1,0 +1,1 @@
+(liblouis :fetcher github :repo "liblouis/liblouis-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Liblouis mode is an Emacs major mode for editing [liblouis](https://github.com/liblouis/liblouis) braille translation tables.

### Direct link to the package repository

https://github.com/liblouis/liblouis-mode

### Your association with the package

I am the maintainer of the package

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - there is one warning that I don't know how to avoid: I use `eval-after-load` to set the `compilation-error-regexp-alist`
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
