### PR TITLE
Update for GHA deprecated workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: Install dependencies
       run: |
-        sudo apt-get install emacs25
+        sudo apt-get install emacs # emacs 26 on ubuntu 20
         sudo apt-get install git jq mercurial texinfo
 
         # Work around SSL-related failures, see


### PR DESCRIPTION
GHA actions/checkout and the runner OS have both been deprecated. Github is starting to throw up a lot of warnings about this.

This bumps the version of ubuntu (20), actions/checkout (v3), and to emacs26 (because of packages on ubuntu 20).

I don't know if there's a hard requirement on emacs25... If so, this CAN be pared back to just the actions/checkout bump... but I'm not sure how long they're going to keep ubuntu-18 as supported. There might be other ways to  go about maintaining emacs 25. I'm open to suggestion.

Obviously I can't test that this change of emacs version will work for all the recipes... just that it passes the current GHA checks.