### PR TITLE
Add recipe for nameframe-project

### DIFF
--- a/recipes/nameframe-project
+++ b/recipes/nameframe-project
@@ -1,0 +1,4 @@
+(nameframe-project
+ :fetcher github
+ :repo "john2x/nameframe"
+ :files ("nameframe-project.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package integrates `project.el` and `nameframe` to create/switch to a frame when switching projects.

### Direct link to the package repository

https://github.com/john2x/nameframe/blob/master/nameframe-project.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

Previous relevant recipes: #3177 #3176


### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
