### PR TITLE
Add recipe for electric-ospl

### DIFF
--- a/recipes/electric-ospl
+++ b/recipes/electric-ospl
@@ -1,0 +1,3 @@
+(electric-ospl
+ :fetcher sourcehut
+ :repo "swflint/electric-ospl-mode")


### PR DESCRIPTION
### Brief summary of what the package does

electric-ospl provides a minor mode with an "electric" space to ensure that a one-sentence-per-line style is followed in prose.

### Direct link to the package repository

https://git.sr.ht/~swflint/electric-ospl-mode

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
