### PR TITLE
Add elisp-autofmt

### DIFF
--- a/recipes/elisp-autofmt
+++ b/recipes/elisp-autofmt
@@ -1,0 +1,4 @@
+(elisp-autofmt
+  :fetcher codeberg
+  :repo "ideasman42/emacs-elisp-autofmt"
+  :files ("elisp-autofmt.py" "elisp-autofmt.overrides.json"))

--- a/recipes/elisp-autofmt
+++ b/recipes/elisp-autofmt
@@ -1,4 +1,4 @@
 (elisp-autofmt
   :fetcher codeberg
   :repo "ideasman42/emacs-elisp-autofmt"
-  :files ("elisp-autofmt.py" "elisp-autofmt.overrides.json"))
+  :files (:defaults "elisp-autofmt.py" "elisp-autofmt.overrides.json"))


### PR DESCRIPTION
### Brief summary of what the package does

Emacs lisp auto-formatter which can be enabled as a minor mode, reformatting the buffer on save.

- The whole file is formatted (it's parsed and rewritten).
- Excessive overhead is avoided by using `replace-buffer-contents`, so minor re-formatting isn't a heavy operation.
- Definitions are extracted from emacs + packages to guide formatting decisions.
- Definitions can optionally be extracted from relative paths too (for multi-file packages).
- In practice I've found this fast enough that even on large elisp files it's typically between 200ms..400ms.
- Tested with all emacs-lisp files and every melpa package to format the files without changing the resulting byte-code output.
- Already used for most of the packages I maintain on melpa.

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-elisp-autofmt

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
