### PR TITLE
Add rgb

### DIFF
--- a/recipes/rgb
+++ b/recipes/rgb
@@ -1,1 +1,4 @@
-(rgb :fetcher gitlab :repo "cwpitts/rgb.el")
+(rgb
+ :fetcher gitlab
+ :repo "cwpitts/rgb.el"
+ :files ("rgb.el"))

--- a/recipes/rgb
+++ b/recipes/rgb
@@ -2,4 +2,4 @@
  :fetcher gitlab
  :repo "cwpitts/rgb.el"
  :files (:defaults
-         (:exclude "el-mock.el" "ert-expectations.el"))
+         (:exclude "el-mock.el" "ert-expectations.el")))

--- a/recipes/rgb
+++ b/recipes/rgb
@@ -1,0 +1,1 @@
+(rgb :fetcher gitlab :repo "cwpitts/rgb.el")

--- a/recipes/rgb
+++ b/recipes/rgb
@@ -1,4 +1,5 @@
 (rgb
  :fetcher gitlab
  :repo "cwpitts/rgb.el"
- :files ("rgb.el"))
+ :files (:defaults
+         (:exclude "el-mock.el" "ert-expectations.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`rgb.el` uses [OpenRGB](https://gitlab.com/CalcProgrammer1/OpenRGB) to provide a Lisp interface for RGB device control.

### Direct link to the package repository

https://gitlab.com/cwpitts/rgb.el

### Your association with the package

I am the sole author and maintainer of `rgb.el`.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
