### PR TITLE
Add all-the-icons-nerd-fonts

### DIFF
--- a/recipes/all-the-icons-nerd-fonts
+++ b/recipes/all-the-icons-nerd-fonts
@@ -1,1 +1,1 @@
-(all-the-icons-nerd-fonts :host github :repo "mohkale/all-the-icons-nerd-fonts")
+(all-the-icons-nerd-fonts :fetcher github :repo "mohkale/all-the-icons-nerd-fonts")

--- a/recipes/all-the-icons-nerd-fonts
+++ b/recipes/all-the-icons-nerd-fonts
@@ -1,0 +1,1 @@
+(all-the-icons-nerd-fonts :host github :repo "mohkale/all-the-icons-nerd-fonts")


### PR DESCRIPTION
### Brief summary of what the package does

Adds compatibility between [all-the-icons][ati] and [nerd-fonts][nf]

[ati]: https://github.com/domtronn/all-the-icons.el 
[nf]: https://github.com/twlz0ne/nerd-fonts.el

### Direct link to the package repository

https://github.com/mohkale/all-the-icons-nerd-fonts

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

Note: I'm keeping MELPA related changes in a feature branch until this PR is approved after which I'll merge them in. Please review [this branch](https://github.com/mohkale/all-the-icons-nerd-fonts/pull/2) instead of the head of the linked repo.