### PR TITLE
Jinx: Ensure that C files are included

### DIFF
--- a/recipes/jinx
+++ b/recipes/jinx
@@ -1,3 +1,4 @@
 (jinx
  :repo "minad/jinx"
+ :files (:defaults "jinx-mod.c" "emacs-module.h")
  :fetcher github)


### PR DESCRIPTION
This is a follow up on #8460. Unfortunately the files jinx-mod.c and emacs-module.h are not part of the package. See https://github.com/minad/jinx/issues/3. Sorry for overlooking this. I had falsely assumed that MELPA includes these files by default.

cc @riscy @tarsius