### PR TITLE
add recipe for inspire

### DIFF
--- a/recipes/inspire
+++ b/recipes/inspire
@@ -1,0 +1,1 @@
+(inspire :fetcher github :repo "Simon-Lin/inspire.el")


### PR DESCRIPTION
### Brief summary of what the package does

inspire is an Emacs interface for literature and references searching on the high energy article database [inspirehep](https://inspirehep.net/).

### Direct link to the package repository

https://github.com/Simon-Lin/inspire.el

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

 **None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Some false-positives:

- with `package-lint`:
596:3: error: `authors` was removed in Emacs version 25.1.
987:16: error: `authors` was removed in Emacs version 25.1.
1038:10: error: `authors` was removed in Emacs version 25.1.
`authors` is a custom variable name used here.

- with `byte-compile`:
inspire.el:881:6: Warning: `inspire--insert-with-face` called with 1 argument, but requires 2+
I am not sure why I got this warning but the function is indeed called with 2 arguments, so I assume this is some bug in the compiler?

