### PR TITLE
Add recipe for repeat-help

### DIFF
--- a/recipes/repeat-help
+++ b/recipes/repeat-help
@@ -1,0 +1,1 @@
+(repeat-help :fetcher github :repo "karthink/repeat-help")


### PR DESCRIPTION
-------

### Brief summary of what the package does

Provides a keybinding description popup that shows available commands when using Emacs 28's `repeat-mode`. This popup can use Embark or Which Key as a backend, but falls back to a built-in method if neither is available (no hard dependencies).

### Direct link to the package repository

https://github.com/karthink/repeat-help

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->