### PR TITLE
Remove .dir-locals.el from packages

### DIFF
--- a/recipes/ess
+++ b/recipes/ess
@@ -1,7 +1,7 @@
 (ess
  :repo "emacs-ess/ESS"
  :fetcher github
- :files ("*.el" "lisp/*.el"
+ :files ("lisp/*.el"
          "doc/ess.texi"
          ("etc" "etc/*")
          ("obsolete" "lisp/obsolete/*")

--- a/recipes/irony
+++ b/recipes/irony
@@ -1,4 +1,3 @@
 (irony :fetcher github
        :repo "Sarcasm/irony-mode"
-       :files ("*.el" "server"
-               (:exclude ".dir-locals.el")))
+       :files (:defaults "server"))

--- a/recipes/irony
+++ b/recipes/irony
@@ -1,3 +1,4 @@
 (irony :fetcher github
        :repo "Sarcasm/irony-mode"
-       :files ("*.el" "server"))
+       :files ("*.el" "server"
+               (:exclude ".dir-locals.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Remove `.dir-locals.el` from packages.

### Direct link to the package repository

- https://github.com/emacs-ess/ESS
- https://github.com/Sarcasm/irony-mode

### Your association with the package

I'm just a user of these packages.

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
  - But it doesn't talk about fixing the recipe.
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
  - I'm not touching .el
- [x] `M-x checkdoc` is happy with my docstrings
  - I'm not touching .el
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

I've also checked the contents of the package by running the following command
```
git checkout origin/master
make ess
tar --to-command=md5sum -xvf packages/ess-20221204.1348.tar | grep -v /$ | paste - - > old
git checkout yashi/remove-dir-locals-from-packages
make ess
tar --to-command=md5sum -xvf packages/ess-20221204.1348.tar | grep -v /$ | paste - - > new
diff -u old new
```
And these are the output
```diff
diff -u old new
--- old	2023-01-26 18:08:39.704212243 +0900
+++ new	2023-01-26 18:09:05.676501247 +0900
@@ -1,4 +1,3 @@
-ess-20221204.1348/.dir-locals.el	c79df97c8c197d00772f819ac3eb159d  -
 ess-20221204.1348/dir	24bd008c418f42fb4d6705c6a4e1fcb1  -
 ess-20221204.1348/ess-bugs-d.el	ffe0c6ffa5b25acc23132490b83b1c39  -
 ess-20221204.1348/ess-bugs-l.el	1b8bbcf9a7d0d6795e7d5584b6f01725  -
```

```diff
diff -u old new                                                                                                    ─╯
--- old	2023-01-26 18:13:25.603310108 +0900
+++ new	2023-01-26 18:13:41.531478187 +0900
@@ -1,4 +1,3 @@
-irony-20220110.849/.dir-locals.el	e94c67ea753fee672831bea79746e1b1  -
 irony-20220110.849/irony-cdb-clang-complete.el	570d26c7c25e2cc8fca035f2291326fe  -
 irony-20220110.849/irony-cdb-json.el	45290e533e521a52692a3839990f47a2  -
 irony-20220110.849/irony-cdb-libclang.el	33c3c7644443eb98dee8d8a7f4f719d4  -
```
<!-- After submitting, please fix any problems the CI reports. -->
