### PR TITLE
Add recipe for media-thumbnail

### DIFF
--- a/recipes/media-thumbnail
+++ b/recipes/media-thumbnail
@@ -1,0 +1,1 @@
+(media-thumbnail :fetcher github :repo "jojojames/media-thumbnail")


### PR DESCRIPTION
### Brief summary of what the package does

Package provides a way to create an image/thumbnail from a media file (picture/video). It also has a minor-mode to display these pictures in Dired.

### Direct link to the package repository

https://github.com/jojojames/media-thumbnail

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
