### PR TITLE
Relocate my projects to codeberg

### DIFF
--- a/recipes/bookmark-in-project
+++ b/recipes/bookmark-in-project
@@ -1,3 +1,3 @@
 (bookmark-in-project
- :repo "ideasman42/emacs-bookmark-in-project"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-bookmark-in-project.git"
+ :fetcher git)

--- a/recipes/counsel-at-point
+++ b/recipes/counsel-at-point
@@ -1,3 +1,3 @@
 (counsel-at-point
-  :repo "ideasman42/emacs-counsel-at-point"
-  :fetcher gitlab)
+  :url "https://codeberg.org/ideasman42/emacs-counsel-at-point.git"
+  :fetcher git)

--- a/recipes/cycle-at-point
+++ b/recipes/cycle-at-point
@@ -1,3 +1,3 @@
 (cycle-at-point
- :repo "ideasman42/emacs-cycle-at-point"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-cycle-at-point.git"
+ :fetcher git)

--- a/recipes/default-font-presets
+++ b/recipes/default-font-presets
@@ -1,3 +1,3 @@
 (default-font-presets
- :repo "ideasman42/emacs-default-font-presets"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-default-font-presets.git"
+ :fetcher git)

--- a/recipes/diff-ansi
+++ b/recipes/diff-ansi
@@ -1,3 +1,3 @@
 (diff-ansi
- :repo "ideasman42/emacs-diff-ansi"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-diff-ansi.git"
+ :fetcher git)

--- a/recipes/diff-at-point
+++ b/recipes/diff-at-point
@@ -1,3 +1,3 @@
 (diff-at-point
- :repo "ideasman42/emacs-diff-at-point"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-diff-at-point.git"
+ :fetcher git)

--- a/recipes/doc-show-inline
+++ b/recipes/doc-show-inline
@@ -1,3 +1,3 @@
 (doc-show-inline
-  :repo "ideasman42/emacs-doc-show-inline"
-  :fetcher gitlab)
+  :url "https://codeberg.org/ideasman42/emacs-doc-show-inline.git"
+  :fetcher git)

--- a/recipes/hl-block-mode
+++ b/recipes/hl-block-mode
@@ -1,3 +1,3 @@
 (hl-block-mode
- :repo "ideasman42/emacs-hl-block-mode"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-hl-block-mode.git"
+ :fetcher git)

--- a/recipes/hl-prog-extra
+++ b/recipes/hl-prog-extra
@@ -1,3 +1,3 @@
 (hl-prog-extra
- :repo "ideasman42/emacs-hl-prog-extra"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-hl-prog-extra.git"
+ :fetcher git)

--- a/recipes/idle-highlight-mode
+++ b/recipes/idle-highlight-mode
@@ -1,3 +1,3 @@
 (idle-highlight-mode
- :repo "ideasman42/emacs-idle-highlight-mode"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-idle-highlight-mode.git"
+ :fetcher git)

--- a/recipes/inkpot-theme
+++ b/recipes/inkpot-theme
@@ -1,3 +1,3 @@
 (inkpot-theme
- :repo "ideasman42/emacs-inkpot-theme"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-theme-inkpot.git"
+ :fetcher git)

--- a/recipes/magit-commit-mark
+++ b/recipes/magit-commit-mark
@@ -1,3 +1,3 @@
 (magit-commit-mark
-  :repo "ideasman42/emacs-magit-commit-mark"
-  :fetcher gitlab)
+  :url "https://codeberg.org/ideasman42/emacs-magit-commit-mark.git"
+  :fetcher git)

--- a/recipes/mode-line-idle
+++ b/recipes/mode-line-idle
@@ -1,3 +1,3 @@
 (mode-line-idle
- :repo "ideasman42/emacs-mode-line-idle"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-mode-line-idle.git"
+ :fetcher git)

--- a/recipes/oblivion-theme
+++ b/recipes/oblivion-theme
@@ -1,3 +1,3 @@
 (oblivion-theme
- :repo "ideasman42/emacs-oblivion-theme"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-theme-oblivion.git"
+ :fetcher git)

--- a/recipes/py-autopep8
+++ b/recipes/py-autopep8
@@ -1,3 +1,3 @@
 (py-autopep8
- :repo "ideasman42/emacs-py-autopep8"
- :fetcher github)
+ :url "https://codeberg.org/ideasman42/emacs-py-autopep8.git"
+ :fetcher git)

--- a/recipes/recomplete
+++ b/recipes/recomplete
@@ -1,3 +1,3 @@
 (recomplete
- :repo "ideasman42/emacs-recomplete"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-recomplete.git"
+ :fetcher git)

--- a/recipes/revert-buffer-all
+++ b/recipes/revert-buffer-all
@@ -1,3 +1,3 @@
 (revert-buffer-all
- :repo "ideasman42/emacs-revert-buffer-all"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-revert-buffer-all.git"
+ :fetcher git)

--- a/recipes/run-stuff
+++ b/recipes/run-stuff
@@ -1,3 +1,3 @@
 (run-stuff
- :repo "ideasman42/emacs-run-stuff"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-run-stuff.git"
+ :fetcher git)

--- a/recipes/scroll-on-drag
+++ b/recipes/scroll-on-drag
@@ -1,3 +1,3 @@
 (scroll-on-drag
- :repo "ideasman42/emacs-scroll-on-drag"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-scroll-on-drag.git"
+ :fetcher git)

--- a/recipes/scroll-on-jump
+++ b/recipes/scroll-on-jump
@@ -1,3 +1,3 @@
 (scroll-on-jump
- :repo "ideasman42/emacs-scroll-on-jump"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-scroll-on-jump.git"
+ :fetcher git)

