### PR TITLE
Add `ligature.el' package support

### DIFF
--- a/recipes/ligature
+++ b/recipes/ligature
@@ -1,0 +1,1 @@
+(ligature :fetcher github :repo "mickeynp/ligature.el")


### PR DESCRIPTION
### Brief summary of what the package does

Adds easy ligature support to Emacs.

### Direct link to the package repository

https://github.com/mickeynp/ligature.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
