### PR TITLE
Add consult-dash

### DIFF
--- a/recipes/consult-dash
+++ b/recipes/consult-dash
@@ -1,0 +1,3 @@
+(consult-dash
+ :fetcher git
+ :url "https://codeberg.org/ravi/consult-dash.git")


### PR DESCRIPTION
### Brief summary of what the package does

Consult interface to dash-docs. Requires /bin/sh.

### Direct link to the package repository

https://codeberg.org/ravi/consult-dash.git

### Your association with the package

I am the sole author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [  ] I have confirmed some of these without doing them

Note that both the byte-compiler and package-lint produce warnings due to the presence of `with-eval-after-load`. Those are the only issues of which I am aware, but I have no idea how to fix them. Those additional features provided by the two `with-eval-after-load` blocks are not worth moving to their own packages.

<!-- After submitting, please fix any problems the CI reports. -->
