### PR TITLE
Add recipe for smithy mode

### DIFF
--- a/recipes/smithy-mode
+++ b/recipes/smithy-mode
@@ -1,2 +1,2 @@
 (smithy-mode :repo "mnemitz/smithy-mode" :fetcher github :files
-             ("smithy.el"))
+             ("smithy-mode.el"))

--- a/recipes/smithy-mode
+++ b/recipes/smithy-mode
@@ -1,0 +1,2 @@
+(smithy-mode :repo "mnemitz/smithy-mode" :fetcher github :files
+             ("smithy.el"))

--- a/recipes/smithy-mode
+++ b/recipes/smithy-mode
@@ -1,2 +1,1 @@
-(smithy-mode :repo "mnemitz/smithy-mode" :fetcher github :files
-             ("smithy-mode.el"))
+(smithy-mode :repo "mnemitz/smithy-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides syntax highlighting (font-lock) for Smithy IDL files:

Smithy is an interface definition language developed by Amazon: https://awslabs.github.io/smithy/

### Direct link to the package repository

https://github.com/mnemitz/smithy-mode

### Your association with the package

Author and maintainer, recipe maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
