### PR TITLE
Remove poet-client

### DIFF
--- a/recipes/poet-client
+++ b/recipes/poet-client
@@ -1,1 +1,0 @@
-(poet-client :repo "wailo/emacs-poet" :fetcher github)


### PR DESCRIPTION
This is a clean-up. po.et project is no longer active and hence the client is of no use. This PR remove poet-client from melpa repository.