### PR TITLE
Recipe for ox-attach-publish

### DIFF
--- a/recipes/ox-attach-publish
+++ b/recipes/ox-attach-publish
@@ -1,0 +1,6 @@
+(ox-attach-publish :fetcher github
+                   :repo "simoninireland/ox-attach-publish"
+                   :files ("ox-attach-publish.el"
+                           "ox-attach-publish-f.el"
+                           "ox-attach-publish-machinery.el"
+                           "ox-attach-publish-frontend.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Integrates org's attachment mechanism with the publication machinery to let us
publish them self-contained, for example "attaching" all their inline images, rather
than manually maintaining a separate image directory.

### Direct link to the package repository

https://github.com/simoninireland/ox-attach-publish

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

The only "problem" not fixed is that package-lint complains that my function names don't
start with "ox-attach-publish": they use "org-attach-publish", which seems to be standard
for org packages regardless of whether they're exporters or not.