### PR TITLE
Update recipe for org-noter

### DIFF
--- a/recipes/org-noter
+++ b/recipes/org-noter
@@ -1,5 +1,4 @@
 (org-noter :fetcher github
            :repo "org-noter/org-noter"
-           :branch "master"
            :files ("*.el" "modules"
                   (:exclude "*-test-utils.el" "*-devel.el")))

--- a/recipes/org-noter
+++ b/recipes/org-noter
@@ -1,1 +1,5 @@
-(org-noter :fetcher github :repo "weirdNox/org-noter")
+(org-noter :fetcher github
+           :repo "org-noter/org-noter"
+           :branch "master"
+           :files ("*.el" "modules"
+                  (:exclude "*-test-utils.el" "*-devel.el")))


### PR DESCRIPTION
new maintainers (issue #8413)

### Brief summary of what the package does

Interleave-style document annotator.  Notes taken on (pdf, epub, djvu)-format files are kept externally in an Org file with links back to the original document.

### Direct link to the package repository

https://github.com/org-noter/org-noter

### Your association with the package

@dmitrym0 and I requested in issue #8413 to take over maintenance of this package.

### Relevant communications with the upstream package maintainer

See [weirdNox/org-noter issue #173](https://github.com/weirdNox/org-noter/issues/173).  Original author has not responded to communications.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Remaining `flycheck` warnings are inherited missing documentation.

<!-- After submitting, please fix any problems the CI reports. -->
