### PR TITLE
recipes: add ansilove

### DIFF
--- a/recipes/ansilove
+++ b/recipes/ansilove
@@ -1,0 +1,1 @@
+(ansilove :fetcher gitlab :repo "xgqt/emacs-ansilove" :files ("src/*"))


### PR DESCRIPTION
Signed-off-by: Maciej Barć <xgqt@gentoo.org>

### Brief summary of what the package does

Display buffers as PNG images using ansilove.

This package provides some integration with the ansilove tool, which is a ANSI and ASCII art to PNG converter.

ansilove repository: https://github.com/ansilove/ansilove/

To test this library out open one of files from ansilove's examples (https://github.com/ansilove/ansilove/tree/master/examples/) and call ansilove (M-x ansilove).

### Direct link to the package repository

https://gitlab.com/xgqt/emacs-ansilove/

### Your association with the package

I am the package maintainer.

### Relevant communications with the upstream package maintainer

If there are issues with the package they can be reported on the project's GitLab issue tracker:
https://gitlab.com/xgqt/emacs-ansilove/-/issues/

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
