### PR TITLE
Update kuronami-theme URL.

### DIFF
--- a/recipes/kuronami-theme
+++ b/recipes/kuronami-theme
@@ -1,2 +1,2 @@
-(kuronami-theme :repo "super3ggo/kuronami"
+(kuronami-theme :repo "inj0h/kuronami"
                 :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs theme with cool autumnal colors against a deep blue background.

I originally submitted a PR for this package [in early March of this year,](https://github.com/melpa/melpa/pull/7931) which subsequently got merged. This PR simply updates the recipe GitHub link.

### Direct link to the package repository

https://github.com/inj0h/kuronami

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
