### PR TITLE
No longer bundle parseclj with spiral

### DIFF
--- a/recipes/spiral
+++ b/recipes/spiral
@@ -1,10 +1,3 @@
 (spiral :repo "volrath/spiral"
         :fetcher github
-        :files (:defaults
-                "blob.clj"
-                "tools"
-                "parseclj/parseclj.el"
-                "parseclj/parseedn.el"
-                "parseclj/parseclj-parser.el"
-                "parseclj/parseclj-lex.el"
-                "parseclj/parseclj-ast.el"))
+        :files (:defaults "blob.clj" "tools"))


### PR DESCRIPTION
@volrath `spiral` tracks `parseclj` as a submodule and the recipe for the former includes files from the latter in its Melpa package. Tracking the dependency as a submodule is okay (though I recommend against it) but bundling a third-party package with a Melpa package is wrong.

This pull-request fixes the recipe. In addition to that you have to add an entry for `parseclj` to `Package-Requires` in `spiral.el`.

Because this package hasn't been touched in five years, I am wondering whether it should be removed from Melpa altogether. Five years seems like a lot in the world of clojure.