### PR TITLE
Cosmetic changes to numerous recipes

### DIFF
--- a/recipes/axiom-environment
+++ b/recipes/axiom-environment
@@ -1,5 +1,10 @@
-(axiom-environment :fetcher git
-                   :url "https://bitbucket.org/pdo/axiom-environment"
-                   :files ("*.el" ("data" "data/*.el") ("themes" "themes/*.el")
-                           (:exclude "axiom.el" "axiom-build-utils.el"
-                                     "ob-axiom.el" "company-axiom.el")))
+(axiom-environment
+ :fetcher git
+ :url "https://bitbucket.org/pdo/axiom-environment"
+ :files ("*.el"
+         ("data" "data/*.el")
+         ("themes" "themes/*.el")
+         (:exclude "axiom.el"
+                   "axiom-build-utils.el"
+                   "ob-axiom.el"
+                   "company-axiom.el")))

--- a/recipes/chronometrist
+++ b/recipes/chronometrist
@@ -5,5 +5,5 @@
  :files (:defaults
          "elisp/*.el"
          "elisp/*.org"
-         (:exclude "elisp/chronometrist-key-values*")
-         (:exclude "elisp/chronometrist-goal*")))
+         (:exclude "elisp/chronometrist-key-values*"
+                   "elisp/chronometrist-goal*")))

--- a/recipes/chronometrist-key-values
+++ b/recipes/chronometrist-key-values
@@ -5,5 +5,5 @@
  :files (:defaults
          "elisp/*.el"
          "elisp/*.org"
-         (:exclude "elisp/chronometrist.*")
-         (:exclude "elisp/chronometrist-goal*")))
+         (:exclude "elisp/chronometrist.*"
+                   "elisp/chronometrist-goal*")))

--- a/recipes/clojure-essential-ref
+++ b/recipes/clojure-essential-ref
@@ -1,4 +1,4 @@
-(clojure-essential-ref :repo "p3r7/clojure-essential-ref"
-                       :fetcher github
-                       :files (:defaults
-                               (:exclude "clojure-essential-ref-nov.el")))
+(clojure-essential-ref
+ :fetcher github
+ :repo "p3r7/clojure-essential-ref"
+ :files (:defaults (:exclude "clojure-essential-ref-nov.el")))

--- a/recipes/clojure-essential-ref-nov
+++ b/recipes/clojure-essential-ref-nov
@@ -1,4 +1,4 @@
-(clojure-essential-ref-nov :repo "p3r7/clojure-essential-ref"
-                           :fetcher github
-                           :files (:defaults
-                                   (:exclude "clojure-essential-ref.el")))
+(clojure-essential-ref-nov
+ :fetcher github
+ :repo "p3r7/clojure-essential-ref"
+ :files (:defaults (:exclude "clojure-essential-ref.el")))

--- a/recipes/ctune
+++ b/recipes/ctune
@@ -1,3 +1,3 @@
-(ctune :repo "maurooaranda/ctune" :fetcher github
-       :files (:defaults
-	      (:exclude "doclicense.texi" "docstyle.texi")))
+(ctune :fetcher github
+       :repo "maurooaranda/ctune"
+       :files (:defaults (:exclude "doclicense.texi" "docstyle.texi")))

--- a/recipes/ddskk
+++ b/recipes/ddskk
@@ -2,5 +2,6 @@
  :repo "skk-dev/ddskk"
  :fetcher github
  :old-names (skk)
- :files ("context-skk.el" "ddskk*.el" "skk*.el" "tar-util.el" "doc/skk.texi" "etc/skk.xpm"
+ :files ("context-skk.el" "ddskk*.el" "skk*.el" "tar-util.el"
+         "doc/skk.texi" "etc/skk.xpm"
          (:exclude "skk-xemacs.el" "skk-lookup.el")))

