### PR TITLE
Move utimeclock to codeberg

### DIFF
--- a/recipes/utimeclock
+++ b/recipes/utimeclock
@@ -1,3 +1,3 @@
 (utimeclock
- :repo "ideasman42/emacs-utimeclock"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-utimeclock.git"
+ :fetcher git)


### PR DESCRIPTION
This PR is to relocate my existing package [utimeclock](https://melpa.org/#/utimeclock) to codeberg (to use a more free and open hosting).

See URL: https://codeberg.org/ideasman42/emacs-utimeclock
Old URL: https://gitlab.com/ideasman42/emacs-utimeclock