### PR TITLE
Remove doneburn-theme

### DIFF
--- a/recipes/doneburn-theme
+++ b/recipes/doneburn-theme
@@ -1,1 +1,0 @@
-(doneburn-theme :fetcher github :repo "manuel-uberti/doneburn-theme")


### PR DESCRIPTION
I'd like to remove [doneburn-theme](https://github.com/manuel-uberti/doneburn-theme) from MELPA.

I am not maintaining it any more.