### PR TITLE
Add citar-embark recipe

### DIFF
--- a/recipes/citar
+++ b/recipes/citar
@@ -1,3 +1,4 @@
 (citar :repo "emacs-citar/citar"
        :fetcher github
+       :files (:defaults (:exclude "citar-embark.el"))
        :old-names (bibtex-actions))

--- a/recipes/citar-embark
+++ b/recipes/citar-embark
@@ -1,0 +1,3 @@
+(citar-embark :repo "emacs-citar/citar"
+       :fetcher github
+       :files ("citar-embark.el"))


### PR DESCRIPTION
I'm the creator and maintainer of the [citar package](https://github.com/emacs-citar/citar).

This PR has two commits, which together splits the package in two.

The first is for a new, small, `citar-embark` integration package for citar, to avoid us having to use `with-eval-after-load` and such, and simplify configuration for users.

The other adjusts the citar existing recipe so it excludes `citar-embark.el`, since the code shares the same repo.