### PR TITLE
add ob-pikchr

### DIFF
--- a/recipes/ob-pikchr
+++ b/recipes/ob-pikchr
@@ -1,0 +1,1 @@
+(ob-pikchr :fetcher github :repo "jaw0/ob-pikchr")


### PR DESCRIPTION
### Brief summary of what the package does

org babel support for pikchr

### Direct link to the package repository

https://github.com/jaw0/ob-pikchr

### Your association with the package

author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] `M-x checkdoc` is happy with my docstrings
- [/] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
