### PR TITLE
Add recipe for ddate

### DIFF
--- a/recipes/ddate
+++ b/recipes/ddate
@@ -1,0 +1,1 @@
+(ddate :fetcher git :url "https://git.sr.ht/~earneson/emacs-ddate")

--- a/recipes/ddate
+++ b/recipes/ddate
@@ -1,1 +1,1 @@
-(ddate :fetcher git :url "https://git.sr.ht/~earneson/emacs-ddate")
+(ddate :fetcher sourcehut :repo "earneson/emacs-ddate")


### PR DESCRIPTION
### Brief summary of what the package does

Provides an easy interface for the ddate (Discordian date) command.

### Direct link to the package repository

https://git.sr.ht/~earneson/emacs-ddate

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
