### PR TITLE
Add fussy (previously flx-completion)

### DIFF
--- a/recipes/flx-completion
+++ b/recipes/flx-completion
@@ -1,0 +1,1 @@
+(flx-completion :fetcher github :repo "jojojames/flx-completion")

--- a/recipes/flx-completion
+++ b/recipes/flx-completion
@@ -1,1 +1,0 @@
-(flx-completion :fetcher github :repo "jojojames/flx-completion")

--- a/recipes/fussy
+++ b/recipes/fussy
@@ -1,0 +1,1 @@
+(fussy :fetcher github :repo "jojojames/fussy")


### PR DESCRIPTION
### Brief summary of what the package does

This is a package to provide a completion-style to Emacs that leverages flx.

### Direct link to the package repository

https://github.com/jojojames/fussy

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
