### PR TITLE
Add recipe for org-notify

### DIFF
--- a/recipes/org-notify
+++ b/recipes/org-notify
@@ -1,0 +1,1 @@
+(org-notify :fetcher github :repo "p-m/org-notify")


### PR DESCRIPTION
### Brief summary of what the package does

`org-notify` provides notifications using categories to org files.

There are already several org notifications packages in melpa (org-notifications, org-wild-notifier, org-alert) but I think this package should be added to melpa anyway as:

1. This package was packaged via org-contrib for a long time, [but isn't anymore](https://git.sr.ht/~bzg/org-contrib/commit/c6aef31ccfc7c4418c3b51e98f7c3bd8e255f5e6)
2. The other packages are focused at either sending notifications on a schedule/deadline time, or at a manually specified number of minutes before said time. Org-notify lets you specify a property (for example "dr-appt") to attach to an entry, and specify a schedule for notifications according to that property (in this case, a low priority notification 10 days before, medium 5 days before, and urgent 1 hour before deadline). I find that this feature set is more powerful than the existing packages and cannot be replaced by them.

### Direct link to the package repository

https://github.com/p-m/org-notify

### Your association with the package

I am a user of org-notify - the maintainer is still active, but is a little busy at the minute.

### Relevant communications with the upstream package maintainer

https://github.com/p-m/org-notify/issues/4#issuecomment-1175808821
https://github.com/p-m/org-notify/pull/5

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback 
  - (I have addressed all but one - there is a non standard separator but I do not want to change it to avoid backwards compatibility issues at the moment).
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings 
  - (I haven't tackled this yet - I wanted to minimize changes if possible before submitting)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
