### PR TITLE
package-build/package-recipe-mode.el: put `whitespace-cleanup' on local `before-save-hook'

### DIFF
--- a/package-build/package-recipe-mode.el
+++ b/package-build/package-recipe-mode.el
@@ -59,7 +59,7 @@
   (setq-local flycheck-checkers nil)
   (setq-local indent-tabs-mode nil)
   (setq-local require-final-newline t)
-  (add-hook 'before-save-hook #'whitespace-cleanup)
+  (add-hook 'before-save-hook #'whitespace-cleanup nil t)
   (message "%s" (substitute-command-keys "\
 Use \\[package-build-current-recipe] to build this recipe, \
 \\[package-build-create-recipe] to create a new recipe")))


### PR DESCRIPTION
After editing a recipe in a melpa repository, this one caught me by surprise, when all of a sudden various precariously formatted files came up mangled. It did take me a while to notice and then another while to find the cause of the problem. Therefore, I think it is a better idea to put this on the local `before-save-hook'.

Disclaimer: This pull request is meant to illustrate a problem without uttering a plethora of words. It is not meant to be the ultimate solution to a problem and the pull request can certainly be ignored, if there is a better way.