### PR TITLE
Fix the updates template so it works for MELPA Stable.

### DIFF
--- a/html/updates.rss.erb
+++ b/html/updates.rss.erb
@@ -3,11 +3,19 @@
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/"
    xmlns:atom="http://www.w3.org/2005/Atom">
-<% base_url = "https://melpa.org/" %>
+  <%
+    repo_title = "MELPA"
+    base_url = "https://melpa.org"
+
+    if File.absolute_path(__FILE__).include? "html-stable"
+      repo_title = "MELPA Stable"
+      base_url = "https://stable.melpa.org"
+    end
+    %>
   <channel>
-    <title>MELPA package updates</title>
-    <link>https://melpa.org</link>
-    <atom:link href="<%= base_url %>updates.rss" rel="self" type="application/rss+xml" />
+    <title><%= repo_title %> package updates</title>
+    <link><%= base_url %></link>
+    <atom:link href="<%= base_url %>/updates.rss" rel="self" type="application/rss+xml" />
     <language>en-us</language>
     <ttl>40</ttl>
     <description>News about package updates</description>
@@ -31,8 +39,8 @@
         rescue ArgumentError
         package.build_time = Time.now()
         end
-        package.url = "#{base_url}packages/#{pkgname}-#{version}." + (pkgtype == "single" ? "el" : "tar")
-        package.info_url = "#{base_url}#/#{pkgname}"
+        package.url = "#{base_url}/packages/#{pkgname}-#{version}." + (pkgtype == "single" ? "el" : "tar")
+        package.info_url = "#{base_url}/#/#{pkgname}"
         package
       end
       packages.sort_by { |p| p.version }.reverse[0..200].each do |package|

--- a/html/updates.rss.erb
+++ b/html/updates.rss.erb
@@ -11,7 +11,7 @@
       repo_title = "MELPA Stable"
       base_url = "https://stable.melpa.org"
     end
-    %>
+  %>
   <channel>
     <title><%= repo_title %> package updates</title>
     <link><%= base_url %></link>


### PR DESCRIPTION
We detect if we're using melpa stable by looking at the path for the script. This is a bit hacky but a lot of the build stuff is hacky surrounding the stable repo. This should be fine and is better than forking the file and having to maintain two different versions.


Except for some whitespace, the change is a no-op for the main repo.

```
> diff html/updates.rss.before html/updates.rss.after
6c6
<
---
>
```

Stable will now put in the correct URLs.