### PR TITLE
Add recipe for pip-frame

### DIFF
--- a/recipes/pip-frame
+++ b/recipes/pip-frame
@@ -1,0 +1,3 @@
+(pip-frame
+ :fetcher git
+ :url "https://git.zamazal.org/pdm/pip-frame")


### PR DESCRIPTION
### Brief summary of what the package does

Display and manage a PIP frame.

### Direct link to the package repository

https://git.zamazal.org/pdm/pip-frame

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

I'm the upstream package maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
