### PR TITLE
Update recipe for `disaster`

### DIFF
--- a/recipes/disaster
+++ b/recipes/disaster
@@ -1,1 +1,1 @@
-(disaster :repo "jart/disaster" :fetcher github)
+(disaster :repo "abougouffa/disaster" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Disaster lets you press C-c d to see the compiled assembly code for the C/C++ file you're currently editing. It even jumps to and highlights the line of assembly corresponding to the line beneath your cursor.

### Direct link to the package repository

https://github.com/abougouffa/disaster

### Your association with the package

I'm trying to maintain the package since the [upstream](https://github.com/jart/disaster) do not seem to be active. This fork contains several improvements.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
