### PR TITLE
Add recipe for chatgpt-shell

### DIFF
--- a/recipes/chatgpt-shell
+++ b/recipes/chatgpt-shell
@@ -1,0 +1,3 @@
+(chatgpt-shell
+ :fetcher github
+ :repo "xenodium/chatgpt-shell")


### PR DESCRIPTION
### Brief summary of what the package does

ChatGPT and DALL-E Emacs shells + Org Babel support.

### Direct link to the package repository

https://github.com/xenodium/chatgpt-shell

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
