### PR TITLE
Remove another useless test files from flycheck-grammalecte package

### DIFF
--- a/recipes/flycheck-grammalecte
+++ b/recipes/flycheck-grammalecte
@@ -1,4 +1,4 @@
 (flycheck-grammalecte
  :fetcher git
  :url "https://git.umaneti.net/flycheck-grammalecte/"
- :files (:defaults "*.py" (:exclude "test-profile.el")))
+ :files (:defaults "*.py" (:exclude "test-profile*.el")))


### PR DESCRIPTION
This MR ensure all test related files are removed from the package. This is specially interesting as one of them requires a dependency, which is not necessarily there on the user side, and which is not needed by the package itself (i.e. installation of the package is currently broken :()

### Brief summary of what the package does

French grammar checker

### Direct link to the package repository

https://git.umaneti.net/flycheck-grammalecte/

### Your association with the package

I’m the current maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them