### PR TITLE
Exclude file ".bump-version.el" to google-translate

### DIFF
--- a/recipes/google-translate
+++ b/recipes/google-translate
@@ -1,4 +1,4 @@
 (google-translate
  :fetcher github
  :repo "atykhonov/google-translate"
- :files (:defaults (:exclude "google-translate-pkg.el")))
+ :files (:defaults (:exclude "google-translate-pkg.el" ".bump-version.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Distributed Lisp files that are not part of the package cause warnings during `package-install`.

<img width="658" alt="スクリーンショット 2022-09-20 23 39 06" src="https://user-images.githubusercontent.com/822086/191290914-b52ad6c8-18fb-41e0-be4f-4139db5e845e.png">

### Direct link to the package repository

https://github.com/atykhonov/google-translate

### Your association with the package

I'm enthusiastic user.

### Relevant communications with the upstream package maintainer

Resolve https://github.com/atykhonov/google-translate/issues/154, @stardiviner 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
