### PR TITLE
Add recipe for elfeed-tube-mpv

### DIFF
--- a/recipes/elfeed-tube-mpv
+++ b/recipes/elfeed-tube-mpv
@@ -1,0 +1,3 @@
+(elfeed-tube-mpv :repo "karthink/elfeed-tube"
+                 :fetcher github
+                 :files ("elfeed-tube-mpv.el"))


### PR DESCRIPTION
-------

### Brief summary of what the package does

This package provides integration with the mpv video player for `elfeed-tube` entries, PR'd in #8087. 

With `elfeed-tube-mpv` loaded, clicking on a transcript segment in an Elfeed Youtube video feed entry will launch mpv at that time, or seek to that point if already playing, or enqueue the entry if presently playing a different entry. There are other features available, like auto-following a video in the transcript in Emacs. There are demos viewable at https://github.com/karthink/elfeed-tube.

### Direct link to the package repository

https://github.com/karthink/elfeed-tube

### Your association with the package

I am the maintainer and package author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
Checkdoc insists on docstrings for all functions, including one-line defsubsts. I've decided to ignore this. All interactive commands provided by the package are documented.