### PR TITLE
Maintenance wgrep

### DIFF
--- a/recipes/wgrep-ack
+++ b/recipes/wgrep-ack
@@ -1,4 +1,5 @@
 (wgrep-ack
  :fetcher github
  :repo "mhayashi1120/Emacs-wgrep"
- :files ("wgrep-ack.el"))
+ :files ("wgrep-ack.el")
+ :version-regexp "\\`ack-\\(.*\\)")

--- a/recipes/wgrep-ag
+++ b/recipes/wgrep-ag
@@ -1,4 +1,5 @@
 (wgrep-ag
  :fetcher github
  :repo "mhayashi1120/Emacs-wgrep"
- :files ("wgrep-ag.el"))
+ :files ("wgrep-ag.el")
+ :version-regexp "\\`ag-\\(.*\\)")

--- a/recipes/wgrep-deadgrep
+++ b/recipes/wgrep-deadgrep
@@ -1,0 +1,5 @@
+(wgrep-deadgrep
+ :fetcher github
+ :repo "mhayashi1120/Emacs-wgrep"
+ :files ("wgrep-deadgrep.el")
+ :version-regexp "\\`deadgrep-\\(.*\\)")

--- a/recipes/wgrep-helm
+++ b/recipes/wgrep-helm
@@ -1,4 +1,5 @@
 (wgrep-helm
  :fetcher github
  :repo "mhayashi1120/Emacs-wgrep"
- :files ("wgrep-helm.el"))
+ :files ("wgrep-helm.el")
+ :version-regexp "\\`helm-\\(.*\\)")

--- a/recipes/wgrep-pt
+++ b/recipes/wgrep-pt
@@ -1,4 +1,5 @@
 (wgrep-pt
  :fetcher github
  :repo "mhayashi1120/Emacs-wgrep"
- :files ("wgrep-pt.el"))
+ :files ("wgrep-pt.el")
+ :version-regexp "\\`pt-\\(.*\\)")


### PR DESCRIPTION
### Brief summary of what the package does

Make writable grep (and family) buffer.

### Direct link to the package repository

https://github.com/mhayashi1120/Emacs-wgrep

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

No needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
