### PR TITLE
remove cask

### DIFF
--- a/recipes/cask
+++ b/recipes/cask
@@ -1,2 +1,0 @@
-(cask :repo "cask/cask" :fetcher github :old-names (carton)
-      :files ("cask.el" "cask-bootstrap.el"))

--- a/recipes/pallet
+++ b/recipes/pallet
@@ -1,3 +1,0 @@
-(pallet :fetcher github
-        :repo "rdallasgray/pallet"
-        :files ("lib/*"))


### PR DESCRIPTION
The only supported install method for cask is command-line.