### PR TITLE
Add recipe to fetch material-ocean-themes.

### DIFF
--- a/recipes/material-ocean-themes
+++ b/recipes/material-ocean-themes
@@ -1,0 +1,3 @@
+(material-ocean-themes
+ :fetcher github
+ :repo "Patrick-Poitras/emacs-material-ocean")


### PR DESCRIPTION
### Brief summary of what the package does

A series of 4 blue themes all based on the VS Code Community Edition Material themes Ocean and Palenight.

### Direct link to the package repository

https://github.com/Patrick-Poitras/

### Your association with the package

I made it!

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
