### PR TITLE
Remove recipe for completions-frame

### DIFF
--- a/recipes/completions-frame
+++ b/recipes/completions-frame
@@ -1,1 +1,0 @@
-(completions-frame :fetcher github :repo "muffinmad/emacs-completions-frame")


### PR DESCRIPTION
This package is not working with recent Emacs versions. I have no plans to support it, I want to deprecate it in favor of `corfu`. Let's remove this recipe to not confuse users.

### Direct link to the package repository

https://github.com/muffinmad/emacs-completions-frame

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**