### PR TITLE
Add recipe for protobuf-ts-mode

### DIFF
--- a/recipes/protobuf-ts-mode
+++ b/recipes/protobuf-ts-mode
@@ -1,0 +1,1 @@
+(protobuf-ts-mode :fetcher git :url "https://git.ookami.one/cgit/protobuf-ts-mode")


### PR DESCRIPTION
### Brief summary of what the package does

tree-sitter support for Protocol Buffers

### Direct link to the package repository

https://git.ookami.one/cgit/protobuf-ts-mode

### Your association with the package

I'm the author of the package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
