### PR TITLE
Add recipe for mybuild-mode

### DIFF
--- a/recipes/mybuild-mode
+++ b/recipes/mybuild-mode
@@ -1,0 +1,1 @@
+(mybuild-mode :fetcher github :repo "easimonenko/mybuild-mode")


### PR DESCRIPTION
### Brief summary of what the package does

_mybuild-mode_ -- major mode for GNU Emacs for Mybuild files from [Embox](https://embox.github.io/) operating system.

_mybuild-mode_ supports:
- syntax highlighting;
- proper indentations.

### Direct link to the package repository

https://github.com/easimonenko/mybuild-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
