### PR TITLE
Adding recipe for zetteldesk-kb

### DIFF
--- a/recipes/zetteldesk-kb
+++ b/recipes/zetteldesk-kb
@@ -1,0 +1,3 @@
+(zetteldesk-kb :fetcher github
+	       :repo "Vidianos-Giannitsis/zetteldesk.el"
+	       :files ("zetteldesk-kb.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package is the default set of keybindings for the Zetteldesk package. Its packaged separately to keep it fully opt-in and also because it would introduce an unnecessary dependency on the hydra package which I used to build this.

### Direct link to the package repository

https://github.com/Vidianos-Giannitsis/zetteldesk.el

### Your association with the package

I am the package's author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

My elisp does not byte-compile cleanly as it gives me an error that the docstrings of the hydra heads are wider than 80 characters. However, as these are automatically generated I don't know how to fix this.

<!-- After submitting, please fix any problems the CI reports. -->
