### PR TITLE
Separate recipes for dash-docs and use-package-dash-docs

### DIFF
--- a/recipes/dash-docs
+++ b/recipes/dash-docs
@@ -1,2 +1,3 @@
 (dash-docs :repo "dash-docs-el/dash-docs"
-                 :fetcher github)
+           :fetcher github
+           :files (:defaults (:exclude "use-package-dash-docs.el")))

--- a/recipes/use-package-dash-docs
+++ b/recipes/use-package-dash-docs
@@ -1,0 +1,3 @@
+(use-package-dash-docs :repo "dash-docs-el/dash-docs"
+                       :fetcher github
+                       :files ("use-package-dash-docs.el"))


### PR DESCRIPTION
@canatella et al.

[dash-docs](https://github.com/dash-docs-el/dash-docs) contains `use-package-dash-docs.el`, which depends on use-package. `use-package` is not listed in the dependencies of `dash-docs.el`, so it should be a separate package.