### PR TITLE
Remove recipe for stack-mode

### DIFF
--- a/recipes/stack-mode
+++ b/recipes/stack-mode
@@ -1,4 +1,0 @@
-(stack-mode
- :repo "commercialhaskell/stack-ide"
- :fetcher github
- :files ("stack-mode/*.el"))


### PR DESCRIPTION
@chrisdone should `stack-mode` be kept on Melpa?

It was last touched in 2016 and was only downloaded 1421 times, which of course doesn't necessarily mean that it has bit rotten by now and/or that nobody uses it anymore, but Melpa is currently unable to build this package, which is why I am asking.

A few packages need their submodules to be checked out to be build properly, so, "to keep things simple", Melpa checks out all submodules for all packages recursively.

The package for `stack-mode` doesn't need the submodules to be checked out but Melpa tries to do it anyway. Unfortunately that fails because the module still uses git's native protocol, which github no longer supports because it isn't secure. The submodule in turn does the same for its own submodule.

For Melpa to be able to build this package again, the urls in the top repository as well as in the submodule would have to be fixed. Since the submodule is maintained by a third-party and also wasn't touched in years, it might be difficult to get this done.

Is it worth it? Or should this package be removed from Melpa?

Re https://github.com/melpa/package-build/issues/62.