### PR TITLE
Add pd-remote

### DIFF
--- a/recipes/pd-remote
+++ b/recipes/pd-remote
@@ -1,0 +1,1 @@
+(pd-remote :repo "agraef/pd-remote" :fetcher github)


### PR DESCRIPTION
pd-remote utility for Emacs->Pd communication

### Brief summary of what the package does

Talks to the pd-remote.pd abstraction in order to send messages from Emacs to Pd, e.g., to compile stuff in Pd, enable/disable DSP mode in Pd, etc.

### Direct link to the package repository

https://github.com/agraef/pd-remote

### Your association with the package

Author and Maintainer, cf. https://agraef.github.io/

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
