### PR TITLE
Add recipe for org-mac-link

### DIFF
--- a/recipes/org-mac-link
+++ b/recipes/org-mac-link
@@ -1,0 +1,3 @@
+(org-mac-link
+ :repo "aimebertrand/org-mac-link"
+ :fetcher gitlab)


### PR DESCRIPTION
* recipes/org-mac-link: New recipe

This package is part of org-contrib.
However will be removed with the next realease - see:
- https://elpa.nongnu.org/nongnu/org-contrib.html
- https://git.sr.ht/~bzg/org-contrib/commit/e69be2c33885033e9706148568a2250c19587cb8

Being the new maintainer I don't want the efforts by the original authors to be in vain.

### Brief summary of what the package does

Insert org-mode links to items selected in various Mac apps.

### Direct link to the package repository

https://gitlab.com/aimebertrand/org-mac-link

### Your association with the package

I am the maintainer?

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
