### PR TITLE
Relocate xref-rst to codeberg

### DIFF
--- a/recipes/xref-rst
+++ b/recipes/xref-rst
@@ -1,3 +1,3 @@
 (xref-rst
- :repo "ideasman42/emacs-xref-rst"
- :fetcher gitlab)
+ :url "https://codeberg.org/ideasman42/emacs-xref-rst.git"
+ :fetcher git)


### PR DESCRIPTION
Relocate xref-rst from gitlab to codeberg:

- https://gitlab.com/ideasman42/emacs-xref-rst (old)
- https://codeberg.org/ideasman42/emacs-xref-rst (new)

----

Recently I relocated my projects to codeberg, but missed this one

https://github.com/melpa/melpa/pull/8018