### PR TITLE
Relax language around checkdoc conventions per #8450

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ https://github.com/your/awesome_package
 - [] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
 - [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 - [] My elisp byte-compiles cleanly
-- [] `M-x checkdoc` is happy with my docstrings
+- [] I've used `M-x checkdoc` to check the package's documentation strings
 - [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
 
 <!-- After submitting, please fix any problems the CI reports. -->

--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -114,7 +114,7 @@ will delay the process.
 - Use quality-checking tools :: Use [[https://melpa.org/#/flycheck][flycheck]], [[https://github.com/purcell/package-lint][package-lint]] and
      [[https://github.com/purcell/flycheck-package][flycheck-package]] to help you identify common errors in your
      package metadata. Use [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html][checkdoc]] to make sure that your package
-     follows the conventions for documentation strings.
+     follows the conventions for documentation strings, within reason.
 
 - Avoid long functions :: The longer a function the harder it is for a
      MELPA maintainer to understand what is happening and to give


### PR DESCRIPTION
Follows the discussion in #8450.  I think some very minor rephrasing is all that's really needed.