### PR TITLE
Add recipe for flymake-collection

### DIFF
--- a/recipes/flymake-collection
+++ b/recipes/flymake-collection
@@ -1,6 +1,5 @@
 (flymake-collection
  :fetcher github
  :repo "mohkale/flymake-collection"
- :branch "release"
  :files (:defaults "src/*.el" "src/checkers/*.el")
  :old-names (flymake-rest))

--- a/recipes/flymake-collection
+++ b/recipes/flymake-collection
@@ -1,0 +1,4 @@
+(flymake-collection
+ :fetcher github
+ :repo "mohkale/flymake-collection"
+ :files (:defaults "checkers/*.el"))

--- a/recipes/flymake-collection
+++ b/recipes/flymake-collection
@@ -1,4 +1,5 @@
 (flymake-collection
  :fetcher github
  :repo "mohkale/flymake-collection"
- :files (:defaults "checkers/*.el"))
+ :files (:defaults "src/*.el" "src/checkers/*.el")
+ :old-names (flymake-rest))

--- a/recipes/flymake-collection
+++ b/recipes/flymake-collection
@@ -1,5 +1,6 @@
 (flymake-collection
  :fetcher github
  :repo "mohkale/flymake-collection"
+ :branch "release"
  :files (:defaults "src/*.el" "src/checkers/*.el")
  :old-names (flymake-rest))

--- a/recipes/flymake-rest
+++ b/recipes/flymake-rest
@@ -1,4 +1,0 @@
-(flymake-rest
- :fetcher github
- :repo "mohkale/flymake-rest"
- :files (:defaults "checkers/*.el"))


### PR DESCRIPTION
Hi, this is a prepratory PR for an impending rename to my package `flymake-rest` to `flymake-collection`. It isn't ready to be merged yet, I just wanted to open this PR to ask what the recommended process for such a transition would be? I was hoping to keep both recipes up for a brief period, archiving the repo for the old one (after committing a message that tells users to migrate). 