### PR TITLE
Add recipe for ob-ffuf

### DIFF
--- a/recipes/ob-ffuf
+++ b/recipes/ob-ffuf
@@ -1,0 +1,1 @@
+(ob-ffuf :repo "daniel-ts/ob-ffuf" :fetcher github)

--- a/recipes/ob-ffuf
+++ b/recipes/ob-ffuf
@@ -1,1 +1,5 @@
-(ob-ffuf :repo "daniel-ts/ob-ffuf" :fetcher github)
+(ob-ffuf
+ :repo "daniel-ts/ob-ffuf"
+ :fetcher github
+ :files ("*.el"
+         (:exclude "*-test.el" "README.org" ".gitignore")))

--- a/recipes/ob-ffuf
+++ b/recipes/ob-ffuf
@@ -1,5 +1,1 @@
-(ob-ffuf
- :repo "daniel-ts/ob-ffuf"
- :fetcher github
- :files ("*.el"
-         (:exclude "*-test.el" "README.org" ".gitignore")))
+(ob-ffuf :repo "daniel-ts/ob-ffuf" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package integrates the [ffuf](https://github.com/ffuf/ffuf) web fuzzer with Org Babel, so that an HTTP request may be written inside a source code block and an Orgmode table specified as a wordlist input and fired off quickly.

### Direct link to the package repository

[https://github.com/daniel-ts/ob-ffuf](https://github.com/daniel-ts/ob-ffuf)

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
