### PR TITLE
Add recipe for org-assistant.

### DIFF
--- a/recipes/org-assistant
+++ b/recipes/org-assistant
@@ -1,0 +1,1 @@
+(org-assistant :fetcher github :repo "tyler-dodge/org-assistant")


### PR DESCRIPTION
### Brief summary of what the package does

org-assistant provides support for accessing chat APIs such as ChatGPT in the context of an org notebook

### Direct link to the package repository

https://github.com/tyler-dodge/org-assistant

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
