### PR TITLE
Add dired-auto-readme package

### DIFF
--- a/recipes/dired-auto-readme
+++ b/recipes/dired-auto-readme
@@ -1,0 +1,1 @@
+(dired-auto-readme :repo "amno1/dired-auto-readme" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Display README files in Dired buffers, similar as in public forges online such as [Codeberg](https://codeberg.org/) or [GitHub[(https://github.com/)

### Direct link to the package repository

https://github.com/amno1/dired-auto-readme

### Your association with the package

I am the author, packager and the enthusiastic user!

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my doc strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
