### PR TITLE
Add emacsql-sqlite-common.el to emacsql-sqlite family of packages

### DIFF
--- a/recipes/emacsql-sqlite
+++ b/recipes/emacsql-sqlite
@@ -1,4 +1,4 @@
 (emacsql-sqlite
  :fetcher github
  :repo "magit/emacsql"
- :files ("emacsql-sqlite.el" "sqlite"))
+ :files ("emacsql-sqlite.el" "emacsql-sqlite-common.el" "sqlite"))

--- a/recipes/emacsql-sqlite-builtin
+++ b/recipes/emacsql-sqlite-builtin
@@ -1,4 +1,4 @@
 (emacsql-sqlite-builtin
  :fetcher github
  :repo "magit/emacsql"
- :files ("emacsql-sqlite-builtin.el"))
+ :files ("emacsql-sqlite-builtin.el" "emacsql-sqlite-common.el"))

--- a/recipes/emacsql-sqlite-module
+++ b/recipes/emacsql-sqlite-module
@@ -1,5 +1,5 @@
 (emacsql-sqlite-module
  :fetcher github
  :repo "magit/emacsql"
- :files ("emacsql-sqlite-module.el")
+ :files ("emacsql-sqlite-common.el" "emacsql-sqlite-module.el")
  :old-names (emacsql-libsqlite3))


### PR DESCRIPTION
-------
The Straight package manager did not appear to produce emacsql-sqlite-common.elc in the `straight/build/emacsql-sqlite` directory without this change to the recipe.

cc @tarsius