### PR TITLE
Support for codeberg repo

### DIFF
--- a/package-build/package-recipe-mode.el
+++ b/package-build/package-recipe-mode.el
@@ -52,7 +52,7 @@
   (interactive
    (list (read-string "Package name: ")
          (intern (completing-read "Fetcher: "
-                                  (list "git" "github" "gitlab" "hg")
+                                  (list "git" "github" "gitlab" "codeberg" "hg")
                                   nil t nil nil "github"))))
   (let ((recipe-file (expand-file-name name package-build-recipes-dir)))
     (when (file-exists-p recipe-file)

--- a/package-build/package-recipe.el
+++ b/package-build/package-recipe.el
@@ -85,6 +85,10 @@
   ((url-format      :initform "https://gitlab.com/%s.git")
    (repopage-format :initform "https://gitlab.com/%s")))
 
+(defclass package-codeberg-recipe (package-git-recipe)
+  ((url-format      :initform "https://codeberg.org/%s.git")
+   (repopage-format :initform "https://codeberg.org/%s")))
+
 ;;;; Mercurial
 
 (defclass package-hg-recipe (package-recipe)
@@ -144,7 +148,7 @@ file is invalid, then raise an error."
           (cl-assert (memq thing all-keys) nil "Unknown keyword %S" thing)))
       (let ((fetcher (plist-get plist :fetcher)))
         (cl-assert fetcher nil ":fetcher is missing")
-        (if (memq fetcher '(github gitlab))
+        (if (memq fetcher '(github gitlab codeberg))
             (progn
               (cl-assert (plist-get plist :repo) ":repo is missing")
               (cl-assert (not (plist-get plist :url)) ":url is redundant"))


### PR DESCRIPTION
This adds support for referencing codeberg repositories, similar to
github & gitlab.

----

Notes:

- There are between 20-40 repositories using codeberg. `cat recipes/* | pcregrep ":url.*codeberg" | wc -l` => 49.
- To test this patch, this example shows the codeberg repository being used:

```
diff --git a/recipes/xref-rst b/recipes/xref-rst
index bb2619d7..a7f271e0 100644
--- a/recipes/xref-rst
+++ b/recipes/xref-rst
@@ -1,3 +1,3 @@
 (xref-rst
- :url "https://codeberg.org/ideasman42/emacs-xref-rst.git"
- :fetcher git)
+ :repo "ideasman42/emacs-xref-rst"
+ :fetcher codeberg)
```
