### PR TITLE
Update `display-wttr` source URL

### DIFF
--- a/recipes/display-wttr
+++ b/recipes/display-wttr
@@ -1,3 +1,3 @@
 (display-wttr
- :fetcher github
+ :fetcher sourcehut
  :repo "josegpt/display-wttr")


### PR DESCRIPTION
### Brief summary of what the package does

Display wttr(weather) in the mode line.

### Direct link to the package repository

https://git.sr.ht/~josegpt/display-wttr

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
