### PR TITLE
Add recipe for mpdel-embark

### DIFF
--- a/recipes/mpdel-embark
+++ b/recipes/mpdel-embark
@@ -1,0 +1,1 @@
+(mpdel-embark :fetcher github :repo "mpdel/mpdel-embark")


### PR DESCRIPTION
### Brief summary of what the package does

Summary: Integrate Emacs package mpdel with embark

### Direct link to the package repository

https://github.com/mpdel/mpdel-embark

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->