### PR TITLE
Add recipe for hide-package-name

### DIFF
--- a/recipes/hide-package-name
+++ b/recipes/hide-package-name
@@ -1,0 +1,3 @@
+(hide-package-name
+ :fetcher gitlab
+ :repo "hraban/hide-package-name-el")


### PR DESCRIPTION
### Brief summary of what the package does

Minor mode to hide the package name from symbols in Emacs Lisp source.
Replaces all symbols like `my-package--some-func` with `❡--some-func`.
Improves legibility while remaining backwards compatible with other elisp
code.


### Direct link to the package repository

https://gitlab.com/hraban/hide-package-name-el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

---

# Checkdoc

I fixed most of the checkdoc warnings. There were some that, IMO, did not add any value, so I've left them unresolved.