### PR TITLE
recipes: add websearch

### DIFF
--- a/recipes/websearch
+++ b/recipes/websearch
@@ -1,0 +1,1 @@
+(websearch :fetcher gitlab :repo "xgqt/emacs-websearch")


### PR DESCRIPTION
Signed-off-by: Maciej Barć <xgqt@gentoo.org>

### Brief summary of what the package does

Query search engines from Emacs.

### Direct link to the package repository

https://gitlab.com/xgqt/emacs-websearch

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

https://gitlab.com/xgqt/emacs-websearch/-/issues/

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
