### PR TITLE
Add org-hyperscheduler to melpa

### DIFF
--- a/recipes/org-hyperscheduler
+++ b/recipes/org-hyperscheduler
@@ -1,4 +1,4 @@
 (org-hyperscheduler :repo "dmitrym0/org-hyperscheduler"
                     :fetcher github
-                    :files ("org-hyperscheduler.el" "LICENSE"
+                    :files (:defaults
                            ("calendar" "calendar/index.html" "calendar/index.js" "calendar/org-hs.css")))

--- a/recipes/org-hyperscheduler
+++ b/recipes/org-hyperscheduler
@@ -1,0 +1,4 @@
+(org-hyperscheduler :repo "dmitrym0/org-hyperscheduler"
+                    :fetcher github
+                    :files ("org-hyperscheduler.el" "LICENSE"
+                           ("calendar" "calendar/index.html" "calendar/index.js" "calendar/org-hs.css")))


### PR DESCRIPTION
### Brief summary of what the package does

org-hyperscheduler provides a web based view of your org-agenda.

### Direct link to the package repository

https://github.com/dmitrym0/org-hyperscheduler


### Your association with the package

I'm the author of org-hyperscheduler.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [nice] I have confirmed some of these without doing them

