### PR TITLE
Add recipe for eyebrowse-restore

### DIFF
--- a/recipes/eyebrowse-restore
+++ b/recipes/eyebrowse-restore
@@ -1,0 +1,3 @@
+(eyebrowse-restore
+ :fetcher github
+ :repo "FrostyX/eyebrowse-restore")


### PR DESCRIPTION
MELPA package requested here https://github.com/FrostyX/eyebrowse-restore/issues/4


### Brief summary of what the package does

This package periodically saves all Eyebrowse window configurations for all Emacs frames. Apart from that, a window configuration is saved when closing a frame or manually using `M-x eyebrowse-restore-save-all`. After an Emacs crash, a user can run `M-x eyebrowse-restore` to restore the Eyebrowse window configurations from a backup of their choice.

### Direct link to the package repository

See https://github.com/FrostyX/eyebrowse-restore/

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
