### PR TITLE
Add tab-bar-buffers

### DIFF
--- a/recipes/tab-bar-buffers
+++ b/recipes/tab-bar-buffers
@@ -1,1 +1,1 @@
-(org-gcal :fetcher github :repo "arosen/tab-bar-buffers")
+(org-gcal :fetcher github :repo "ajrosen/tab-bar-buffers")

--- a/recipes/tab-bar-buffers
+++ b/recipes/tab-bar-buffers
@@ -1,1 +1,1 @@
-(org-gcal :fetcher github :repo "ajrosen/tab-bar-buffers")
+(tab-bar-buffers :fetcher github :repo "ajrosen/tab-bar-buffers")

--- a/recipes/tab-bar-buffers
+++ b/recipes/tab-bar-buffers
@@ -1,0 +1,1 @@
+(org-gcal :fetcher github :repo "arosen/tab-bar-buffers")


### PR DESCRIPTION
### Brief summary of what the package does

This package piggy-backs on `tab-bar-mode' to implement a simple buffer manager.  Instead of managing tabs it manages buffers.

### Direct link to the package repository

https://github.com/ajrosen/tab-bar-buffers

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