--- a/recipes/dogears
+++ b/recipes/dogears
@@ -1,2 +1,3 @@
-(dogears :fetcher github :repo "alphapapa/dogears.el"
+(dogears :fetcher github
+         :repo "alphapapa/dogears.el"
          :files (:defaults (:exclude "helm-dogears.el")))

--- a/recipes/eldev
+++ b/recipes/eldev
@@ -1,3 +1,5 @@
 (eldev :repo "doublep/eldev"
        :fetcher github
-       :files (:defaults ("bin" "bin/*") (:exclude "bin/*.in" "bin/*.part")))
+       :files (:defaults
+               ("bin" "bin/*")
+               (:exclude "bin/*.in" "bin/*.part")))

--- a/recipes/erlang
+++ b/recipes/erlang
@@ -1,6 +1,8 @@
-(erlang :repo "erlang/otp"
-  :fetcher github
-  ;; Requiring one dot in the version-string to weed out the old
-  ;; "erl_1252" tags
-  :version-regexp "[^0-9]*\\([0-9]*\\..*\\)"
-  :files ("lib/tools/emacs/*.el" (:exclude "lib/tools/emacs/erlang_appwiz.el")))
+(erlang
+ :fetcher github
+ :repo "erlang/otp"
+ ;; Requiring one dot in the version-string to weed out the old
+ ;; "erl_1252" tags
+ :version-regexp "[^0-9]*\\([0-9]*\\..*\\)"
+ :files ("lib/tools/emacs/*.el"
+         (:exclude "lib/tools/emacs/erlang_appwiz.el")))

--- a/recipes/friendly-remote-shell
+++ b/recipes/friendly-remote-shell
@@ -1,4 +1,4 @@
-(friendly-remote-shell :repo "p3r7/friendly-shell"
-                       :fetcher github
-                       :files (:defaults
-                               (:exclude "friendly-shell-command.el" "friendly-shell.el")))
+(friendly-remote-shell
+ :repo "p3r7/friendly-shell"
+ :fetcher github
+ :files (:defaults (:exclude "friendly-shell-command.el" "friendly-shell.el")))

--- a/recipes/friendly-shell
+++ b/recipes/friendly-shell
@@ -1,4 +1,5 @@
 (friendly-shell :repo "p3r7/friendly-shell"
                 :fetcher github
                 :files (:defaults
-                        (:exclude "friendly-shell-command.el" "friendly-remote-shell.el")))
+                        (:exclude "friendly-shell-command.el"
+                                  "friendly-remote-shell.el")))

--- a/recipes/friendly-shell-command
+++ b/recipes/friendly-shell-command
@@ -1,4 +1,4 @@
-(friendly-shell-command :repo "p3r7/friendly-shell"
-                        :fetcher github
-                        :files (:defaults
-                                (:exclude "friendly-shell.el" "friendly-remote-shell.el")))
+(friendly-shell-command
+ :fetcher github
+ :repo "p3r7/friendly-shell"
+ :files (:defaults (:exclude "friendly-shell.el" "friendly-remote-shell.el")))

--- a/recipes/frimacs
+++ b/recipes/frimacs
@@ -1,4 +1,5 @@
 (frimacs :repo "pdo/frimacs"
          :fetcher github
-         :files ("*.el" ("data" "data/*.dat")
+         :files ("*.el"
+                 ("data" "data/*.dat")
                  (:exclude "frimacs-build-utils.el")))

--- a/recipes/howm
+++ b/recipes/howm
@@ -1,5 +1,3 @@
 (howm  :fetcher git
        :url "https://scm.osdn.net/gitroot/howm/howm.git"
-       :files
-       (:defaults
-        (:exclude "*.el.in")))
+       :files (:defaults (:exclude "*.el.in")))

--- a/recipes/indent-lint
+++ b/recipes/indent-lint
@@ -1,2 +1,3 @@
-(indent-lint :fetcher github :repo "conao3/indent-lint.el"
+(indent-lint :fetcher github
+             :repo "conao3/indent-lint.el"
              :files (:defaults (:exclude "flycheck-indent.el")))

--- a/recipes/ivy
+++ b/recipes/ivy
@@ -1,5 +1,5 @@
 (ivy :repo "abo-abo/swiper"
      :fetcher github
      :files (:defaults
-             (:exclude "swiper.el" "counsel.el" "ivy-hydra.el" "ivy-avy.el")
-             "doc/ivy-help.org"))
+             "doc/ivy-help.org"
+             (:exclude "swiper.el" "counsel.el" "ivy-hydra.el" "ivy-avy.el")))

