### PR TITLE
Add `no-clown-fiesta-theme` recipe

### DIFF
--- a/recipes/no-clown-fiesta-theme
+++ b/recipes/no-clown-fiesta-theme
@@ -1,0 +1,2 @@
+(no-clown-fiesta-theme :repo "ranmaru22/no-clown-fiesta-theme.el"
+                       :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A not-so-colorful theme for Emacs. Based on the [Neovim theme of the same name](https://github.com/aktersnurra/no-clown-fiesta.nvim) by aktersnurra. Comes with out-of-the-box support for a few common packages and an optional accompanying Treemacs theme.

### Direct link to the package repository

https://github.com/ranmaru22/no-clown-fiesta-theme.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
