### PR TITLE
Add recipe for elixir-ts-mode and heex-ts-mode

### DIFF
--- a/recipes/elixir-ts-mode
+++ b/recipes/elixir-ts-mode
@@ -1,0 +1,2 @@
+(elixir-ts-mode :repo "wkirschbaum/elixir-ts-mode"
+                :fetcher github)

--- a/recipes/heex-ts-mode
+++ b/recipes/heex-ts-mode
@@ -1,0 +1,2 @@
+(heex-ts-mode :repo "wkirschbaum/heex-ts-mode"
+              :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for Elixir based on tree-sitter. This recipe also contains heex-ts-mode as a dependency for elixir-ts-mode for embedded templating.

### Direct link to the package repository

https://github.com/wkirschbaum/elixir-ts-mode

https://github.com/wkirschbaum/heex-ts-mode

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

As this is a new mode these are some of the discussions with elixir-mode ( existing, non ts- elixir-mode ) contributors: 
https://github.com/elixir-editors/emacs-elixir/pull/496
https://github.com/elixir-editors/emacs-elixir/issues/494
https://github.com/elixir-editors/emacs-elixir/issues/465

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

Comments:
This is a similar submission to https://github.com/melpa/melpa/pull/8336

I am/was unsure about how to deal with elixir-ts-mode and heex-ts-mode as a single package/file. Heex has its own tree-sitter grammar, but is essentially part of elixir. It would make very little sense to split them into two where a user has to knowingly install heex-ts-mode as an optional dependency to ensure elixir-ts-mode functions as expected. It will also be very confusing if there is a heex-ts-mode as heex only exists within the Elixir programming world. heex-ts-mode is a mandatory requirement to elixir-ts-mode at the moment and makes sense to keep it this way. Another issue might be if users of the existing elixir-mode tries to install heex-ts-mode by itself which will probably not work as they expect it to work. 
Given it is not recommended to package two modes together I would like to motivate that this is a special case where it will cause confusion and/or create bad discoverability if it becomes a separate package. I am happy for any feedback regarding this. This will also not be an issue once it gets submitted to emacs core. 

Preparation started for submitting this to emacs core, but it will probably take more than a year before it will be easily available to users so thought it might be worth while to submit this to MELPA in the mean time. 


