### PR TITLE
Add recipe for dired-duplicates

### DIFF
--- a/recipes/dired-duplicates
+++ b/recipes/dired-duplicates
@@ -1,0 +1,3 @@
+(dired-duplicates
+ :url "https://codeberg.org/hjudt/dired-duplicates.git"
+ :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

This Emacs package helps to find duplicate files on local and remote filesystems, showing the results in a Dired buffer. It is similar to the fdupes command-line utility but written in Emacs Lisp and should also work on every remote filesystem that TRAMP supports and where executable commands can be called remotely (the checksumming is still done using an external checksum program for performance reasons).

### Direct link to the package repository

https://codeberg.org/hjudt/find-duplicates

### Your association with the package

I am both the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
