### PR TITLE
Add org-incoming

### DIFF
--- a/recipes/org-incoming
+++ b/recipes/org-incoming
@@ -1,0 +1,2 @@
+(org-incoming :fetcher github
+              :repo "tinloaf/org-incoming")


### PR DESCRIPTION
### Brief summary of what the package does

org-incoming is a package to ingest incoming PDFs (e.g. from scanning handwritten notes) into your org (or org-roam) files. It provides an interactive workflow of naming, dating and annotating or transcribing the files.

### Direct link to the package repository

https://github.com/tinloaf/org-incoming

### Your association with the package

I am the maintainer (and author).

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly (**Note**: There are two warnings, one "function used to take X arguments, now takes Y", and one "not known to be defined", which I assume are false positives. I'd be happy to hear how to get rid of them!)
- [x] `M-x checkdoc` is happy with my docstrings (**Note**: Sort of. It keeps complaining about lines longer than 80 characters, but all my lines are below 80 characters.)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
