### PR TITLE
Add recipe for elfeed-tube

### DIFF
--- a/recipes/elfeed-tube
+++ b/recipes/elfeed-tube
@@ -1,0 +1,2 @@
+(elfeed-tube :repo "karthink/elfeed-tube" :fetcher github
+             :files ("elfeed-tube.el" "elfeed-tube-utils.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Elfeed Tube is an extension for Elfeed, the feed reader for Emacs, that enhances Youtube RSS feed subscriptions.

Typically Youtube RSS feeds contain only the title and author of each video. Elfeed Tube adds video descriptions, thumbnails, durations, chapters and "live" transcrips to video entries. See https://github.com/karthink/elfeed-tube for demos. This information can optionally be added to the entry in the Elfeed database.

### Direct link to the package repository

https://github.com/karthink/elfeed-tube

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
Checkdoc insists on docstrings for all functions, including one-line `defsubst`s. I've decided to ignore this. All interactive commands provided by the package are documented.