### PR TITLE
Protocol buffers was moved to a new Github repo

### DIFF
--- a/recipes/protobuf-mode
+++ b/recipes/protobuf-mode
@@ -1,3 +1,3 @@
 (protobuf-mode :fetcher github
-               :repo "google/protobuf"
+               :repo "protocolbuffers/protobuf"
                :files ("editors/protobuf-mode.el"))


### PR DESCRIPTION
protobuf-mode was moved to a new Github repo. You can check this by heading to https://github.com/google/protobuf and seeing that it redirects to https://github.com/protocolbuffers/protobuf .

I discovered this using straight.el as git wasn't able to follow the redirect when attempting to install protobuf-mode. This resulted in an error on installation.