### PR TITLE
add recipe for nerd-icons.el

### DIFF
--- a/recipes/nerd-icons
+++ b/recipes/nerd-icons
@@ -1,0 +1,4 @@
+(nerd-icons
+ :repo "rainstormstudio/nerd-icons.el"
+ :fetcher github
+ :files (:defaults "data"))


### PR DESCRIPTION
### Brief summary of what the package does

**nerd-icons.el** is an icon library package similar to **all-the-icons** package. It uses Nerd Fonts for icons so all of the icons can be rendered on both GUI and terminal.

### Note
This is a different but updated PR to #8467 as there's a naming change for the whole package.

Note that package-lint will have these errors:
```
549:5: error: You should depend on (emacs "25.1") if you need `js-jsx-mode'.
561:5: error: You should depend on (emacs "24.4") if you need `eww-mode'.
565:5: error: You should depend on (emacs "24.4") if you need `messages-buffer-mode'.
615:5: error: You should depend on (emacs "25.1") if you need `elisp-byte-code-mode'.
657:5: error: You should depend on (emacs "25.1") if you need `scss-mode'.
659:5: error: You should depend on (emacs "26.1") if you need `less-css-mode'.
```
but they can be IGNORED as **nerd-icons.el** does NOT depend on these modes but simply supports them.

### Direct link to the package repository

https://github.com/rainstormstudio/nerd-icons.el

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
