### PR TITLE
Add recipe for zk-luhmann

### DIFF
--- a/recipes/zk-luhmann
+++ b/recipes/zk-luhmann
@@ -1,0 +1,2 @@
+(zk-luhmann :repo "localauthor/zk-luhmann"
+            :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a companion package to zk and zk-index (both already in MELPA). It adds support for a specific kind of note-management, resembling that of sociologist Niklas Luhmann (hence the package name).

### Direct link to the package repository

https://github.com/localauthor/zk-luhmann

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
