### PR TITLE
Include embark-org in embark package

### DIFF
--- a/recipes/embark
+++ b/recipes/embark
@@ -1,3 +1,3 @@
 (embark :repo "oantolin/embark"
         :fetcher github
-        :files ("embark.el" "embark.texi"))
+        :files ("embark.el" "embark-org.el" "embark.texi"))


### PR DESCRIPTION
This PR is a simple change to the MELPA recipe to include the file `embark-org.el` in the embark package.

### Brief summary of what the package does

Embark provides a sort of right-click or contextual menu for Emacs, making it easy to run relevant actions on the current target, which can be a minibuffer completion candidate or the thing at point. The actions offered depend on the type of target, for example, if you are currently in find-file, Embark will offer you actions such as copy-file, delete-file, make-directory, etc. The determination of what the target is and which actions to offer is highly configurable.

This is similar to the notion of actions in the well-known Helm and Ivy packages (though those are limited to acting on minibuffer completion candidates).

### Direct link to the package repository

https://github.com/oantolin/embark

### Your association with the package

I am the author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
