### PR TITLE
add recipe for colors

### DIFF
--- a/recipes/colors
+++ b/recipes/colors
@@ -1,0 +1,1 @@
+(colors :fetcher github :repo "galdor/colors")


### PR DESCRIPTION
### Brief summary of what the package does

_[Copied from the readme]_

`colors` is a small Emacs Lisp package providing arious functions to manipulate colors.

While Emacs contains a builtin `color` package, it has several shortcomings:

- Functions are hard to combine because colors are usually returned as lists
  but passed as separate arguments.
- The representation of RGB color components as floating point values between
  0.0 and 1.0 is unusual and annoying to work with.
- There is no support for HSL color strings.
- Results are not what you would expect. For example converting `#cc241d` to
  HSL yields a hue of 0.006666666666666636 (e.g. 0°) instead of 2°.
  
The `colors` package aims to be easier to use.

### Direct link to the package repository

https://github.com/galdor/colors

### Your association with the package

I'm the author and the maintainer of the package.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings¹
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

[1] checkdoc signals 4 false positive diagnostics because it does not recognize that "color" can be used as a name which does not refer to the `color` argument.

<!-- After submitting, please fix any problems the CI reports. -->
