### PR TITLE
Add recipe for readable-numbers

### DIFF
--- a/recipes/readable-numbers
+++ b/recipes/readable-numbers
@@ -1,0 +1,4 @@
+(readable-numbers
+ :fetcher github
+ :repo "Titan-C/cardano.el"
+ :files ("readable-numbers.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Minor mode which places an overlay on large integers to make them readable
This is an isolated package dependency for https://github.com/melpa/melpa/pull/8077
### Direct link to the package repository
https://github.com/Titan-C/cardano.el


### Your association with the package

I'm the maintainer
### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
