### PR TITLE
Add emacs-mint-mode

### DIFF
--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -1,0 +1,5 @@
+(mint-mode
+ :fetcher github
+ :url "https://github.com/creatorrr/emacs-mint-mode"
+ :repo "creatorrr/emacs-mint-mode"
+ :files ("mint-mode.el"))

--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -1,6 +1,5 @@
 (mint-mode
  :fetcher github
- :url "https://github.com/creatorrr/emacs-mint-mode"
  :repo "creatorrr/emacs-mint-mode"
  :version-regexp "0\\.4\\..+"
  :files ("mint-mode.el" "tokens"))

--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -2,4 +2,5 @@
  :fetcher github
  :url "https://github.com/creatorrr/emacs-mint-mode"
  :repo "creatorrr/emacs-mint-mode"
- :files ("mint-mode.el"))
+ :version-regexp "0\\.4\\..+"
+ :files ("mint-mode.el" "tokens"))

--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -1,4 +1,4 @@
 (mint-mode
  :fetcher github
  :repo "creatorrr/emacs-mint-mode"
- :files ("mint-mode.el" "tokens"))
+ :files (:defaults "tokens"))

--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -1,5 +1,5 @@
 (mint-mode
  :fetcher github
  :repo "creatorrr/emacs-mint-mode"
- :version-regexp "0\\.4\\..+"
+ :version-regexp "0\\.5\\..+"
  :files ("mint-mode.el" "tokens"))

--- a/recipes/mint-mode
+++ b/recipes/mint-mode
@@ -1,5 +1,4 @@
 (mint-mode
  :fetcher github
  :repo "creatorrr/emacs-mint-mode"
- :version-regexp "0\\.5\\..+"
  :files ("mint-mode.el" "tokens"))


### PR DESCRIPTION
 Emacs major mode for mint lang. 

This PR closes #5816 

### Direct link to the package repository

https://github.com/creatorrr/emacs-mint-mode

### Your association with the package

I am the current maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Let me know if there is any quality assurance updates that need to be made in this PR or the `emacs-mint-mode` codebase before this gets accepted.