### PR TITLE
Add recipe for consult-hatena-bookmark

### DIFF
--- a/recipes/consult-hatena-bookmark
+++ b/recipes/consult-hatena-bookmark
@@ -1,0 +1,1 @@
+(consult-hatena-bookmark :fetcher github :repo "Nyoho/consult-hatena-bookmark")


### PR DESCRIPTION
### Brief summary of what the package does

consult-hatena-bookmark is a package to search bookmarks of the Hatena Bookmark with consult.el.
Hatena Bookmark is the biggest social bookmarking site in Japan.

### Direct link to the package repository

https://github.com/Nyoho/consult-hatena-bookmark

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


~~Although the latest version of [package-lint](https://github.com/purcell/package-lint) shows the following, `consult-spotify`, which is already accepted in https://github.com/melpa/melpa/pull/7427, uses `with-eval-after-load`.~~ [2022/11/14]  This was resolved with https://github.com/Nyoho/consult-hatena-bookmark/commit/b920542d2aa5ec66e862b73f7b2b1a7dd488f2d9

```sh
1 issue found:

230:1: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
```

<!-- After submitting, please fix any problems the CI reports. -->