### PR TITLE
Add recipe for ob-nix

### DIFF
--- a/recipes/ob-nix
+++ b/recipes/ob-nix
@@ -1,0 +1,3 @@
+(ob-nix
+ :fetcher codeberg
+ :repo "theesm/ob-nix")


### PR DESCRIPTION
### Brief summary of what the package does

Simple `nix` support for `org-babel`, so nix source-blocks:

* can be evaluated
* results can be either plain text, json or xml

### Direct link to the package repository

[theesm/ob-nix - Codeberg.org](https://codeberg.org/theesm/ob-nix)

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
