### PR TITLE
Update repo and maintainer of goto-last-point recipe

### DIFF
--- a/recipes/goto-last-point
+++ b/recipes/goto-last-point
@@ -1,1 +1,1 @@
-(goto-last-point :fetcher github :repo "manuel-uberti/goto-last-point")
+(goto-last-point :fetcher git :url "https://git.sr.ht/~gitmux/goto-last-point")


### PR DESCRIPTION
### Brief summary of what the package does

A minor-mode to record and jump to the last point in the buffer.

### Direct link to the package repository

https://git.sr.ht/~gitmux/goto-last-point

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

https://github.com/manuel-uberti/goto-last-point/issues/1

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
