### PR TITLE
Update repository for org-zettelkasten

### DIFF
--- a/recipes/org-zettelkasten
+++ b/recipes/org-zettelkasten
@@ -1,1 +1,1 @@
-(org-zettelkasten :repo "ymherklotz/emacs-zettelkasten" :fetcher github :files ("org-zettelkasten.el"))
+(org-zettelkasten :fetcher sourcehut :repo "ymherklotz/org-zettelkasten")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a very simple and minimal implementation of the Zettelkasten method using Org as a base.  I have separated the combined repository as the code is quite separate now and wanted to update the recipe on melpa for it.

### Direct link to the package repository

https://sr.ht/~ymherklotz/org-zettelkasten

### Your association with the package

I'm the maintainer of the project.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

I get the two following issues running melpazoid:

```
209:1: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
210:1: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
```

However, this is a way I've seen [consult add additional functions when some modes are available](https://github.com/minad/consult/blob/98693ed79a270ff52b541ca1e11b2dd856b4bff7/consult.el#L4920).  If there is a more recommended way to do it though I'm happy to update it.
