### PR TITLE
Update recipe for pg.el with revitalized upstream version

### DIFF
--- a/recipes/pg
+++ b/recipes/pg
@@ -1,3 +1,3 @@
 (pg
- :repo "cbbrowne/pg.el"
+ :repo "emarsden/pg-el"
  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

pg.el is a socket-level interface for the PostgreSQL database.

### Direct link to the package repository

https://github.com/emarsden/pg-el

### Your association with the package

Author. 

### Relevant communications with the upstream package maintainer

I am the original author of this code, from around 2001. MELPA currently contains a version of pg.el hosted by cbbrowne, which has not been maintained since 2013. I have made numerous updates to support new PostgreSQL versions (the 3.0 wire protocol, new authentication methods). 

This new version is source-incompatible with the existing version (mostly because of a change to use Emacs Lisp style conventions, pg- prefix instead of pg:), but the old code will not work with current PostgreSQL versions due to lack of support for current authentication methods. 

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

