### PR TITLE
Add recipe for math-tex-convert

### DIFF
--- a/recipes/math-tex-convert
+++ b/recipes/math-tex-convert
@@ -1,0 +1,1 @@
+(math-tex-convert :repo "enricoflor/math-tex-convert" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package allows you to replace (La)TeX macros into unicode symbols, and back interactively (or not, the interface is similar to `query-replace`). The predefined tables are inherited from [math-symbol-lists](https://elpa.gnu.org/packages/math-symbol-lists.html), a dependency, but the user can define whatever alternative mappings they want (also non functional ones) by just setting the value of an alist.

### Direct link to the package repository

https://github.com/enricoflor/math-tex-convert

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
