### PR TITLE
Added ob-fricas recipe.

### DIFF
--- a/recipes/ob-fricas
+++ b/recipes/ob-fricas
@@ -1,0 +1,3 @@
+(ob-fricas :repo "pdo/frimacs"
+           :fetcher github
+           :files ("extras/ob-fricas.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Org-Babel backend for the FriCAS computer algebra system.

### Direct link to the package repository

https://github.com/pdo/frimacs.git

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
