### PR TITLE
add: tree-sitter-ess-r, tree-sitter for R

### DIFF
--- a/recipes/tree-sitter-ess-r
+++ b/recipes/tree-sitter-ess-r
@@ -1,0 +1,3 @@
+(tree-sitter-ess-r :fetcher git
+               :url "https://github.com/ShuguangSun/tree-sitter-ess-r.git"
+               )

--- a/recipes/tree-sitter-ess-r
+++ b/recipes/tree-sitter-ess-r
@@ -1,3 +1,2 @@
 (tree-sitter-ess-r :fetcher git
-               :url "https://github.com/ShuguangSun/tree-sitter-ess-r.git"
-               )
+                   :url "https://github.com/ShuguangSun/tree-sitter-ess-r.git")


### PR DESCRIPTION
### Brief summary of what the package does

R with tree-sitter support. 

### Direct link to the package repository

https://github.com/ShuguangSun/tree-sitter-ess-r

### Your association with the package

I'm the creator and matainer.

### Relevant communications with the upstream package maintainer

None needed for elisp part.

Now tree-sitter-r has not been added to tree-sitter-langs (PR created). It require the user to compile r.dll/r.so by themself as the instruction in the README of the repo.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
