### PR TITLE
adds org-edit-indirect

### DIFF
--- a/recipes/org-edit-indirect
+++ b/recipes/org-edit-indirect
@@ -1,0 +1,1 @@
+(org-edit-indirect :fetcher github :repo "agzam/org-edit-indirect.el")


### PR DESCRIPTION
### Brief summary of what the package does

Extension for `(org-edit-special)` that includes things that are not covered, like quote, verse, and comment blocks

### Direct link to the package repository

https://github.com/agzam/org-edit-indirect.el

### Your association with the package

I'm the author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
