### PR TITLE
Add recipe for org-ai

### DIFF
--- a/recipes/org-ai
+++ b/recipes/org-ai
@@ -1,0 +1,1 @@
+(org-ai :fetcher github :repo "rksm/org-ai")


### PR DESCRIPTION
### Brief summary of what the package does

Minor mode for Emacs org-mode that provides access to OpenAI API's.
Inside an org-mode buffer you can use ChatGPT to generate text or DALL-E to generate images.

### Direct link to the package repository

https://github.com/rksm/org-ai

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
