### PR TITLE
Add package pyconf

### DIFF
--- a/recipes/pyconf
+++ b/recipes/pyconf
@@ -1,0 +1,1 @@
+(pyconf :fetcher github :repo "andcarnivorous/pyconf")


### PR DESCRIPTION
### Brief summary of what the package does

This package allows to create and run python execution configurations similar to the ones from dap-mode.
Only byte-compile complaint is a docstring too long.

### Direct link to the package repository

https://github.com/andcarnivorous/pyconf

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
