### PR TITLE
Add hl-indent-scope

### DIFF
--- a/recipes/hl-indent-scope
+++ b/recipes/hl-indent-scope
@@ -1,0 +1,3 @@
+(hl-indent-scope
+ :url "https://codeberg.org/ideasman42/emacs-hl-indent-scope.git"
+ :fetcher git)


### PR DESCRIPTION
### Brief summary of what the package does

Highlight indentation, unlike existing packages it uses scope depth from the syntax-table (works well for C/C++ / GLSL Lisp and similar languages), CMake & Python are also supported.

Using the syntax-table has the advantage that pre-processor commands don't break the highlighting, something that made existing packages such such as [highlight-indent-guides](https://github.com/DarthFennec/highlight-indent-guides) unusable for me.
Screenshot of `hl-indent-scope` https://codeberg.org/attachments/b50b1aeb-b653-4ca0-9a27-2fcc311d9bab

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-hl-indent-scope

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
