### PR TITLE
Add org-gratitude package

### DIFF
--- a/recipes/org-gratitude
+++ b/recipes/org-gratitude
@@ -1,0 +1,1 @@
+(org-gratitude :fetcher github :repo "accraze/org-gratitude")


### PR DESCRIPTION
### Brief summary of what the package does

org-gratitude is a simple gratitude journal for org-mode

### Direct link to the package repository

https://github.com/accraze/org-gratitude

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
