### PR TITLE
jeison: Take ownership and publish new release

### DIFF
--- a/recipes/jeison
+++ b/recipes/jeison
@@ -1,3 +1,3 @@
 (jeison
- :repo "SavchenkoValeriy/jeison"
+ :repo "bscottm/jeison"
  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

jeison transforms a parsed JSON stream (or `alist`) into EIEIO objects, lists, vectors and hash tables. Easier JSON traversal by navigating structures.

### Direct link to the package repository

https://github.com/bscottm/jeison

### Your association with the package

Enthusiastic user posing as a future maintainer.

### Relevant communications with the upstream package maintainer

Three year old merge request in the original maintainer's repo sitting unprocessed (https://github.com/SavchenkoValeriy/jeison/pulls). Added recent comments to the pull, no response from original maintainer. (@SavchenkoValeriy)

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

NOTE: `package-lint` notes:

```
76:9: error: You should depend on (emacs "27.1") if you need `json-parse-string'.
81:13: error: You should depend on (emacs "27.1") if you need `json-parse-buffer'.
```

These are non-errors. The code looks for whether `json-available-p` is `fboundp`, so there isn't a strict dependency on emacs 27.1.
<!-- After submitting, please fix any problems the CI reports. -->
