### PR TITLE
Add recipe for related-files

### DIFF
--- a/recipes/related-files
+++ b/recipes/related-files
@@ -1,0 +1,1 @@
+(related-files :fetcher github :repo "DamienCassou/related-files")


### PR DESCRIPTION
### Brief summary of what the package does

Thousands times a day you want to jump from a file to its test file
(or to its CSS file, or to its header file, or any other related file)
and just as many times you want to go back to the initial file.
Jumping to related files is what this package is about.

### Direct link to the package repository

https://github.com/DamienCassou/related-files

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
