### PR TITLE
Add glue recipe

### DIFF
--- a/recipes/bubbles
+++ b/recipes/bubbles
@@ -1,1 +1,0 @@
-(bubbles :repo "hajovonta/glue" :fetcher sourcehut)

--- a/recipes/bubbles
+++ b/recipes/bubbles
@@ -1,0 +1,2 @@
+(bubbles :repo "hajovonta/bubbles" :fetcher sourcehut)
+

--- a/recipes/bubbles
+++ b/recipes/bubbles
@@ -1,2 +1,1 @@
 (bubbles :repo "hajovonta/bubbles" :fetcher sourcehut)
-

--- a/recipes/bubbles
+++ b/recipes/bubbles
@@ -1,1 +1,1 @@
-(bubbles :repo "hajovonta/bubbles" :fetcher sourcehut)
+(bubbles :repo "hajovonta/glue" :fetcher sourcehut)

--- a/recipes/glue
+++ b/recipes/glue
@@ -1,0 +1,1 @@
+(glue :repo "hajovonta/glue" :fetcher sourcehut)


### PR DESCRIPTION
### Brief summary of what the package does

Allows interop between Common Lisp and Emacs.
Provides functions to run Common Lisp code on the SLIME-connected CL backend from Emacs Lisp. It is now possible to outsource long-running processes from Emacs and get feedback (think about progressbars, status updates etc)

### Direct link to the package repository

https://git.sr.ht/~hajovonta/glue/

### Your association with the package

Package author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
