### PR TITLE
git-timemachine and git-lens moved to codeberg.org

### DIFF
--- a/recipes/git-lens
+++ b/recipes/git-lens
@@ -1,1 +1,1 @@
-(git-lens :fetcher gitlab :repo "pidu/git-lens")
+(git-lens :fetcher git :url "https://codeberg.org/pidu/git-lens")

--- a/recipes/git-timemachine
+++ b/recipes/git-timemachine
@@ -1,1 +1,1 @@
-(git-timemachine :fetcher gitlab :repo "pidu/git-timemachine")
+(git-timemachine :fetcher git :url "https://codeberg.org/pidu/git-timemachine.git")


### PR DESCRIPTION
### Brief summary of what the package does

Two git related packages already in melpa.

### Direct link to the package repository

https://codeberg.org/pidu/git-timemachine
https://codeberg.org/pidu/git-lens

### Your association with the package

Maintianer

### Relevant communications with the upstream package maintainer

**None needed*

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
