### PR TITLE
Fix a typo, add a link, and clean up some whitespace

### DIFF
--- a/html/partials/getting-started.html
+++ b/html/partials/getting-started.html
@@ -10,9 +10,9 @@
       </p>
 
       <p>
-	Consider using Emacs 26.3 or greater; otherwise you will have
-	to add a kludge to work around a bug described in *Known
-	Issues* below.
+        Consider using Emacs 26.3 or greater; otherwise you will have
+        to add a kludge to work around a bug described in
+        <a href="#knownIssues">Known Issues</a> below.
       </p>
 
       <p>
@@ -115,9 +115,9 @@
       </dl>
     </section>
     <section>
-      <h2>Known Issues</h2>
+      <h2 id="knownIssues">Known Issues</h2>
       <h3>Failed to download ‘MELPA’ archive</h3>
-      <p>This occationally happens when using Emacs &#60;= 26.2
+      <p>This occasionally happens when using Emacs &#60;= 26.2
         with Gnutls &#62;= 3.6.  The recommended fix is to update to
         Emacs 26.3 or greater.  Alternatively you can disable TLS1.3
         by adding the following setting early in your init file.  For
@@ -164,9 +164,10 @@
       <a name="adding"></a>
       <h2>Adding a Package</h2>
       <p>
-	In so many words, fork the project's source tree
-	and create a pull request with a recipe for your package.
-	The <a href="https://github.com/melpa/melpa/blob/master/README.md">README.md</a> file on GitHub has more details.
+        In so many words, fork the project's source tree and create a
+        pull request with a recipe for your package.
+        The <a href="https://github.com/melpa/melpa/blob/master/README.md">README.md</a>
+        file on GitHub has more details.
       </p>
       <a name="development"></a>
       <h2>Development</h2>


### PR DESCRIPTION
As the title says: I found a typo, wanted to fix it and my editor complained about some tabs vs. mostly spaces. I also added a link to the "Known Issues" section for slightly improved accessibility.