--- a/recipes/sidecar-locals
+++ b/recipes/sidecar-locals
@@ -1,3 +1,3 @@
 (sidecar-locals
- :repo "ideasman42/emacs-sidecar-locals"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-sidecar-locals.git"
+ :fetcher git)

--- a/recipes/spatial-navigate
+++ b/recipes/spatial-navigate
@@ -1,3 +1,3 @@
 (spatial-navigate
- :repo "ideasman42/emacs-spatial-navigate"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-spatial-navigate.git"
+ :fetcher git)

--- a/recipes/spell-fu
+++ b/recipes/spell-fu
@@ -1,3 +1,3 @@
 (spell-fu
- :repo "ideasman42/emacs-spell-fu"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-spell-fu.git"
+ :fetcher git)

--- a/recipes/undo-fu
+++ b/recipes/undo-fu
@@ -1,3 +1,3 @@
 (undo-fu
- :repo "ideasman42/emacs-undo-fu"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-undo-fu.git"
+ :fetcher git)

--- a/recipes/undo-fu-session
+++ b/recipes/undo-fu-session
@@ -1,3 +1,3 @@
 (undo-fu-session
- :repo "ideasman42/emacs-undo-fu-session"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-undo-fu-session.git"
+ :fetcher git)


### PR DESCRIPTION
Relocate projects I maintain to codeberg, all of the original URL's have a redirection to the new location.

----

- bookmark-in-project
- counsel-at-point
- cycle-at-point
- default-font-presets
- diff-ansi
- diff-at-point
- doc-show-inline
- hl-block-mode
- hl-prog-extra
- idle-highlight-mode
- inkpot-theme
- magit-commit-mark
- mode-line-idle
- oblivion-theme
- py-autopep8
- recomplete
- revert-buffer-all
- run-stuff
- scroll-on-drag
- scroll-on-jump
- sidecar-locals
- spatial-navigate
- spell-fu
- undo-fu
- undo-fu-session

----

URL's of both projects:

-   https://gitlab.com/ideasman42/emacs-inkpot-theme -> https://codeberg.org/ideasman42/emacs-theme-inkpot
 
-   https://gitlab.com/ideasman42/emacs-oblivion-theme -> https://codeberg.org/ideasman42/emacs-theme-oblivion
 
-   https://gitlab.com/ideasman42/emacs-undo-fu-session -> https://codeberg.org/ideasman42/emacs-undo-fu-session
 
-   https://gitlab.com/ideasman42/emacs-undo-fu -> https://codeberg.org/ideasman42/emacs-undo-fu
 
-   https://gitlab.com/ideasman42/emacs-spell-fu -> https://codeberg.org/ideasman42/emacs-spell-fu
 
-   https://gitlab.com/ideasman42/emacs-spatial-navigate -> https://codeberg.org/ideasman42/emacs-spatial-navigate
 
-   https://gitlab.com/ideasman42/emacs-sidecar-locals -> https://codeberg.org/ideasman42/emacs-sidecar-locals
 
-   https://gitlab.com/ideasman42/emacs-scroll-on-jump -> https://codeberg.org/ideasman42/emacs-scroll-on-jump
 
-   https://gitlab.com/ideasman42/emacs-scroll-on-drag -> https://codeberg.org/ideasman42/emacs-scroll-on-drag
 
-   https://gitlab.com/ideasman42/emacs-run-stuff -> https://codeberg.org/ideasman42/emacs-run-stuff
 
-   https://gitlab.com/ideasman42/emacs-revert-buffer-all -> https://codeberg.org/ideasman42/emacs-revert-buffer-all
 
-   https://gitlab.com/ideasman42/emacs-recomplete -> https://codeberg.org/ideasman42/emacs-recomplete
 
-   https://gitlab.com/ideasman42/emacs-bookmark-in-project -> https://codeberg.org/ideasman42/emacs-bookmark-in-project
 
-   https://gitlab.com/ideasman42/emacs-counsel-at-point -> https://codeberg.org/ideasman42/emacs-counsel-at-point
 
-   https://gitlab.com/ideasman42/emacs-cycle-at-point -> https://codeberg.org/ideasman42/emacs-cycle-at-point
 
-   https://gitlab.com/ideasman42/emacs-default-font-presets -> https://codeberg.org/ideasman42/emacs-default-font-presets
 
-   https://gitlab.com/ideasman42/emacs-diff-ansi -> https://codeberg.org/ideasman42/emacs-diff-ansi
 
-   https://gitlab.com/ideasman42/emacs-diff-at-point -> https://codeberg.org/ideasman42/emacs-diff-at-point
 
-   https://gitlab.com/ideasman42/emacs-doc-show-inline -> https://codeberg.org/ideasman42/emacs-doc-show-inline
 
-   https://gitlab.com/ideasman42/emacs-hl-block-mode -> https://codeberg.org/ideasman42/emacs-hl-block-mode
 
-   https://gitlab.com/ideasman42/emacs-hl-prog-extra -> https://codeberg.org/ideasman42/emacs-hl-prog-extra
 
-   https://gitlab.com/ideasman42/emacs-idle-highlight-mode -> https://codeberg.org/ideasman42/emacs-idle-highlight-mode
 
-   https://gitlab.com/ideasman42/emacs-magit-commit-mark -> https://codeberg.org/ideasman42/emacs-magit-commit-mark
 
-   https://gitlab.com/ideasman42/emacs-mode-line-idle -> https://codeberg.org/ideasman42/emacs-mode-line-idle
 
-   https://github.com/ideasman42/emacs-py-autopep8 -> https://codeberg.org/ideasman42/emacs-py-autopep8

