### PR TITLE
fix: github for tree-sitter-ess-r

### DIFF
--- a/recipes/tree-sitter-ess-r
+++ b/recipes/tree-sitter-ess-r
@@ -1,2 +1,3 @@
-(tree-sitter-ess-r :fetcher git
-                   :url "https://github.com/ShuguangSun/tree-sitter-ess-r.git")
+(tree-sitter-ess-r
+  :repo "ShuguangSun/tree-sitter-ess-r"
+  :fetcher github)


### PR DESCRIPTION
update the repo to github instead a git url.

### Direct link to the package repository

https://github.com/ShuguangSun/tree-sitter-ess-r

### Your association with the package

I'm the author.


