### PR TITLE
Add recipe for inspector

### DIFF
--- a/recipes/inspector
+++ b/recipes/inspector
@@ -1,0 +1,4 @@
+(inspector
+ :fetcher github
+ :repo "mmontone/emacs-inspector"
+ :files ("inspector.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Tool for inspecting Emacs Lisp objects.

### Direct link to the package repository

https://github.com/mmontone/emacs-inspector

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)