### PR TITLE
Update repository of guix recipe

### DIFF
--- a/recipes/guix
+++ b/recipes/guix
@@ -1,6 +1,6 @@
 (guix
- :fetcher github
- :repo "alezost/guix.el"
+ :fetcher git
+ :url "https://git.savannah.gnu.org/git/guix/emacs-guix.git"
  :files ("elisp/*.el"
          "doc/*.texi"
          ("images" "images/*.svg")


### PR DESCRIPTION
The development of guix.el at github.com/alezost/guix.el has stopped (last commit 8 Jun 2021) but the package
development has continued at git.savannah.gnu.org/git/guix/emacs-guix.git. The package on github is broken because it depends on geiser-company.el which has been removed from geiser. The updated version at savannah fixes this issue.

### Brief summary of what the package does
This package adds an interface for the guix package manager

### Direct link to the package repository

https://git.savannah.gnu.org/git/guix/emacs-guix.git/

### Your association with the package

I am a new user that found the package broken in it's current state.

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
