### PR TITLE
Add sql-trino recipe

### DIFF
--- a/recipes/sql-trino
+++ b/recipes/sql-trino
@@ -1,4 +1,1 @@
-(sql-trino
- :fetcher github
- :repo "regadas/sql-trino"
- :files ("sql-trino.el"))
+(sql-trino :fetcher github :repo "regadas/sql-trino")

--- a/recipes/sql-trino
+++ b/recipes/sql-trino
@@ -1,0 +1,4 @@
+(sql-trino
+ :fetcher github
+ :repo "regadas/sql-trino"
+ :files ("sql-trino.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Add product type `trino` for builtin SQL mode.

### Direct link to the package repository

https://github.com/regadas/sql-trino

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
