### PR TITLE
Use newer fork of jabber.el

### DIFF
--- a/recipes/jabber
+++ b/recipes/jabber
@@ -1,4 +1,5 @@
 (jabber
- :repo "legoscia/emacs-jabber"
- :fetcher github
- :files ("*.el" "*.texi" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))
+ :fetcher git
+ :url     "https://codeberg.org/emacs-jabber/emacs-jabber.git"
+ :branch  "production"
+ :files   ("*.org" "*.el" "*.texi" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))

--- a/recipes/jabber
+++ b/recipes/jabber
@@ -2,4 +2,4 @@
  :fetcher git
  :url     "https://codeberg.org/emacs-jabber/emacs-jabber.git"
  :branch  "production"
- :files   ("*.org" "*.el" "*.texi" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))
+ :files   (:defaults "*.org" ("jabber-fallback-lib" "jabber-fallback-lib/hexrgb.el")))


### PR DESCRIPTION
### Brief summary of what the package does

A client for the Jabber/XMPP instant messaging protocol.

### Direct link to the package repository

https://codeberg.org/emacs-jabber/emacs-jabber

### Your association with the package

Maintainer/Contributor

### Relevant communications with the upstream package maintainer

Another maintainer (wgreenhouse) tried to get in touch with @legoscia a few months ago and did not get a response.

### Checklist

We've been slowly chipping away at these over many months. Unfortunately, it's a large package, and contributor time is limited.

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
