### PR TITLE
Add citar-org-roam recipe

### DIFF
--- a/recipes/citar-org-roam
+++ b/recipes/citar-org-roam
@@ -1,1 +1,1 @@
-(citar :repo "emacs-citar/citar-org-roam" :fetcher github)
+(citar-org-roam :repo "emacs-citar/citar-org-roam" :fetcher github)

--- a/recipes/citar-org-roam
+++ b/recipes/citar-org-roam
@@ -1,0 +1,1 @@
+(citar :repo "emacs-citar/citar-org-roam" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a small new extension to integrate `citar` and `org-roam`.

### Direct link to the package repository

https://github.com/emacs-citar/citar-org-roam

### Your association with the package

Maintainer

### Checklist

Note: package-lint and install complain about org-roam 2.2 not being available, but I'm not seeing why.

Also, the CI error appears to be with the CI config:

```
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. 
```

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
