### PR TITLE
Update recipe for google-translate

### DIFF
--- a/recipes/google-translate
+++ b/recipes/google-translate
@@ -1,1 +1,4 @@
-(google-translate :fetcher github :repo "atykhonov/google-translate")
+(google-translate
+ :fetcher github
+ :repo "atykhonov/google-translate"
+ :files (:defaults (:exclude "google-translate-pkg.el")))


### PR DESCRIPTION
This -pkg.el file doesn't specify the dependencies (i.e. popup) but is being detected as the package's "main" file; if the user doesn't already have popup installed, the package won't install correctly.

@atykhonov and @stardiviner fyi -- you might decide you instead want to include the dependencies in the -pkg.el file, in which case we could revert this change.

(This will also allow https://github.com/melpa/melpa/pull/8189 to be fully built and tested.)