### PR TITLE
Add recipe for ruff-flymake

### DIFF
--- a/recipes/ruff-flymake
+++ b/recipes/ruff-flymake
@@ -1,0 +1,3 @@
+(ruff-flymake
+ :repo "cjfuller/ruff-flymake"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This is a flymake backend for the python linter [ruff](https://github.com/charliermarsh/ruff). While ruff itself technically supports emacs via the language server protocol, a dedicated flymake backend allows you to run a primary language server in eglot that provides more than just lint suggestions while still seeing feedback from ruff. Ruff itself is an extremely fast linter that combines rules from a number of python linters into one tool.

### Direct link to the package repository

https://github.com/cjfuller/ruff-flymake

### Your association with the package

I am the author / maintainer.

### Relevant communications with the upstream package maintainer

**None needed.**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
