### PR TITLE
Update recipe for ox-qmd

### DIFF
--- a/recipes/ox-qmd
+++ b/recipes/ox-qmd
@@ -1,1 +1,1 @@
-(ox-qmd :fetcher github :repo "0x60df/ox-qmd")
+(ox-qmd :fetcher github :repo "0x60df/ox-qmd" :branch "upload-inline-image")


### PR DESCRIPTION
### Brief summary of what the package does

`ox-qmd` provides org-mode export back-end for [Qiita](https://qiita.com/) flavored markdown,
and this commit specifies the branch which includes the experimentally added auxiliary feature for the package.
The added feature is named as `ox-qmd-upload-inline-image`,
and it provides the commands to upload inline images in org-mode file for Qiita.

### Direct link to the package repository

https://github.com/0x60df/ox-qmd/tree/upload-inline-image

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
