### PR TITLE
Add recipe for mos-mode

### DIFF
--- a/recipes/mos-mode
+++ b/recipes/mos-mode
@@ -1,0 +1,1 @@
+(mos-mode :fetcher github :repo "themkat/mos-mode")


### PR DESCRIPTION
### Brief summary of what the package does
Package for working with MOS 6502 projects using the [MOS toolkit](https://github.com/datatrash/mos). Provides helpers for making usage with lsp-mode and dap-mode easy. MOS is a standalone program that provides both (lsp+dap) in a single executable, which is why it makes sense to have as a separate package instead of as part of the aforementioned. 

### Direct link to the package repository

https://github.com/themkat/mos-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer
 **None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them


**checkdoc note:** One error according to checkdoc. "tests" should be singular, but what the function does is indeed run ALL tests. Other than that, checkdoc is happy.


<!-- After submitting, please fix any problems the CI reports. -->
