### PR TITLE
added recipe for sticky-shell

### DIFF
--- a/recipes/sticky-shell
+++ b/recipes/sticky-shell
@@ -1,0 +1,1 @@
+(sticky-shell :repo "andyjda/sticky-shell" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Helps keeping track of the previous prompt in a shell, by creating a "sticky" header displaying the prompt at the top of the buffer.

### Direct link to the package repository

https://github.com/andyjda/sticky-shell

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

