### PR TITLE
Add recipe for time-uuid-mode

### DIFF
--- a/recipes/time-uuid-mode
+++ b/recipes/time-uuid-mode
@@ -1,0 +1,2 @@
+(time-uuid-mode :fetcher github
+          :repo "RobertPlant/time-uuid-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Convert time UUIDs (v1) into the date time, adds an overlay triggerable via function or via a minor mode finding all v1 UUIDS to convert

### Direct link to the package repository

https://github.com/RobertPlant/time-uuid-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
