### PR TITLE
Move dired-single to a new repository

### DIFF
--- a/recipes/dired-single
+++ b/recipes/dired-single
@@ -1,1 +1,1 @@
-(dired-single :fetcher github :repo "crocket/dired-single")
+(dired-single :fetcher codeberg :repo "amano.kenji/dired-single")


### PR DESCRIPTION
### Direct link to the package repository

https://codeberg.org/amano.kenji/dired-single

### Your association with the package

I'm the new maintainer.

### Relevant communications with the upstream package maintainer

The management for the package has been transferred.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)