### PR TITLE
Add recipe for arXiv-citation

### DIFF
--- a/recipes/arxiv-citation
+++ b/recipes/arxiv-citation
@@ -1,0 +1,1 @@
+(arxiv-citation :fetcher gitlab :repo "slotThe/arxiv-citation")


### PR DESCRIPTION
### Brief summary of what the package does

Utility functions for dealing with arXiv papers.  It can generate citation data for PDF files from the arXiv and, optionally, download preprints to a specified directory and open them.  It also includes integration into `elfeed`. 

(If needed, a longer explanation, as well as preview GIFs, can be found in the README)

### Direct link to the package repository

https://gitlab.com/slotThe/arxiv-citation

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

NOTE: There are two false positives

    157:14: error: `authors' was removed in Emacs version 25.1.
    218:10: error: `authors' was removed in Emacs version 25.1.

that I left in since I like the name of the variables in these cases.

- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
