### PR TITLE
package-build/package-build.el: package-build--get-timestamp-version (hg)

### DIFF
--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -237,9 +237,10 @@ Otherwise do nothing.  FORMAT-STRING and ARGS are as per that function."
                      ;; "hgdate" because that makes it easier to discard
                      ;; the time zone offset, which doesn't interest us.
                      "hg" "log" "--limit" "1"
-                     "--template" "{node} {date|hgdate}\n" "--rev" rev
-                     (and (not exact)
-                          (cons "--" (package-build--spec-globs rcp)))))
+                     "--template" "{node} {date|hgdate}\n"
+                     (or (and rev (list "--rev" rev))
+                         (and (not exact)
+                              (cons "--" (package-build--spec-globs rcp))))))
          " ")))
     (list hash (string-to-number time))))
 
@@ -298,9 +299,9 @@ Otherwise do nothing.  FORMAT-STRING and ARGS are as per that function."
       (list rev-hash rev-time))))
 
 (cl-defmethod package-build--get-timestamp-version ((rcp package-hg-recipe))
-  ;; TODO Respect commit and branch properties.
-  ;; TODO Use latest release if appropriate.
-  (package-build--select-commit rcp "." nil))
+  ;; TODO Respect branch property.
+  (let ((commit (oref rcp commit)))
+    (package-build--select-commit rcp commit nil)))
 
 ;;; Run Process
 


### PR DESCRIPTION
# fix empty timestamp problem, respect commit property

The problem with

``` sh
hg log --limit 1  --rev . -- --include glob:file.el
```

is that it results in an empty string, if the referenced revision does
not contain a commit for any of the specified files.

Disclaimer: This pull request is meant to illustrate a problem without uttering a plethora of words (which I still do). It is not meant to be the ultimate solution to a problem and the pull request can certainly be ignored, if there is a better way.

According to the documentation, "." is a special name, relating to the
state of the working directory

> The reserved name "." indicates the working directory parent. If no
> working directory is checked out, it is equivalent to null. If an
> uncommitted merge is in progress, "." is the revision of the first
> parent.

So IMHO using it for the purpose of a deterministic revision
identification is a really bad idea.

Especially, since it defaults to null without a working directory, which
automatically results in a 0 timestamp in all cases with a glob pattern,
since revision null never contains any commits at all.

Even specifying \`tip' with a glob pattern results in a blank line, if
the latest revision does not contain a commit for the matched files.

Therefore, no revision should be specified at all, if a glob pattern is
given.

When a specific revision is referenced, the glob pattern does not change
the outcome, since any given commit in the revision has the same
timestamp anyway. However, if the glob pattern does not match any file
commit in the revision, again a blank line is delivered.

``` sh
(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev null )
0000000000000000000000000000000000000000 0 0

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev null -- --include glob:dist-selpa.sh --include glob:README.txt )
<BLANKLINE>

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev tip -- --include glob:dist-selpa.sh --include glob:README.txt )
e4c502bddd4fcf14776b5ebd43c69a5b30974de3 1679001444 -3600

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev tip -- --include glob:README.txt )
<BLANKLINE>

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' -- --include glob:dist-selpa.sh --include glob:README.txt )
e4c502bddd4fcf14776b5ebd43c69a5b30974de3 1679001444 -3600

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' -- --include glob:README.txt )
53fb5b8676e62339ee68137f888a77220aad6ccc 1678853918 -3600

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev 53fb5b8676e6 -- --include glob:dist-selpa.sh )
<BLANKLINE>

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev 53fb5b8676e6 )
53fb5b8676e62339ee68137f888a77220aad6ccc 1678853918 -3600
```

Based on these findings, the algorithm implemented does the following in
the given order:

1.  In *package-build--get-timestamp-version (hg)* pass on *commit*
    property to `package-build--select-commit
    (hg)`
2.  in *package-build--select-commit*, use option \`--rev' only, when
    the *rev* parameter is not nil.
3.  Otherwise, get the timestamp for the latest commit containing one of
    the supplied glob patterns.
4.  If there is no glob pattern appended, the latest timestamp for the
    repository is obtained.
