### PR TITLE
feat: adds new package: magit-stats

### DIFF
--- a/recipes/magit-stats
+++ b/recipes/magit-stats
@@ -1,0 +1,4 @@
+(magit-stats
+  :repo "LionyxML/magit-stats"
+  :fetcher github
+  :files ("magit-stats.el"))

--- a/recipes/magit-stats
+++ b/recipes/magit-stats
@@ -1,4 +1,3 @@
 (magit-stats
   :repo "LionyxML/magit-stats"
-  :fetcher github
-  :files ("magit-stats.el"))
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
A package that generates a Repository Statistics Report (git) from inside Emacs.

You call `magit-stats` when inside a file inside a git folder and you're presented with some options:
- An HTML report rendered by shr on its own buffer
- An HTML report saved as an html file and opened with the OS default browser
- An JSON report output to it's own buffer

This package is actually a "wrapper" for a cli tool (written in NodeJS) with the same name hosted on npm registry: https://www.npmjs.com/package/magit-stats.

Here's an image of it in action: 
![image](https://user-images.githubusercontent.com/16169950/217370324-aee24ce2-3914-4832-837a-44612f573edd.png)


### Direct link to the package repository

https://github.com/LionyxML/magit-stats

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

This package, as said above, is a wrapper for a cli tool. It needs the executable `npx` that automatically "downloads" and runs a binary from the Npm registry. This is a very common pratice on the NodeJS world. If your machine have nodeJS (node@latest and npm@latest) you probably have npx installed, if not, it will be necessary, more info: https://www.npmjs.com/package/npx

This project is the result from an idea shared with @tarsius, that may be found here: https://github.com/magit/magit/discussions/4846. I hope he is OK with the package name :) 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