--- a/recipes/keg
+++ b/recipes/keg
@@ -1,2 +1,3 @@
-(keg :fetcher github :repo "conao3/keg.el"
+(keg :fetcher github
+     :repo "conao3/keg.el"
      :files (:defaults (:exclude "keg-mode.el" "flycheck-keg.el")))

--- a/recipes/kubel
+++ b/recipes/kubel
@@ -1,4 +1,3 @@
-(kubel :repo "abrochard/kubel" :fetcher github
-       :files
-       (:defaults
-        (:exclude "kubel-evil.el")))
+(kubel :fetcher github
+       :repo "abrochard/kubel"
+       :files (:defaults (:exclude "kubel-evil.el")))

--- a/recipes/kubernetes
+++ b/recipes/kubernetes
@@ -1,5 +1,3 @@
 (kubernetes :repo "kubernetes-el/kubernetes-el"
             :fetcher github
-            :files
-            (:defaults
-             (:exclude "kubernetes-evil.el")))
+            :files (:defaults (:exclude "kubernetes-evil.el")))

--- a/recipes/langtool-ignore-fonts
+++ b/recipes/langtool-ignore-fonts
@@ -1,1 +1,4 @@
-(langtool-ignore-fonts :fetcher github :repo "cjl8zf/langtool-ignore-fonts" :files (:defaults (:exclude "doc/*")))
+(langtool-ignore-fonts
+ :fetcher github
+ :repo "cjl8zf/langtool-ignore-fonts"
+ :files (:defaults (:exclude "doc/*")))

--- a/recipes/magit
+++ b/recipes/magit
@@ -6,10 +6,9 @@
                "docs/magit.texi"
                "docs/AUTHORS.md"
                "LICENSE"
+               "Documentation/magit.texi" ; temporarily for stable
+               "Documentation/AUTHORS.md" ; temporarily for stable
                (:exclude "lisp/magit-libgit.el"
                          "lisp/magit-libgit-pkg.el"
                          "lisp/magit-section.el"
-                         "lisp/magit-section-pkg.el")
-               ;; temporarily for stable:
-               "Documentation/magit.texi"
-               "Documentation/AUTHORS.md"))
+                         "lisp/magit-section-pkg.el")))

--- a/recipes/nix-mode
+++ b/recipes/nix-mode
@@ -1,3 +1,3 @@
-(nix-mode :repo "NixOS/nix-mode" :fetcher github
-          :files (:defaults
-           (:exclude "nix-company.el" "nix-mode-mmm.el")))
+(nix-mode :fetcher github
+          :repo "NixOS/nix-mode"
+          :files (:defaults (:exclude "nix-company.el" "nix-mode-mmm.el")))

--- a/recipes/org-ql
+++ b/recipes/org-ql
@@ -1,2 +1,3 @@
-(org-ql :fetcher github :repo "alphapapa/org-ql"
+(org-ql :fetcher github
+        :repo "alphapapa/org-ql"
         :files (:defaults (:exclude "helm-org-ql.el")))

--- a/recipes/org-recent-headings
+++ b/recipes/org-recent-headings
@@ -1,2 +1,4 @@
-(org-recent-headings :fetcher github :repo "alphapapa/org-recent-headings"
-                     :files (:defaults (:exclude "helm-org-recent-headings.el")))
+(org-recent-headings
+ :fetcher github
+ :repo "alphapapa/org-recent-headings"
+ :files (:defaults (:exclude "helm-org-recent-headings.el")))

--- a/recipes/org-starter
+++ b/recipes/org-starter
@@ -1,5 +1,7 @@
 (org-starter :repo "akirak/org-starter"
              :fetcher github
              :files (:defaults
-                     (:exclude "counsel-org-starter.el" "helm-org-starter.el"
-                               "org-starter-swiper.el" "org-starter-extras.el")))
+                     (:exclude "counsel-org-starter.el"
+                               "helm-org-starter.el"
+                               "org-starter-swiper.el"
+                               "org-starter-extras.el")))

