### PR TITLE
Add recipe for verilog-ext

### DIFF
--- a/recipes/verilog-ext
+++ b/recipes/verilog-ext
@@ -1,0 +1,3 @@
+(verilog-ext :fetcher github
+             :repo "gmlarumbe/verilog-ext"
+             :files ("verilog-ext.el" "snippets"))


### PR DESCRIPTION
### Brief summary of what the package does

SystemVerilog Extensions for Emacs.

### Direct link to the package repository

https://github.com/gmlarumbe/verilog-ext/

### Your association with the package

Author/maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

