### PR TITLE
Move log4j-mode to GitHub

### DIFF
--- a/recipes/log4j-mode
+++ b/recipes/log4j-mode
@@ -1,4 +1,4 @@
 (log4j-mode
- :fetcher git
- :url "https://git.code.sf.net/p/log4j-mode/code"
+ :repo "dykstrom/log4j-mode"
+ :fetcher github
  :files ("src/*.el"))


### PR DESCRIPTION
### Brief summary of the change

I have moved my package log4j-mode from SourceForge to GitHub before making some upgrades to it. I would like the recipe to point to the new location.

### Direct link to the package repository

New: https://github.com/dykstrom/log4j-mode
Old: https://git.code.sf.net/p/log4j-mode/code

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

The elisp file on GitHub is identical to the one on SourceForge that is already published on Melpa.