### PR TITLE
Org habit stats

### DIFF
--- a/recipes/org-habit-stats
+++ b/recipes/org-habit-stats
@@ -1,0 +1,3 @@
+(org-habit-stats :repo "ml729/org-habit-stats"
+                 :fetcher github
+                 :files ("org-habit-stats.el"))

--- a/recipes/org-habit-stats
+++ b/recipes/org-habit-stats
@@ -1,3 +1,1 @@
-(org-habit-stats :repo "ml729/org-habit-stats"
-                 :fetcher github
-                 :files ("org-habit-stats.el"))
+(org-habit-stats :repo "ml729/org-habit-stats" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

View statistics, a calendar, and bar graphs of your org-habits in Emacs org-mode.

### Direct link to the package repository

https://github.com/ml729/org-habit-stats

### Your association with the package

Author, maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
