### PR TITLE
Add recipe for org-custom-cookies

### DIFF
--- a/recipes/org-custom-cookies
+++ b/recipes/org-custom-cookies
@@ -1,0 +1,2 @@
+(org-custom-cookies :repo "gsingh93/org-custom-cookies"
+                    :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`org-custom-cookies` allows you define custom `org-mode` statistics cookies (i.e. `[1/3]` in headings). Some built-in custom cookies around calculating scheduled time, clock time, and effort are included, but the user is able to add their own if they would like.

### Direct link to the package repository

https://github.com/gsingh93/org-custom-cookies

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
