### PR TITLE
Update `electric-cursor` URL to Codeberg.org

### DIFF
--- a/recipes/electric-cursor
+++ b/recipes/electric-cursor
@@ -1,4 +1,3 @@
 (electric-cursor
  :url "https://codeberg.org/acdw/electric-cursor.el"
- :fetcher git
- :branch "main")
+ :fetcher git)

--- a/recipes/electric-cursor
+++ b/recipes/electric-cursor
@@ -1,3 +1,4 @@
 (electric-cursor
- :fetcher github
- :repo "duckwork/electric-cursor")
+ :url "https://codeberg.org/acdw/electric-cursor.el"
+ :fetcher git
+ :branch "main")


### PR DESCRIPTION
Moved to codeberg for greater freedom.