### PR TITLE
Add jit-lock-stealth-progress

### DIFF
--- a/recipes/jit-lock-stealth-progress
+++ b/recipes/jit-lock-stealth-progress
@@ -1,0 +1,1 @@
+(jit-lock-stealth-progress :fetcher codeberg :repo "ideasman42/emacs-jit-lock-stealth-progress")


### PR DESCRIPTION
### Shows progress for `jit-lock-stealth`

Once enabled, a buffer local string is set that can be used in the mode-line to show font locking progress.

_Note that I find this useful when stealthy font locking is enabled to see the progress, otherwise it's not obvious when font locking is finished and some poor performance might be attributable to something else besides fonitification._

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-jit-lock-stealth-progress

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm with `x`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->
