### PR TITLE
Add recipe for ox-linuxmag-fr

### DIFF
--- a/recipes/ox-linuxmag-fr
+++ b/recipes/ox-linuxmag-fr
@@ -1,0 +1,4 @@
+(ox-linuxmag-fr
+ :fetcher github
+ :repo "DamienCassou/ox-linuxmag-fr"
+ :files (:defaults "resources"))


### PR DESCRIPTION
### Brief summary of what the package does

This package is an [Org Mode](https://orgmode.org/) exporter for the French [GNU/Linux Magazine](https://www.gnulinuxmag.com/). As the magazine requires authors to submit ODT files, this exporter heavily relies on Org Mode’s builtin ODT exporter and even inherits from it.

### Direct link to the package repository

https://github.com/DamienCassou/ox-linuxmag-fr

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
