### PR TITLE
feat: Add opam-switch-mode

### DIFF
--- a/recipes/opam-switch-mode
+++ b/recipes/opam-switch-mode
@@ -1,0 +1,3 @@
+(opam-switch-mode
+ :fetcher github
+ :repo "ProofGeneral/opam-switch-mode")


### PR DESCRIPTION
### Brief summary of what the package does

It provides a command, and menu, to change the [opam](https://opam.ocaml.org/) switch of the running Emacs session.

This minor mode is hosted in the [ProofGeneral GH organization](https://github.com/ProofGeneral) and is already [supported](https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General/#Opam_002dswitch_002dmode-support) by the `proof-general` package (major mode for proof assistants).

### Direct link to the package repository

https://github.com/ProofGeneral/opam-switch-mode

### Your association with the package

I'm not the main author (it is @hendriktews) but just one of the co-maintainers.

### Relevant communications with the upstream package maintainer

**None needed** (see https://github.com/ProofGeneral/opam-switch-mode/issues/5 just FYI)

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) → GPL-3.0-or-later
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings → except 4 warnings that better have to be ignored
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org) → this helped catching missing autoloads
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->

Cc @hendriktews @Matafou