### PR TITLE
Add recipe for ligature-pragmatapro

### DIFF
--- a/recipes/ligature-pragmatapro
+++ b/recipes/ligature-pragmatapro
@@ -1,0 +1,2 @@
+(ligature-pragmatapro :repo "wavexx/ligature-pragmatapro.el"
+                      :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides pre-baked [ligature](https://github.com/mickeynp/ligature.el) configuration for the [PragmataPro](https://fsd.it/shop/fonts/pragmatapro/) programming font.

### Direct link to the package repository

https://gitlab.com/wavexx/ligature-pragmatapro.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

n/a

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
