### PR TITLE
Add Recipe for lsp-cfn

### DIFF
--- a/recipes/lsp-cfn
+++ b/recipes/lsp-cfn
@@ -1,0 +1,4 @@
+(lsp-cfn
+ :repo "LaurenceWarne/lsp-cfn.el"
+ :fetcher github
+ :files ("*.el" "snippets"))

--- a/recipes/lsp-cfn
+++ b/recipes/lsp-cfn
@@ -1,4 +1,4 @@
 (lsp-cfn
  :repo "LaurenceWarne/lsp-cfn.el"
  :fetcher github
- :files ("*.el" "snippets"))
+ :files (:defaults "snippets")))


### PR DESCRIPTION
### Brief summary of what the package does

`lsp-mode` integration for https://github.com/LaurenceWarne/cfn-lsp-extra.

### Direct link to the package repository

https://github.com/LaurenceWarne/lsp-cfn.el

### Your association with the package
Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (1)
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

(1) I get:
```
lsp-cfn.el:91:1: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
Found 1 warning in file ‘lsp-cfn.el’
```
But I'm not sure there's an alternative? https://github.com/AndreaCrotti/yasnippet-snippets/blob/master/yasnippet-snippets.el does the same thing.