### PR TITLE
added recipe for miri.el

### DIFF
--- a/recipes/miri
+++ b/recipes/miri
@@ -1,0 +1,3 @@
+(miri
+ :fetcher codeberg
+ :repo "theesm/miri.el")


### PR DESCRIPTION
### Brief summary of what the package does

[miri.el](https://codeberg.org/theesm/miri.el) provides functionality to search/list a shell history provided by the rust program [ellie/atuin](https://github.com/ellie/atuin). It also provides a quick way to open atuins sqlite database in `sql-mode`.

### Direct link to the package repository

https://codeberg.org/theesm/miri.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
