### PR TITLE
Move tok-theme to sourcehut

### DIFF
--- a/recipes/tok-theme
+++ b/recipes/tok-theme
@@ -1,1 +1,1 @@
-(tok-theme :fetcher github :repo "topikettunen/tok-theme" :old-names (brutal-theme))
+(tok-theme :fetcher git :url "https://git.sr.ht/~tok/tok-theme" :old-names (brutal-theme))


### PR DESCRIPTION
### Brief summary of what the package does

Migrating to sourcehut.

### Direct link to the package repository

https://git.sr.ht/~tok/tok-theme

### Your association with the package

Owner

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
