### PR TITLE
Add gitstatus recipe

### DIFF
--- a/recipes/gitstatus
+++ b/recipes/gitstatus
@@ -1,0 +1,2 @@
+(gitstatus :repo "igorepst/gitstatus-el"
+           :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Front-end for external executable [gitstatusd](https://github.com/romkatv/gitstatus) to provide a fast and asynchronous Git status information that may be used as an UI element, say, in `eshell` prompt or in mode line.

### Direct link to the package repository

https://github.com/igorepst/gitstatus-el

### Your association with the package

I am the author and the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