--- a/recipes/org2blog
+++ b/recipes/org2blog
@@ -1,1 +1,4 @@
-(org2blog :repo "org2blog/org2blog" :fetcher github :files (:defaults "README.org" (:exclude "metaweblog.el")))
+(org2blog
+ :fetcher github
+ :repo "org2blog/org2blog"
+ :files (:defaults "README.org" (:exclude "metaweblog.el")))

--- a/recipes/package-lint
+++ b/recipes/package-lint
@@ -1,1 +1,3 @@
-(package-lint :fetcher github :repo "purcell/package-lint" :files (:defaults "data" (:exclude "*flymake.el")))
+(package-lint :fetcher github
+              :repo "purcell/package-lint"
+              :files (:defaults "data" (:exclude "*flymake.el")))

--- a/recipes/racket-mode
+++ b/recipes/racket-mode
@@ -1,8 +1,8 @@
 (racket-mode
- :repo    "greghendershott/racket-mode"
  :fetcher github
- :files   (:defaults
-           "*.rkt"
-           ("racket" "racket/*")
-           (:exclude "racket/example/*"
-                     "racket/test/*")))
+ :repo "greghendershott/racket-mode"
+ :files (:defaults
+         "*.rkt"
+         ("racket" "racket/*")
+         (:exclude "racket/example/*"
+                   "racket/test/*")))

--- a/recipes/sage-shell-mode
+++ b/recipes/sage-shell-mode
@@ -1,2 +1,3 @@
-(sage-shell-mode :repo "sagemath/sage-shell-mode" :fetcher github
+(sage-shell-mode :fetcher github
+                 :repo "sagemath/sage-shell-mode"
                  :files (:defaults "*.py" (:exclude "*test.py")))

--- a/recipes/shm
+++ b/recipes/shm
@@ -1,1 +1,3 @@
-(shm :fetcher github :repo "projectional-haskell/structured-haskell-mode" :files ("elisp/*.el" (:exclude "shm-test.el" "shm-tests.el")))
+(shm :fetcher github
+     :repo "projectional-haskell/structured-haskell-mode"
+     :files ("elisp/*.el" (:exclude "shm-test.el" "shm-tests.el")))

--- a/recipes/slime
+++ b/recipes/slime
@@ -5,9 +5,9 @@
                "swank"
                "*.lisp"
                "*.asd"
-               ("contrib" "contrib/*")
-               (:exclude "contrib/test" "contrib/Makefile")
                "doc/slime.texi"
                "doc/slime.info"
                "doc/dir"
-               "ChangeLog"))
+               "ChangeLog"
+               ("contrib" "contrib/*")
+               (:exclude "contrib/test" "contrib/Makefile")))

--- a/recipes/solidity-mode
+++ b/recipes/solidity-mode
@@ -1,5 +1,6 @@
 (solidity-mode
-    :fetcher github
-    :repo "ethereum/emacs-solidity"
-    :files (:defaults (:exclude "company-solidity.el"
-                                "solidity-flycheck.el")))
+ :fetcher github
+ :repo "ethereum/emacs-solidity"
+ :files (:defaults
+         (:exclude "company-solidity.el"
+                   "solidity-flycheck.el")))

--- a/recipes/subemacs
+++ b/recipes/subemacs
@@ -1,3 +1,2 @@
 (subemacs :fetcher github :repo "kbauer/subemacs"
-          :files (:defaults
-                  (:exclude "*experimental*")))
+          :files (:defaults (:exclude "*experimental*")))

--- a/recipes/tree-edit
+++ b/recipes/tree-edit
@@ -1,1 +1,3 @@
-(tree-edit :repo "ethan-leba/tree-edit" :fetcher github :files (:defaults (:exclude "evil-tree-edit*.el")))
+(tree-edit :fetcher github
+           :repo "ethan-leba/tree-edit"
+           :files (:defaults (:exclude "evil-tree-edit*.el")))

