### PR TITLE
adds youtube-sub-extractor.el recipe

### DIFF
--- a/recipes/youtube-sub-extractor
+++ b/recipes/youtube-sub-extractor
@@ -1,1 +1,1 @@
-(youtube-sub-extractor :fetcher github :repo "agzam/youtube-sub-extractor.el" :files ("*.el"))
+(youtube-sub-extractor :repo "agzam/youtube-sub-extractor.el" :fetcher github)

--- a/recipes/youtube-sub-extractor
+++ b/recipes/youtube-sub-extractor
@@ -1,0 +1,1 @@
+(youtube-sub-extractor :fetcher github :repo "agzam/youtube-sub-extractor.el" :files ("*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Extracts video subtitles using https://github.com/yt-dlp (recommended) or `youtube-dl` and shows them in a buffer

### Direct link to the package repository

https://github.com/agzam/youtube-sub-extractor.el

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
