### PR TITLE
Add recipe for new package lsp-scheme

### DIFF
--- a/recipes/lsp-scheme
+++ b/recipes/lsp-scheme
@@ -1,4 +1,4 @@
 (lsp-scheme :fetcher git
             :url "https://codeberg.org/rgherdt/emacs-lsp-scheme"
-            :commit "66a24fc55789a2ce88dbc36a077a8d8c90943745"
+            :commit "9fa2ec12d04452ec412cb15115a570cc7b7f258f"
             :files ("*.el" ("scripts" "*.scm")))

--- a/recipes/lsp-scheme
+++ b/recipes/lsp-scheme
@@ -1,4 +1,4 @@
 (lsp-scheme :fetcher git
             :url "https://codeberg.org/rgherdt/emacs-lsp-scheme"
-            :commit "98cfe77da0eca66c1c632e8d2c450771ea07e996"
+            :commit "caf74adf31c91b10e4d88058a07a00da61f60607"
             :files ("*.el" ("scripts" "*.scm")))

--- a/recipes/lsp-scheme
+++ b/recipes/lsp-scheme
@@ -1,0 +1,4 @@
+(lsp-scheme :fetcher git
+            :url "https://codeberg.org/rgherdt/emacs-lsp-scheme"
+            :commit "98cfe77da0eca66c1c632e8d2c450771ea07e996"
+            :files ("*.el" ("scripts" "*.scm")))

--- a/recipes/lsp-scheme
+++ b/recipes/lsp-scheme
@@ -1,3 +1,2 @@
 (lsp-scheme :fetcher git
-            :url "https://codeberg.org/rgherdt/emacs-lsp-scheme"
-            :files (:defaults "scripts"))
+            :url "https://codeberg.org/rgherdt/emacs-lsp-scheme")

--- a/recipes/lsp-scheme
+++ b/recipes/lsp-scheme
@@ -1,4 +1,3 @@
 (lsp-scheme :fetcher git
             :url "https://codeberg.org/rgherdt/emacs-lsp-scheme"
-            :commit "33201276f5eb56c5c6d8b21d8b6c38c0e499dd6a"
-            :files ("*.el" ("scripts" "*.scm")))
+            :files (:defaults "scripts"))

--- a/recipes/lsp-scheme
+++ b/recipes/lsp-scheme
@@ -1,4 +1,4 @@
 (lsp-scheme :fetcher git
             :url "https://codeberg.org/rgherdt/emacs-lsp-scheme"
-            :commit "9fa2ec12d04452ec412cb15115a570cc7b7f258f"
+            :commit "33201276f5eb56c5c6d8b21d8b6c38c0e499dd6a"
             :files ("*.el" ("scripts" "*.scm")))

--- a/recipes/lsp-scheme
+++ b/recipes/lsp-scheme
@@ -1,4 +1,4 @@
 (lsp-scheme :fetcher git
             :url "https://codeberg.org/rgherdt/emacs-lsp-scheme"
-            :commit "caf74adf31c91b10e4d88058a07a00da61f60607"
+            :commit "66a24fc55789a2ce88dbc36a077a8d8c90943745"
             :files ("*.el" ("scripts" "*.scm")))

--- a/recipes/lsp-scheme
+++ b/recipes/lsp-scheme
@@ -1,2 +1,3 @@
 (lsp-scheme :fetcher git
-            :url "https://codeberg.org/rgherdt/emacs-lsp-scheme")
+            :url "https://codeberg.org/rgherdt/emacs-lsp-scheme"
+            :files (:defaults "scripts"))


### PR DESCRIPTION
Add support for Scheme to the lsp-mode. Currently only CHICKEN and Guile are
supported. This package relies on scheme-lsp-server available at
https://codeberg.org/rgherdt/scheme-lsp-server. I am the creator of both the
LSP server and this package.

Repository: https://codeberg.org/rgherdt/emacs-lsp-scheme

Differently than most other lsp-mode packages, lsp-scheme creates a single
instance of Scheme (Guile or CHICKEN, depending on which library is loaded) that
spawns on demand new threads providing LSP servers. This way the user can
interact with the running instance, for which a REPL is available at
*lsp-scheme*, and information is provided based on what the user defined/loaded.

### Brief summary of what the package does

[Please write a quick summary of the package.]

### Direct link to the package repository

https://github.com/your/awesome_package

### Your association with the package

[Are you the maintainer? A contributor? An enthusiastic user?]

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
