### PR TITLE
Exercise CI even when no recipes changed; fix CI for mercurial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         echo -e "[ui]\ntls = False" >> $HOME/.hgrc
         # enable mercurial's purge extension:
         echo -e "[extensions]\npurge =" >> $HOME/.hgrc
-    - name: Check changed recipes
+    - name: Run CI script
       run: |
         [ "$GITHUB_EVENT_NAME" = "push" ] \
           && export CHANGED_FILES=$(git diff-tree --name-only --no-commit-id -r ${{ github.sha }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
 
         # Work around SSL-related failures, see
         # https://stackoverflow.com/questions/21477683/mercurial-https-clone-abort-error-wrong-version-number
-        echo "[ui]\ntls = False" > $HOME/.hgrc
+        echo -e "[ui]\ntls = False" >> $HOME/.hgrc
+        # enable mercurial's purge extension:
+        echo -e "[extensions]\npurge =" >> $HOME/.hgrc
     - name: Check changed recipes
       run: |
         [ "$GITHUB_EVENT_NAME" = "push" ] \

--- a/run-ci.sh
+++ b/run-ci.sh
@@ -13,9 +13,6 @@ echo "EMACS = $EMACS"
 echo
 
 changed_recipes=$(echo "$CHANGED_FILES" | (grep -Po '(?<=^recipes/)[a-z0-9].*' || true))
-# if changed_recipes is empty/not-set, test a couple of "interesting" recipes:
-changed_recipes=${changed_recipes:-"kanban magit"}
-
 for recipe_name in $changed_recipes; do
     if [ -f "./recipes/$recipe_name" ]; then
         echo "----------------------------------------------------"
@@ -23,5 +20,15 @@ for recipe_name in $changed_recipes; do
         emacs --batch --eval "(let ((debug-on-error t)) (add-to-list 'load-path \"$PWD/package-build/\")(load-file \"package-build/package-build.el\")(package-build-archive \"$recipe_name\"))"
     fi
 done
+
+# if the tooling in ./package-build changed test a couple 'interesting' recipes:
+changed_tooling=$(echo "$CHANGED_FILES" | (grep -Po '(?<=^package-build/)[a-z0-9].*' || true))
+if [ -n "$changed_tooling" ]; then
+    for recipe_name in "kanban" "magit"; do
+        echo "----------------------------------------------------"
+        echo "Building recipe to test build tooling: $recipe_name"
+        emacs --batch --eval "(let ((debug-on-error t)) (add-to-list 'load-path \"$PWD/package-build/\")(load-file \"package-build/package-build.el\")(package-build-archive \"$recipe_name\"))"
+    done
+fi
 
 echo "Build successful"

--- a/run-ci.sh
+++ b/run-ci.sh
@@ -24,7 +24,7 @@ done
 # if the tooling in ./package-build changed test a couple 'interesting' recipes:
 changed_tooling=$(echo "$CHANGED_FILES" | (grep -Po '(?<=^package-build/)[a-z0-9].*' || true))
 if [ -n "$changed_tooling" ]; then
-    for recipe_name in "kanban" "magit"; do
+    for recipe_name in "evil" "kanban" "magit"; do
         echo "----------------------------------------------------"
         echo "Building recipe to test build tooling: $recipe_name"
         emacs --batch --eval "(let ((debug-on-error t)) (add-to-list 'load-path \"$PWD/package-build/\")(load-file \"package-build/package-build.el\")(package-build-archive \"$recipe_name\"))"

--- a/run-ci.sh
+++ b/run-ci.sh
@@ -13,6 +13,9 @@ echo "EMACS = $EMACS"
 echo
 
 changed_recipes=$(echo "$CHANGED_FILES" | (grep -Po '(?<=^recipes/)[a-z0-9].*' || true))
+# if changed_recipes is empty/not-set, test a couple of "interesting" recipes:
+changed_recipes=${changed_recipes:-"kanban magit"}
+
 for recipe_name in $changed_recipes; do
     if [ -f "./recipes/$recipe_name" ]; then
         echo "----------------------------------------------------"


### PR DESCRIPTION
I noticed these when testing @zenspider's very welcome CI upgrade in #8233.

- Exercise the build machinery even when no recipes are changed.  The two "test" recipes I chose were kanban (a mercurial recipe) and magit (a sophisticated recipe).  (Earlier I thought this addresses #7903 but I was mistaken.)
- Fix: we should have been using `echo -e` instead of `echo` for the carriage-return to work when modifying .hgrc
- Fix: building mercurial recipes requires the "purge" extension to be enabled (I suspect our old Travis environment had this extension enabled by default, but GitHub actions needs it set explicitly)