### PR TITLE
Update fetcher for dtache package

### DIFF
--- a/recipes/dtache
+++ b/recipes/dtache
@@ -1,2 +1,3 @@
 (dtache
- :fetcher "https://git.sr.ht/~niklaseklund/dtache")
+ :fetcher git
+ :url "https://git.sr.ht/~niklaseklund/dtache")

--- a/recipes/dtache
+++ b/recipes/dtache
@@ -1,3 +1,2 @@
 (dtache
- :repo "niklaseklund/dtache"
- :fetcher gitlab)
+ :fetcher "https://git.sr.ht/~niklaseklund/dtache")


### PR DESCRIPTION
The development of dtache has been migrated from gitlab to
sourcehut. The fetcher in the dtache recipe is therefore updated
accordingly.

For reference see this commit:
https://gitlab.com/niklaseklund/dtache/-/commit/b762fe472f1a47d0f1808620d4468aee645654ee