### PR TITLE
New recipe: org-calibre-notes

### DIFF
--- a/recipes/org-calibre-notes
+++ b/recipes/org-calibre-notes
@@ -1,0 +1,1 @@
+(org-calibre-notes :repo "bpanthi977/org-calibre-notes" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package extract highlights and notes taken in Calibre ebook reader and saves them to a org file.

### Direct link to the package repository

https://github.com/bpanthi977/org-calibre-notes

### Your association with the package

I am the maintainer and creator of this package.

### Relevant communications with the upstream package maintainer

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
