### PR TITLE
Add recipe for ob-d2

### DIFF
--- a/recipes/ob-d2
+++ b/recipes/ob-d2
@@ -1,0 +1,3 @@
+(ob-d2
+ :repo "xcapaldi/ob-d2"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

`ob-d2` enables [Org-Babel](http://orgmode.org/worg/org-contrib/babel/intro.html) support for evaluating [D2](https://d2lang.com/tour/intro/) code. It was created based on the usage of [ob-ditaa](https://orgmode.org/worg//org-contrib/babel/languages/ob-doc-ditaa.html). The D2 code is compiled via the `d2` command.

### Direct link to the package repository

[https://github.com/xcapaldi/ob-d2](https://github.com/xcapaldi/ob-d2)

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)