### PR TITLE
Update eide URL (Chalec)

### DIFF
--- a/recipes/eide
+++ b/recipes/eide
@@ -1,1 +1,1 @@
-(eide :fetcher git :url "https://forge.chapril.org/hjuvi/eide.git" :files ("src/*.el" "src/themes/*.el"))
+(eide :fetcher git :url "https://forge.chalec.org/hjuvi/eide.git" :files ("src/*.el" "src/themes/*.el"))


### PR DESCRIPTION
The project moved from Chapril to Chalec forge.
The change is mentioned in the description of the project on Chapril.
It will be removed from Chapril when it is updated in Melpa.

### Brief summary of what the package does

A package for Emacs that provides IDE features.

### Direct link to the package repository

https://forge.chalec.org/hjuvi/eide
(was: https://forge.chapril.org/hjuvi/eide)

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
