### PR TITLE
Update buffer sets recipe to new location

### DIFF
--- a/recipes/buffer-sets
+++ b/recipes/buffer-sets
@@ -1,1 +1,1 @@
-(buffer-sets :url "https://git.flintfam.org/swf-projects/buffer-sets.git" :fetcher git :files ("buffer-sets.el"))
+(buffer-sets :url "https://git.sr.ht/~swflint/buffer-sets" :fetcher git :files ("buffer-sets.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package already exists.  It is now in a new location

### Direct link to the package repository

https://git.sr.ht/~swflint/buffer-sets

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
