### PR TITLE
Add recipe for igist

### DIFF
--- a/recipes/igist
+++ b/recipes/igist
@@ -1,0 +1,1 @@
+(igist :fetcher github :repo "KarimAziev/igist")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a transient interface for editing, creating, updating and deleting GitHub gists and comments.

There is an existing [gist](https://melpa.org/#/gist) package, but it is not working with recent Emacs versions. Collaboration is hardly possible because it hasn't been touched in five years and has stale open issues and pull requests.

### Direct link to the package repository

<https://github.com/KarimAziev/igist>

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)