### PR TITLE
Add recipe for ob-git-permalink

### DIFF
--- a/recipes/ob-git-permalink
+++ b/recipes/ob-git-permalink
@@ -1,0 +1,1 @@
+(ob-git-permalink :fetcher github :repo "kijimaD/ob-git-permalink")


### PR DESCRIPTION
### Brief summary of what the package does

Org-Babel support for expand permalink and insert source code.

```
#+begin_src git-permalink
https://github.com/emacs-mirror/emacs/blob/a4dcc8b9a94466c792be3743760a4a45cf6e1e61/README#L1-L2
#+end_src
```

↓ evaluate(C-c)

```
#+RESULTS:
: Copyright (C) 2001-2022 Free Software Foundation, Inc.
: See the end of the file for license conditions.
```

### Direct link to the package repository

https://github.com/kijimaD/ob-git-permalink

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

non needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
