### PR TITLE
Add recipe for org-unique-id

### DIFF
--- a/recipes/org-unique-id
+++ b/recipes/org-unique-id
@@ -1,0 +1,1 @@
+(org-unique-id :repo "Phundrak/org-unique-id" :fetcher github)


### PR DESCRIPTION
-------

### Brief summary of what the package does

`org-unique-id` is a package that adds unique custom IDs to org headings in a buffer. It adds the new option `auto-id` that can be enabled with `auto-id:t` in the file’s options.

### Direct link to the package repository

https://github.com/Phundrak/org-unique-id

### Your association with the package

I’m the maintainer of `org-unique-id`.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->