### PR TITLE
adding d2-mode recipe

### DIFF
--- a/recipes/d2-mode
+++ b/recipes/d2-mode
@@ -1,0 +1,1 @@
+(d2-mode :repo "andorsk/d2-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for working with d2 graphs

recipe for supporting [d2](https://github.com/terrastruct/d2) directly in emacs. Allows user to compile and render d2 markdown directly in the buffer. 

### Direct link to the package repository

https://github.com/andorsk/d2-mode

### Your association with the package

I am a maintainer and creator of this package. 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

```
 • Building package d2-mode ...
Package: d2-mode
Fetcher: github
Source:  https://github.com/andorsk/d2-mode.git

Cloning https://github.com/andorsk/d2-mode.git to /Users/akmb2/workspace/github.com/andorsk/melpa/working/d2-mode/
Checking out origin/HEAD
Checking out 6c627db165a3c79103d1740dc07c89d77831b412
Built d2-mode in 6.910s, finished at 2022-11-29T21:11:51+0000
 ✓ Success:
16 -rw-r--r--  1 akmb2  staff   7.6K Nov 30 02:41 packages/d2-mode-20221129.2107.el
 8 -rw-r--r--  1 akmb2  staff   395B Nov 30 02:41 packages/d2-mode-20221129.2107.entry
```
<!-- After submitting, please fix any problems the CI reports. -->
