### PR TITLE
Add recipe for frim

### DIFF
--- a/recipes/frim
+++ b/recipes/frim
@@ -1,0 +1,3 @@
+(frim
+ :repo "OlMon/frim"
+ :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

Removes all images in the buffer and leaves a marker. 
At the marker it is possible to display the image in a child frame.

### Direct link to the package repository

https://gitlab.com/OlMon/frim

### Your association with the package

I am the maintainer/author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
