### PR TITLE
Add recipe for pet-mode

### DIFF
--- a/recipes/pet
+++ b/recipes/pet
@@ -1,0 +1,1 @@
+(pet :fetcher github :repo "wyuenho/emacs-pet")


### PR DESCRIPTION
### Brief summary of what the package does

__P__ ython __E__ xecutable __T__ racker.  Tracks downs the correct Python executables from the various virtualenv management tools and assign them to buffer local variables.  The package to end all Emacs virtualenv packages.

### Direct link to the package repository

https://github.com/wyuenho/emacs-pet

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
