### PR TITLE
Proposal: py-autopep8 was unmaintained, point to repository with improvements/fixes

### DIFF
--- a/recipes/py-autopep8
+++ b/recipes/py-autopep8
@@ -1,3 +1,3 @@
 (py-autopep8
- :repo "paetzke/py-autopep8.el"
+ :repo "ideasman42/emacs-py-autopep8"
  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

I'm proposing to take over maintenance of py-autopep8, as it hasn't been updated since 2016 and there are unaddressed issues which I've resolved in my repository.

I've made the following changes:

- Fixed https://github.com/paetzke/py-autopep8.el/issues/29
- Fixed https://github.com/paetzke/py-autopep8.el/issues/24
- Address https://github.com/paetzke/py-autopep8.el/issues/16
- Remove need for external diffing tool & temporary files (allowing for MS-Windows support).
- Silence checkdoc and package-lint warnings.
- Tests now pass.

### Direct link to the package repository

https://github.com/ideasman42/emacs-py-autopep8

### Your association with the package

Contributor/user.

### Relevant communications with the upstream package maintainer

- I tried emailing  "Friedrich Paetzke"  using his `fastmail.fm` address (from the git commit history) but it bounced.
- Judging by this thread the original author is no longer active.
https://github.com/paetzke/py-autopep8.el/issues/28 (from 2018)

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
