### PR TITLE
Add recipe for ox-rss.

### DIFF
--- a/recipes/ox-rss
+++ b/recipes/ox-rss
@@ -1,0 +1,1 @@
+(ox-rss :fetcher github :repo "benedicthw/ox-rss")


### PR DESCRIPTION
Summary: RSS 2.0 Back-End for Org Export Engine
Link: https://gitlab.com/nsavage/ox-rss
Association: User
Communication: Maintainer notified at
https://gitlab.com/nsavage/ox-rss/-/issues/1

-------

### Brief summary of what the package does

This library implements an RSS 2.0 back-end for Org exporter, based on the
`html' back-end. It requires Emacs 24.1 at least. It provides two commands for
export, depending on the desired output: org-rss-export-as-rss' (temporary
buffer) and org-rss-export-to-rss' (as a ".xml" file).

### Direct link to the package repository

https://gitlab.com/nsavage/ox-rss

### Your association with the package

I am not the maintainer but an enthusiastic user! It used to be part of
org-contrib but was moved to it's own separate repository.

https://git.sr.ht/~bzg/org-contrib/log/release_0.4

I have notified the maintainer of this request for MELPA addition.

https://gitlab.com/nsavage/ox-rss/-/issues/1

I've NOT modified the package in any way for MELPA.

### Relevant communications with the upstream package maintainer

None needed to the best of my knowledge.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

``` shell
ben@BHW-THINKPAD:~/melpa$ make recipes/ox-rss
 • Building package ox-rss ...
Package: ox-rss
Fetcher: gitlab
Source:  https://gitlab.com/nsavage/ox-rss.git

Cloning https://gitlab.com/nsavage/ox-rss.git to /home/ben/melpa/working/ox-rss/
Checking out 80b5001c3d1c10b578d799bd8ff49e9267a2d5ff
Built ox-rss in 1.208s, finished at 2023-01-05T04:43:30+0000
 ✓ Success:
 16K -rw-r--r-- 1 ben ben 15K Jan  4 23:43 packages/ox-rss-20210605.1055.el
4.0K -rw-r--r-- 1 ben ben 345 Jan  4 23:43 packages/ox-rss-20210605.1055.entry
```

<!-- After submitting, please fix any problems the CI reports. -->