### PR TITLE
Add recipe for whiley-mode

### DIFF
--- a/recipes/whiley-mode
+++ b/recipes/whiley-mode
@@ -1,0 +1,1 @@
+(whiley-mode :repo "Whiley/WhileyEmacsMode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A major mode providing rudimentary syntax highlighting for programs written the [Whiley](http://whiley.org) programming language.  Since Whiley is an experimental language, there are no other recipes available for it.

If/when the package is accepted I shall add an installation from melpa section to the README.

### Direct link to the package repository

https://github.com/Whiley/WhileyEmacsMode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
