### PR TITLE
Clean: remove obsolete lakota-input package

### DIFF
--- a/recipes/lakota-input
+++ b/recipes/lakota-input
@@ -1,1 +1,0 @@
-(lakota-input :fetcher sourcehut :repo "shoshin/lakota-input")


### PR DESCRIPTION
### Brief summary of what the package does

Removes the `lakota-input` package recipe, as it is now in Emacs source.

### Direct link to the package repository

https://git.sr.ht/~shoshin/lakota-input

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

