### PR TITLE
Add recipe for move-mode

### DIFF
--- a/recipes/move-mode
+++ b/recipes/move-mode
@@ -1,0 +1,2 @@
+(move-mode :repo "amnn/move-mode"
+           :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for [Move](https://github.com/move-language/move), a smart contract programming language, providing support for syntax, font-lock, indent and fill as well as keybindings to build, test, etc from within Emacs using the compilation buffer.

### Direct link to the package repository

https://github.com/amnn/move-mode

### Your association with the package

Author and maintainer for `move-mode`, contributor to `move-language/move`.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
  - Apache 2.0
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
