### PR TITLE
Adding recipe for zetteldesk-ref

### DIFF
--- a/recipes/zetteldesk-ref
+++ b/recipes/zetteldesk-ref
@@ -1,0 +1,3 @@
+(zetteldesk-ref :fetcher github
+	    	:repo "Vidianos-Giannitsis/zetteldesk.el"
+	    	:files ("zetteldesk-ref.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Zetteldesk-ref is an extension to Zetteldesk which was recently uploaded to MELPA. It implements the logic of Zetteldesk but for notes on reference material, especially focusing on research paper notes made with org-noter. I had the need for these to be handled in a special way which I think is more sensible than the default one in zetteldesk.el for anyone wanting to use this package with reference notes.

### Direct link to the package repository

https://github.com/Vidianos-Giannitsis/zetteldesk.el

### Your association with the package

I am the package's author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [ x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [ x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ x] My elisp byte-compiles cleanly
- [ x] `M-x checkdoc` is happy with my docstrings
- [ x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
