### PR TITLE
Add recipe for auth-source-gopass

### DIFF
--- a/recipes/auth-source-gopass
+++ b/recipes/auth-source-gopass
@@ -1,0 +1,1 @@
+(auth-source-gopass :fetcher github :repo "triplem/auth-source-gopass")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides [gopass - the team password manager](https://www.gopass.pw/) as an auth-source for emacs. This could be used with packages like eg. smtpmail to provide passwords for the smtp-user. It is a drop-in replacement for the default auth-info source.

### Direct link to the package repository

https://github.com/triplem/auth-source-gopass

### Your association with the package

I am the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
