### PR TITLE
Add obsidian recipe

### DIFF
--- a/recipes/obsidian
+++ b/recipes/obsidian
@@ -1,0 +1,1 @@
+(obsidian :repo "licht1stein/obsidian.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Emacs front-end for [Obsidian Notes](https://obsidian.md).

Allows you to work with Obsidian Notes using Emacs. Obviously you already can open your Obsidian folder and start editing markdown files with Emacs. Obsidian.el adds conveniences like:

- autocomplete for tags
- `obsidian-insert-link` and `obsidian-insert-wikilink` commands with autcomplete
- `obsidian-follow-link-at-point` that correctly handles links generated by the Obsisian Notes app

Here's the announcement and reaction to the package on reddit:
https://www.reddit.com/r/emacs/comments/w82c8m/obsidianel_obsidian_notes_within_emacs/

### Direct link to the package repository

https://github.com/licht1stein/obsidian.el

### Your association with the package

Maintainer and author

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
