### PR TITLE
Add 'baidupan', used to operate files on baidu netdisk (百度网盘)。

### DIFF
--- a/recipes/mpvi
+++ b/recipes/mpvi
@@ -1,0 +1,1 @@
+(mpvi :fetcher github :repo "lorniu/mpvi")


### PR DESCRIPTION
### Brief summary of what the package does

Client of Baidu Netdisk (百度网盘客户端)。

### Direct link to the package repository

https://github.com/lorniu/emacs-baidupan

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
