### PR TITLE
Add recipe for ROOT-mode

### DIFF
--- a/recipes/cern-root-mode
+++ b/recipes/cern-root-mode
@@ -1,4 +1,3 @@
 (cern-root-mode
  :fetcher github
- :repo "jaypmorgan/cern-root-mode"
- :branch "main")
+ :repo "jaypmorgan/cern-root-mode")

--- a/recipes/cern-root-mode
+++ b/recipes/cern-root-mode
@@ -1,0 +1,4 @@
+(cern-root-mode
+ :fetcher github
+ :repo "jaypmorgan/cern-root-mode"
+ :branch "main")

--- a/recipes/root-mode
+++ b/recipes/root-mode
@@ -1,5 +1,0 @@
-(root-mode
- :fetcher github
- :repo "jaypmorgan/root-mode"
- :branch "main"
- :version-regexp "v\\([0-9.]+.*\\)")

--- a/recipes/root-mode
+++ b/recipes/root-mode
@@ -1,0 +1,8 @@
+(root-mode
+ :fetcher github
+ :url "https://github.com/jaypmorgan/root-mode"
+ :repo "jaypmorgan/root-mode"
+ :commit "1699a61b3a4490a048a4fd599a5a485d143b4b2a"
+ :branch "main"
+ :version-regexp "v\\([0-9.]+.*\\)"
+ :files ("*.el"))

--- a/recipes/root-mode
+++ b/recipes/root-mode
@@ -1,8 +1,5 @@
 (root-mode
  :fetcher github
- :url "https://github.com/jaypmorgan/root-mode"
  :repo "jaypmorgan/root-mode"
- :commit "1699a61b3a4490a048a4fd599a5a485d143b4b2a"
  :branch "main"
- :version-regexp "v\\([0-9.]+.*\\)"
- :files ("*.el"))
+ :version-regexp "v\\([0-9.]+.*\\)")


### PR DESCRIPTION
### Brief summary of what the package does

ROOT-mode provides the functionality to evaluate C++ code using the ROOT REPL (https://root.cern/) in C++ buffers, and C++ org-mode source code blocks.

### Direct link to the package repository

https://github.com/jaypmorgan/root-mode

### Your association with the package

I am the maintainer of ROOT-mode.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
