### PR TITLE
Add all files in the ekg package

### DIFF
--- a/recipes/ekg
+++ b/recipes/ekg
@@ -1,4 +1,3 @@
 (ekg
  :fetcher github
- :repo "ahyatt/ekg"
- :files ("ekg.el"))
+ :repo "ahyatt/ekg")


### PR DESCRIPTION
The initial reason for restricting this to just ekg.el, was to not have to have a dependency on org-roam.  However, it makes sense to include ekg-org-roam.el even though we don't declare that dependency, because ekg-org-roam.el has no use without org-roam itself.

See discussion in https://github.com/melpa/melpa/pull/8394# for context.  If this is merged, I will remove the other pull request.
