### PR TITLE
Add recipe for cern-ldap

### DIFF
--- a/recipes/cern-ldap
+++ b/recipes/cern-ldap
@@ -1,0 +1,3 @@
+(cern-ldap
+ :fetcher sourcehut
+ :repo "nbarrientos/cern-ldap.el")


### PR DESCRIPTION
For context, [CERN](https://en.wikipedia.org/wiki/CERN) is an international organisation operating the largest particle physics laboratory in the world, hosting and providing resources for more than 12,000 users from institutions in more than 70 countries.

It's clear that the potential audience of this package is rather limited but I'm sure that there are a few Emacs users among CERN users who would be grateful to have means to easily install the package from MELPA. I would totally understand if you decided to not to include it, though.

On the other hand, https://github.com/melpa/melpa/pull/8003 is rather CERN specific too and it's in MELPA. :smile: 

### Brief summary of what the package does

This package provides an interface to do look-ups in CERN's LDAP servers.

### Direct link to the package repository

https://git.sr.ht/~nbarrientos/cern-ldap.el

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm with `x`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

<!-- After submitting, please fix any problems the CI reports. -->