### PR TITLE
Update eide URL (back to TeDomum)

### DIFF
--- a/recipes/eide
+++ b/recipes/eide
@@ -1,1 +1,1 @@
-(eide :fetcher git :url "https://forge.chalec.org/hjuvi/eide.git" :files ("src/*.el" "src/themes/*.el"))
+(eide :fetcher git :url "https://forge.tedomum.net/hjuvi/eide.git" :files ("src/*.el" "src/themes/*.el"))


### PR DESCRIPTION
Update eide URL, back to TeDomum (same forge as the homepage that uses GitLab Pages)

### Brief summary of what the package does

A package for Emacs that provides IDE features

### Direct link to the package repository

https://forge.tedomum.net/hjuvi/eide

### Your association with the package

The author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] `M-x checkdoc` is happy with my docstrings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
