### PR TITLE
Remove recipe for "autocrypt"

### DIFF
--- a/recipes/autocrypt
+++ b/recipes/autocrypt
@@ -1,1 +1,0 @@
-(autocrypt :fetcher sourcehut :repo "pkal/autocrypt")


### PR DESCRIPTION
I'd like to move the package to GNU ELPA.