### PR TITLE
Add receipe for my repo pins

### DIFF
--- a/recipes/my-repo-pins
+++ b/recipes/my-repo-pins
@@ -1,0 +1,1 @@
+(my-repo-pins :fetcher github :repo "ninjatrappeur/my-repo-pins")


### PR DESCRIPTION
### Brief summary of what the package does

The general idea of this package is to help with keeping a set of git repositories in a single unified tree.

IE. organizing the git repositories in a structure like that

```
~/code-root
├── codeberg.org
│   └── Freeyourgadget
│       └── Gadgetbridge
└── github.com
    ├── BaseAdresseNationale
    │   └── fantoir
    ├── mpv-player
    │   └── mpv
    └── NinjaTrappeur
        ├── cinny
        └── h.el
```

The package provides a unified entry point to jump to a local repository clone, and query remote forges then clone a repository found there.

Some screencaps shamelessly stolen from the project's readme illustrating what I mean with the (confusing?) previous paragraph :)

![](https://github.com/NinjaTrappeur/h.el/raw/master/doc/assets/jump-local.webp)
![](https://github.com/NinjaTrappeur/h.el/raw/master/doc/assets/clone-project.webp)
![](https://github.com/NinjaTrappeur/h.el/raw/master/doc/assets/clone-absolute-url.webp)

### Direct link to the package repository

https://github.com/NinjaTrappeur/h.el

### Your association with the package

I am the maintainer.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
