### PR TITLE
Add recipe for xit-mode

### DIFF
--- a/recipes/xit-mode
+++ b/recipes/xit-mode
@@ -1,0 +1,1 @@
+(xit-mode :fetcher github :repo "ryanolsonx/xit-mode")


### PR DESCRIPTION
### Brief summary of what the package does

[x]it! is a plain-text file format for todos and check lists. This is an Emacs major mode that gives highlighting for .xit files.

### Direct link to the package repository

https://github.com/ryanolsonx/xit-mode/

### Your association with the package

Contributor

### Relevant communications with the upstream package maintainer

Issue reference: https://github.com/ryanolsonx/xit-mode/issues/7

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

