### PR TITLE
Citar-Denote (new package)

### DIFF
--- a/recipes/citar-denote
+++ b/recipes/citar-denote
@@ -1,5 +1,2 @@
-(citar-denote
- :fetcher github
- :repo "pprevos/citar-denote"
- :files ("citar-denote.el"))
+(citar-denote :repo "pprevos/citar-denote" :fetcher github)
 

--- a/recipes/citar-denote
+++ b/recipes/citar-denote
@@ -1,0 +1,5 @@
+(citar-denote
+ :fetcher github
+ :repo "pprevos/citar-denote"
+ :files ("citar-denote.el"))
+


### PR DESCRIPTION
### Brief summary of what the package does

Citar-Denote offers integration of Denote with bibliographies, using the Citar package. 

### Direct link to the package repository

https://github.com/pprevos/citar-denote/

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Thanks for considering the package.