### PR TITLE
Add 'adwaita-dark-theme' package

### DIFF
--- a/recipes/adwaita-dark-theme
+++ b/recipes/adwaita-dark-theme
@@ -1,0 +1,1 @@
+(adwaita-dark-theme :fetcher gitlab :repo "jessieh/adwaita-dark-theme")


### PR DESCRIPTION
### Brief summary of what the package does

`adwaita-dark-theme` is a dark color scheme that aims to replicate the appearance and colors of GTK4 "libadwaita" applications.

### Direct link to the package repository

https://gitlab.com/jessieh/adwaita-dark-theme

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
