### PR TITLE
Add recipe for dired-rsync-transient

### DIFF
--- a/recipes/dired-rsync
+++ b/recipes/dired-rsync
@@ -1,1 +1,3 @@
-(dired-rsync :repo "stsquad/dired-rsync" :fetcher github)
+(dired-rsync :repo "stsquad/dired-rsync"
+             :fetcher github
+             :files ("dired-rsync.el"))

--- a/recipes/dired-rsync-transient
+++ b/recipes/dired-rsync-transient
@@ -1,0 +1,3 @@
+(dired-rsync-transient :repo "stsquad/dired-rsync"
+                       :fetcher github
+                       :files ("dired-rsync-transient.el"))


### PR DESCRIPTION
This is a useful dired-rsync command but I packaged it as separate file to avoid the extra dependency for the base package. I've also cleaned up the formatting for the dired-rsync recipe and set an explicit file for it as well to avoid pulling in the testing files from the repo.

See: https://github.com/stsquad/dired-rsync/issues/40

### Brief summary of what the package does

Transient version of the dired-rsync command

### Direct link to the package repository

https://github.com/stsquad/dired-rsync/

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

https://github.com/stsquad/dired-rsync/issues/40

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
