### PR TITLE
Adding sixcolors-mode

### DIFF
--- a/recipes/sixcolors-mode
+++ b/recipes/sixcolors-mode
@@ -1,4 +1,1 @@
-(sixcolors-mode
- :fetcher github
- :repo "mastro35/sixcolors-mode"
- :files ("sixcolors-mode.el"))
+(sixcolors-mode :repo "mastro35/sixcolors-mode" :fetcher github)

--- a/recipes/sixcolors-mode
+++ b/recipes/sixcolors-mode
@@ -1,0 +1,4 @@
+(sixcolors-mode
+ :fetcher github
+ :repo "mastro35/sixcolors-mode"
+ :files ("sixcolors-mode.el" "img"))

--- a/recipes/sixcolors-mode
+++ b/recipes/sixcolors-mode
@@ -1,4 +1,4 @@
 (sixcolors-mode
  :fetcher github
  :repo "mastro35/sixcolors-mode"
- :files ("sixcolors-mode.el" "img"))
+ :files ("sixcolors-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

sixcolors-mode is a horizontal scrollbar for emacs. It is similar to nyan-mode but without the cat image, the animation and the music and the colored rainbow is inspired to Apple six colors logo used between 1977 and 1998.

### Direct link to the package repository

https://github.com/mastro35/sixcolors-mode

### Your association with the package

I am the author and the current mantainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
