### PR TITLE
Add recipe for emacs tardis theme

### DIFF
--- a/recipes/tardis-theme
+++ b/recipes/tardis-theme
@@ -1,0 +1,1 @@
+(tardis-theme :fetcher github :repo "antonhibl/tardis-theme")

--- a/recipes/tardis-theme
+++ b/recipes/tardis-theme
@@ -1,1 +1,2 @@
 (tardis-theme :fetcher github :repo "antonhibl/tardis-theme")
+;;

--- a/recipes/tardis-theme
+++ b/recipes/tardis-theme
@@ -1,2 +1,1 @@
 (tardis-theme :fetcher github :repo "antonhibl/tardis-theme")
-;;

--- a/recipes/tardis-theme
+++ b/recipes/tardis-theme
@@ -1,1 +1,2 @@
 (tardis-theme :fetcher github :repo "antonhibl/tardis-theme")
+    ;;

--- a/recipes/tardis-theme
+++ b/recipes/tardis-theme
@@ -1,2 +1,1 @@
 (tardis-theme :fetcher github :repo "antonhibl/tardis-theme")
-    ;;


### PR DESCRIPTION
### Brief summary of what the package does

The Tardis theme brings a clean off-white background to purple and black text for a clean light theme for Emacs.

### Direct link to the package repository

https://github.com/antonhibl/tardis-theme

### Your association with the package

Owner and Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
