### PR TITLE
Add recipe for i3bar

### DIFF
--- a/recipes/i3bar
+++ b/recipes/i3bar
@@ -1,0 +1,1 @@
+(i3bar :fetcher github :repo "Stebalien/i3bar.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package renders the output of any i3status compatible command in either the mode-line or the tab-bar.  It's primarily useful for EXWM users who want to render a status-bar inside their Emacs frame.

### Direct link to the package repository

https://github.com/Stebalien/i3bar.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them