### PR TITLE
Add package typer-mode to melpa

### DIFF
--- a/recipes/typer-mode
+++ b/recipes/typer-mode
@@ -1,0 +1,1 @@
+(typer-mode :fetcher github :repo "lordnik22/typer-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a little game which makes the user type random sentences from a file or `view-emacs-news`. It's meant to train your typing skills.

### Direct link to the package repository

https://github.com/lordnik22/typer-mode

### Your association with the package

Not original author. Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
