### PR TITLE
Add recipe for file-info

### DIFF
--- a/recipes/file-info
+++ b/recipes/file-info
@@ -1,0 +1,1 @@
+(file-info :repo "Artawower/file-info.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package provides the ability to display and copy information (e.g. file directory, file contributors, commit hash, remote repo, etc.) about the current opened file in a pretty styled buffer 

### Direct link to the package repository

https://github.com/artawower/file-info.el

### Your association with the package

I am the author of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
