### PR TITLE
Update location of scad-mode to github:openscad/emacs-scad-mode

### DIFF
--- a/recipes/scad-mode
+++ b/recipes/scad-mode
@@ -1,4 +1,3 @@
 (scad-mode
-	:repo "openscad/openscad"
-	:fetcher github
-	:files ("contrib/scad-mode.el"))
+ :repo "openscad/emacs-scad-mode"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for OpenSCAD files. The Emacs mode is moved out of the OpenSCAD monorepository (contrib directory) to a small separate repository.

### Direct link to the package repository

https://github.com/openscad/emacs-scad-mode

### Your association with the package

Maintainer, User

### Relevant communications with the upstream package maintainer

See https://github.com/openscad/openscad/pull/4403 for the discussion regarding the move.