### PR TITLE
Add org-ivy-search

### DIFF
--- a/recipes/org-ivy-search
+++ b/recipes/org-ivy-search
@@ -1,0 +1,1 @@
+(org-ivy-search :repo "beacoder/org-ivy-search" :fetcher github)

--- a/recipes/org-searcher
+++ b/recipes/org-searcher
@@ -1,1 +1,0 @@
-(org-searcher :repo "beacoder/org-searcher" :fetcher github)

--- a/recipes/org-searcher
+++ b/recipes/org-searcher
@@ -1,0 +1,1 @@
+(org-searcher :repo "beacoder/org-searcher" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Poor man's full-text search engine over org files powered by ivy.

### Direct link to the package repository

https://github.com/beacoder/org-ivy-search

### Your association with the package

author

### Relevant communications with the upstream package maintainer

N/A

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
