### PR TITLE
Adding recipe for zetteldesk-info

### DIFF
--- a/recipes/zetteldesk-info
+++ b/recipes/zetteldesk-info
@@ -1,0 +1,3 @@
+(zetteldesk-info :fetcher github
+	    	 :repo "Vidianos-Giannitsis/zetteldesk.el"
+	    	 :files ("zetteldesk-info.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Zetteldesk-info is an extension to the Zetteldesk package which build on its concepts but differentiates itself by not manipulating buffers or org-roam files but info-nodes for the Info documentation viewer built-in to Emacs. I recommend it be packaged separately (hence why I am making this commit) as its conceptually different to what the core package tries to achieve

### Direct link to the package repository

https://github.com/Vidianos-Giannitsis/zetteldesk.el

### Your association with the package

I am the author and maintainer of the package

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [ x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [ x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [ x] `M-x checkdoc` is happy with my docstrings
- [ x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
