### PR TITLE
org-ai: add snippets directory

### DIFF
--- a/recipes/org-ai
+++ b/recipes/org-ai
@@ -1,1 +1,3 @@
-(org-ai :fetcher github :repo "rksm/org-ai")
+(org-ai :fetcher github
+        :repo "rksm/org-ai"
+        :files (:defaults "snippets"))


### PR DESCRIPTION
### Brief summary of what the package does

Minor mode for Emacs org-mode that provides access to OpenAI API's. 

This MR adds a snippet directory addresses https://github.com/rksm/org-ai/issues/14

### Direct link to the package repository

https://github.com/rksm/org-ai/

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
