### PR TITLE
Install newly-added snippets along with abs-mode

### DIFF
--- a/recipes/abs-mode
+++ b/recipes/abs-mode
@@ -1,3 +1,3 @@
 (abs-mode :repo "abstools/abs-mode"
           :fetcher github
-          :files ("abs-mode.el"))
+          :files ("abs-mode.el" "snippets"))


### PR DESCRIPTION
- Install the new subdirectory `snippets/` along with `abs-mode.el`

### Brief summary of what the package does

This is a modification to the existing abs-mode package.  The upstream version adds yasnippet support and installs some predefined snippets; adapt the recipe to include the `snippets/` directory in the melpa package.

### Direct link to the package repository

https://github.com/abstools/abs-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
