### PR TITLE
Add recipe for project-rootfile

### DIFF
--- a/recipes/project-rootfile
+++ b/recipes/project-rootfile
@@ -1,0 +1,1 @@
+(project-rootfile :repo "buzztaiki/project-rootfile.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs [project](https://www.gnu.org/software/emacs/manual/html_node/emacs/Projects.html) backend that uses a root file (e.g. Gemfile) for detection.

### Direct link to the package repository

https://github.com/buzztaiki/project-rootfile.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed


### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