--- a/recipes/tree-sitter
+++ b/recipes/tree-sitter
@@ -1,5 +1,4 @@
 (tree-sitter :repo "emacs-tree-sitter/elisp-tree-sitter"
              :fetcher github
              :branch "release"
-             :files (:defaults
-                     (:exclude "lisp/tree-sitter-tests.el")))
+             :files (:defaults (:exclude "lisp/tree-sitter-tests.el")))

--- a/recipes/use-package
+++ b/recipes/use-package
@@ -1,7 +1,8 @@
 (use-package
-    :fetcher github
-    :repo "jwiegley/use-package"
-    :files (:defaults (:exclude "bind-key.el"
-                                "bind-chord.el"
-                                "use-package-chords.el"
-                                "use-package-ensure-system-package.el")))
+ :fetcher github
+ :repo "jwiegley/use-package"
+ :files (:defaults
+         (:exclude "bind-key.el"
+                   "bind-chord.el"
+                   "use-package-chords.el"
+                   "use-package-ensure-system-package.el")))

--- a/recipes/vterm
+++ b/recipes/vterm
@@ -1,5 +1,8 @@
-(vterm :fetcher github
-	:repo "akermu/emacs-libvterm"
-    :files ("*"
-        (:exclude ".dir-locals.el" ".gitignore" ".clang-format" ".travis.yml"))
-    )
+(vterm
+ :fetcher github
+ :repo "akermu/emacs-libvterm"
+ :files ("*"
+         (:exclude ".dir-locals.el"
+                   ".gitignore"
+                   ".clang-format"
+                   ".travis.yml")))


### PR DESCRIPTION
```
This commit only touches recipes whose `:files' property contains an
`:exclude' element, because I had to look at all those recipes for an
only marginally related reason.

To an extend these changes only reflect my own personal preference, so
I will explain the types of changes I have made.  This should serve as
a starting point for a future discussion in case we want to encourage
a certain style or even enforce it.

- Lines should be intended as `indent-for-tab-command' would, except
  in special-cases such as in the recipe of `use-package', which is
  also a macro with special indentation rules; we override those
  because the `use-package' in use-package's recipe is not that macro,
  it is just a symbol appearing as the first element of a data list.

- I prefer it if there is a newline between the package symbol (the
  car) and the plist that follows, but usually only add it to existing
  recipes when lines would otherwise get to long.  I also do not
  change this if I am not making any other changes that affect more
  than one line.

- Either the complete list should be on a single line or each line
  should contain only one key/value pair.  The first pair may share a
  line with the package symbol (see previous point).  If the recipe
  needs more than one line, then two key/value pairs should never
  appear on one line.  Newline characters are cheap enough these days.

- `:fetcher' should come before `:url' or `:repo', not least because
  the former dictates which of the latter two is required/valid.  You
  can also think of the fetcher as the type or class of the recipe,
  which IMO should come first, like in code: (git-fetcher :url val).

- The most common keywords should be specified in this order:
  `:fetcher', `:url'/`:repo', `:files'.  Other keywords should go
  either before or after `:files' (but preferable not on both sides
  of that for any given recipe).

- A common value of `:files' is: (:defaults (:exclude "...")).
  This could be split across multiple lines, but writing everything
  on one line makes it easier to read it as 'use the defaults, except
  exclude "..."':

    :files (:defaults (:exclude "..."))

- If the value of `:files' is too long for one line, then place
  newlines "semantically", instead of trying to "save space".  For
  example any element that is a list should appear on its own line.
  Two sibling lists should never appear on the same line.  String
  siblings should also not appear on one line in many cases, though
  it might makes sense (but isn't my preference) to group them by
  "type" as in:

    (:defaults
     "foo/*.el" "bar/*.el"
     "docs/foo/*.texi" "docs/bar/*.texi"
     (:exclude "..."))

- While there may be multiple (:exclude ...) elements, I've merged
  them into one.  Mostly for future proofing.

- The position of `:exclude' elements in `:files' value is significant
  in theory.  However in most cases it already appears at the very end
  and I have moved it there in cases where the order is not
  significant.  Mostly for future proofing.
```