### PR TITLE
Add 'naga' theme

### DIFF
--- a/recipes/naga-theme
+++ b/recipes/naga-theme
@@ -1,0 +1,1 @@
+(naga-theme :fetcher github :repo "kenranunderscore/emacs-naga-theme")


### PR DESCRIPTION
### Brief summary of what the package does

A (very) dark color scheme with a green foreground color, a somewhat retro look, but more colorful than some other retro themes. Some screenshots can be found in the repository's readme.

The theme is WIP still, as I haven't gotten around to styling packages I don't actually use, yet, but I plan to. It's very much usable already; I've used it for close to a year now, as part of my personal Emacs configuration. Some colleagues have asked about it and when I last checked there wasn't any very similar theme out there.

### Direct link to the package repository

https://github.com/kenranunderscore/emacs-naga-theme

### Your association with the package

I'm the author+maintainer of the package.

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
