### PR TITLE
change repo to gitlab

### DIFF
--- a/recipes/aria2
+++ b/recipes/aria2
@@ -1,2 +1,2 @@
-(aria2 :fetcher gitlab
+(aria2 :fetcher github
        :repo "ukaszg/aria2")


### PR DESCRIPTION
### Brief summary of what the package does

aria2 changing repo since I switched to github

### Direct link to the package repository

https://github.com/ukaszg/aria2

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
