### PR TITLE
add recipe for emacs-nerd-icons

### DIFF
--- a/recipes/emacs-nerd-icons
+++ b/recipes/emacs-nerd-icons
@@ -1,0 +1,4 @@
+(emacs-nerd-icons
+ :repo "rainstormstudio/emacs-nerd-icons"
+ :fetcher github
+ :files (:defaults "data"))


### PR DESCRIPTION
### Brief summary of what the package does

emacs-nerd-icons is an icon library package similar to all-the-icons. It uses Nerd Fonts for icons so all of the icons can be rendered on both GUI and terminal.

### Direct link to the package repository

https://github.com/rainstormstudio/emacs-nerd-icons

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
