### PR TITLE
Add recipe for treesit-auto

### DIFF
--- a/recipes/treesit-auto
+++ b/recipes/treesit-auto
@@ -1,0 +1,3 @@
+(treesit-auto
+ :fetcher github
+ :repo "renzmann/treesit-auto")


### PR DESCRIPTION
### Brief summary of what the package does

Adds a function `treesit-auto-apply-remap`, which enables Emacs to check for installed tree-sitter grammars, and automatically choose between the tree-sitter enhanced major mode and a default fallback.  For instance, if I have the Python tree-sitter grammar installed, Emacs will load `python-ts-mode` when I go to a Python buffer.  If I do *not* have the grammar installed, Emacs will instead use `python-mode`.

### Direct link to the package repository

https://github.com/renzmann/treesit-auto

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

In regards to package-lint: this package is designed for Emacs 29, so it rightfully complains that this package will not work on any currently released Emacs version.