### PR TITLE
Remove canary from pull request template; update doc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,13 +16,13 @@ https://github.com/your/awesome_package
 
 ### Checklist
 
-<!-- Please confirm with `x`: -->
+<!-- Please confirm by replacing `[]` with `[x]`: -->
 
-- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
-- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
-- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
-- [ ] My elisp byte-compiles cleanly
-- [ ] `M-x checkdoc` is happy with my docstrings
-- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
+- [] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
+- [] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
+- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
+- [] My elisp byte-compiles cleanly
+- [] `M-x checkdoc` is happy with my docstrings
+- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
 
 <!-- After submitting, please fix any problems the CI reports. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,5 @@ https://github.com/your/awesome_package
 - [ ] My elisp byte-compiles cleanly
 - [ ] `M-x checkdoc` is happy with my docstrings
 - [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
-- [ ] I have confirmed some of these without doing them
 
 <!-- After submitting, please fix any problems the CI reports. -->

--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -222,16 +222,9 @@ is a useful way to discover missing dependencies.
 
 Create a [[https://github.com/magit/magit/wiki/Dedicated-pull-request-branches][dedicated pull request branch]] in your clone of the [[https://github.com/melpa/melpa][MELPA
 repository]] and push this branch to your fork. Finally, go to the MELPA
-repository and open the pull request.
-
-Include the following information in the pull request description:
-
-- a brief summary of what the package does;
-- a direct link to the package repository;
-- your association with the package (e.g., are you the maintainer?
-  have you contributed? do you just like the package a lot?);
-- relevant communications with the upstream package maintainer (e.g.,
-  ~package.el~ compatibility changes that you have submitted).
+repository and open the pull request.  The pull request description
+will contain a [[file:.github/PULL_REQUEST_TEMPLATE.md][template]] to help guide you through any other details
+you must provide.
 
 Consider the [[https://github.com/github/hub][hub]] command-line utility by [[http://chriswanstrath.com/][defunkt]] which helps simplify
 this process.


### PR DESCRIPTION
1. I like the idea for the pull request canary ("I have confirmed these without doing them") which I believe was @purcell's add.  But in my experience it doesn't provide a strong signal, and also sometimes trips up people who aren't English-fluent.
2. The information in the pull request template is repeated in CONTRIBUTING.md.  That document is already quite long, and I thought it might be a good idea to deduplicate.