### PR TITLE
Add recipe for h5dump-mode

### DIFF
--- a/recipes/h5dump-mode
+++ b/recipes/h5dump-mode
@@ -1,0 +1,1 @@
+(h5dump-mode :fetcher github :repo "berquist/h5dump-mode")


### PR DESCRIPTION
### Brief summary of what the package does

[h5dump](https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html) is a CLI tool for printing data and attributes from [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) (binary) files.  This is a major mode that enables the ability to use hideshow on `{...}` blocks in the output which are the main structural delimiter, much like JSON maps.  There is also some minimal font locking implemented.  (The output from h5dump is not really code but actually conforms to a [grammar](https://support.hdfgroup.org/HDF5/doc/ddl.html) even though the files themselves aren't used as input for anything or even data transfer, that's what the parent HDF5 file is for.)

### Direct link to the package repository

https://github.com/berquist/h5dump-mode

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
