### PR TITLE
Add recipe for cue-mode

### DIFF
--- a/recipes/cue-mode
+++ b/recipes/cue-mode
@@ -1,0 +1,1 @@
+(cue-mode :fetcher github :repo "russell/cue-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This adds the CUE language mode.  CUE is a data definition language like YAML but with support for inline schemas. https://cuelang.org/

### Direct link to the package repository

https://github.com/russell/cue-mode/

### Your association with the package

I'm the maintainer of the package

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
