### PR TITLE
Add recipe for lean4-mode

### DIFF
--- a/recipes/lean4-mode
+++ b/recipes/lean4-mode
@@ -1,0 +1,4 @@
+(lean4-mode
+ :repo "leanprover/lean4-mode"
+ :fetcher github
+ :files ("lean-*.el"))


### PR DESCRIPTION


### Brief summary of what the package does

This package adds a major mode for the Lean4 programming language and theorem prover.

https://github.com/leanprover/lean4

### Direct link to the package repository

https://github.com/leanprover/lean4-mode

### Your association with the package

I am a contributor of the package and of Lean4. This mode was ported from `lean-mode`  which is written by @leodemoura @Kha and others. 

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
