### PR TITLE
Adding recipe for zetteldesk-remark

### DIFF
--- a/recipes/zetteldesk-remark
+++ b/recipes/zetteldesk-remark
@@ -1,0 +1,3 @@
+(zetteldesk-remark :fetcher github
+	    	   :repo "Vidianos-Giannitsis/zetteldesk.el"
+	   	   :files ("zetteldesk-remark.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Zetteldesk-remark is an extension of the Zetteldesk package for implementing compatibility of the package with org-remark. Org-remark is a great package for creating margin notes in your buffers but it requires the buffer be associated to a file. Since zetteldesk.el relies heavily on a buffer not associated to a file but where margin notes would be useful I have made this package to ease the implementation of both.

### Direct link to the package repository

https://github.com/Vidianos-Giannitsis/zetteldesk.el

### Your association with the package

I am the package's author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x ] `M-x checkdoc` is happy with my docstrings
- [x ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
