### PR TITLE
Migrate Alex Griffin's repositories to GitLab

### DIFF
--- a/recipes/edwina
+++ b/recipes/edwina
@@ -1,4 +1,4 @@
 (edwina
- :fetcher github
+ :fetcher gitlab
  :repo "ajgrf/edwina"
  :old-names (edwin))

--- a/recipes/parchment-theme
+++ b/recipes/parchment-theme
@@ -1,3 +1,3 @@
 (parchment-theme
- :fetcher github
+ :fetcher gitlab
  :repo "ajgrf/parchment")


### PR DESCRIPTION
### Brief summary of what the package does

I'm migrating my packages from GitHub to GitLab. There are still mirrors on GitHub but I may remove them in a few months.

### Direct link to the package repository

https://gitlab.com/ajgrf/edwina
https://gitlab.com/ajgrf/parchment

### Your association with the package

I'm the maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
