### PR TITLE
Update :repo for evil-cleverparens

### DIFF
--- a/recipes/evil-cleverparens
+++ b/recipes/evil-cleverparens
@@ -1,1 +1,1 @@
-(evil-cleverparens :fetcher github :repo "luxbock/evil-cleverparens")
+(evil-cleverparens :fetcher github :repo "emacs-evil/evil-cleverparens")


### PR DESCRIPTION
@luxbock (previous maintainer of evil-cleverparens) has transferred ownership of the repo to emacs-evil, hence this change.