### PR TITLE
Add recipe for nerd-icons-ivy-rich

### DIFF
--- a/recipes/nerd-icons-ivy-rich
+++ b/recipes/nerd-icons-ivy-rich
@@ -1,0 +1,3 @@
+(nerd-icons-ivy-rich
+ :fetcher github
+ :repo "seagle0128/nerd-icons-ivy-rich")


### PR DESCRIPTION
### Brief summary of what the package does

Excellent experience with nerd icons for ivy/counsel. It's similar to [all-the-icons-ivy-rich](https://github.com/seagle0128/all-the-icons-ivy-rich).

### Direct link to the package repository

https://github.com/seagle0128/nerd-icons-ivy-rich

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
