### PR TITLE
Update jet

### DIFF
--- a/recipes/jet
+++ b/recipes/jet
@@ -1,1 +1,1 @@
-(jet :repo "ericdallo/jet.el" :fetcher github)
+(jet :fetcher github :repo "ericdallo/jet.el")


### PR DESCRIPTION
"_Recipe for jet is malformed_"  message after _straight-get-recipe_ on **doom-emacs**. This proposed change seems to follow the expected form.
