### PR TITLE
Add recipe for compile-multi

### DIFF
--- a/recipes/compile-multi
+++ b/recipes/compile-multi
@@ -1,0 +1,1 @@
+(compile-multi :fetcher github :repo "mohkale/compile-multi")


### PR DESCRIPTION
### Brief summary of what the package does

An emacs [multi-compile](https://github.com/ReanGD/emacs-multi-compile) style package that uses a more lisp style configuration and supports dynamically plugging in compilation targets from external tools which also makes it usable as a replacement for [helm-make](https://github.com/abo-abo/helm-make).

I'm about to release a new projectile replacement package I've called [projector](https://github.com/mohkale/projector) (will rename to avoid conflict) and it makes use of this as a dependency.

### Direct link to the package repository

https://github.com/mohkale/compile-multi

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
