### PR TITLE
use main branch for magit and forge recipes

### DIFF
--- a/recipes/forge
+++ b/recipes/forge
@@ -1,1 +1,1 @@
-(forge :fetcher github :repo "magit/forge")
+(forge :fetcher github :repo "magit/forge" :branch "main")

--- a/recipes/magit
+++ b/recipes/magit
@@ -1,5 +1,6 @@
 (magit :fetcher github
        :repo "magit/magit"
+       :branch "main"
        :files ("lisp/magit"
                "lisp/magit*.el"
                "lisp/git-rebase.el"


### PR DESCRIPTION
Magit has been using "main" branch instead of master for a few months. As a result, magit doesn't get updated when using straight.el. Same fix for el-get already exists: https://github.com/dimitri/el-get/blob/master/recipes/magit.rcp.

cc @tarsius 