### PR TITLE
Update catppuccin-theme

### DIFF
--- a/recipes/catppuccin-theme
+++ b/recipes/catppuccin-theme
@@ -1,1 +1,2 @@
-(catppuccin-theme :fetcher github :repo "catppuccin/emacs")
+(catppuccin-theme :fetcher github :repo "catppuccin/emacs" :files("catppuccin-mocha-theme.el" "
+catppuccin-macchiato-theme.el" "catppuccin-frappe-theme.el" "catppuccin-latte-theme.el" "catppuccin-theme.el"))

--- a/recipes/catppuccin-theme
+++ b/recipes/catppuccin-theme
@@ -1,2 +1,2 @@
 (catppuccin-theme :fetcher github :repo "catppuccin/emacs" :files("catppuccin-mocha-theme.el" "
-catppuccin-macchiato-theme.el" "catppuccin-frappe-theme.el" "catppuccin-latte-theme.el" "catppuccin-theme.el"))
+catppuccin-macchiato-theme.el" "catppuccin-frappe-theme.el" "catppuccin-latte-theme.el"))

--- a/recipes/catppuccin-theme
+++ b/recipes/catppuccin-theme
@@ -1,2 +1,1 @@
-(catppuccin-theme :fetcher github :repo "catppuccin/emacs" :files("catppuccin-mocha-theme.el" "
-catppuccin-macchiato-theme.el" "catppuccin-frappe-theme.el" "catppuccin-latte-theme.el"))
+(catppuccin-theme :fetcher github :repo "catppuccin/emacs" :files("catppuccin-theme.el"))


### PR DESCRIPTION
Had to specify multiple packages

### Brief summary of what the package does

Emacs Theme

### Direct link to the package repository

https://github.com/catppuccin/emacs

### Your association with the package

a maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
**About package-lint
When I run on other confirmed files it gives the same errors so I think there's an issue on my side. If someone could take a look at this just to check then that would be appreciated.
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
