### PR TITLE
Set file timestamps to fixed value for reproducible files.

### DIFF
--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -828,6 +828,9 @@ in `package-build-archive-dir'."
           (package-build--copy-package-files files source-dir target)
           (package-build--write-pkg-file desc target)
           (package-build--generate-info-files files source-dir target)
+          (package-build--run-process tmp-dir nil
+                                      "find" "." "-exec" "touch" "-t"
+                                      "197001010000" "\{\}" "\;")
           (package-build--create-tar name version tmp-dir)
           (package-build--write-pkg-readme name files source-dir)
           (package-build--write-archive-entry desc))


### PR DESCRIPTION
The goal is to produce hash-identical archives whenever the source did not
change. Previously timestamps caused this to fail as they are recorded in
the tar archive.
