### PR TITLE
Rename diffsync to diffed

### DIFF
--- a/recipes/diffed
+++ b/recipes/diffed
@@ -1,3 +1,4 @@
 (diffed
  :fetcher github
- :repo "ber-ro/diffed")
+ :repo "ber-ro/diffed"
+ :old-names (diffsync))

--- a/recipes/diffed
+++ b/recipes/diffed
@@ -1,0 +1,3 @@
+(diffed
+ :fetcher github
+ :repo "ber-ro/diffed")

--- a/recipes/diffsync
+++ b/recipes/diffsync
@@ -1,3 +1,0 @@
-(diffsync
- :fetcher github
- :repo "ber-ro/diffsync")


### PR DESCRIPTION
### Brief summary of what the package does

Diffed is for recursive diff like Dired is for ls.

### Direct link to the package repository

https://github.com/ber-ro/diffed

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
