### PR TITLE
Add recipe for flymake-cspell

### DIFF
--- a/recipes/flymake-cspell
+++ b/recipes/flymake-cspell
@@ -1,0 +1,1 @@
+(flymake-cspell :fetcher github :repo "fritzgrabo/flymake-cspell")


### PR DESCRIPTION
### Brief summary of what the package does

A Flymake backend for [CSpell – A Spell Checker for Code!](https://cspell.org/) by [Street Side Software](https://streetsidesoftware.com/). ❤️

From a developer's perspective, it's a pretty regular Flymake backend that calls `cspell` with the checked buffer's contents, then parses the output into Flymake diagnostics. There are a few complications related to applying exclusion lists in CSpell's configuration files, but nothing crazy really.

### Direct link to the package repository

https://github.com/fritzgrabo/flymake-cspell

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Thank you!