### PR TITLE
add recipe for nerd-icons-dired

### DIFF
--- a/recipes/nerd-icons-dired
+++ b/recipes/nerd-icons-dired
@@ -1,0 +1,3 @@
+(nerd-icons-dired
+ :repo "rainstormstudio/nerd-icons-dired"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

nerd-icons-dired uses nerd-icons.el package for displaying icons in dired-mode. This is inspired by [all-the-icons-dired](https://github.com/jtbm37/all-the-icons-dired).

note:
package-lint might say 
```
115:5: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
```
but this is necessary as all-the-icons-dired has this [commit](https://github.com/jtbm37/all-the-icons-dired/commit/db074300e25de3c11cf502ae6081c5602f9f2fc9) for refreshing overlays after dired-narrow--internal.

### Direct link to the package repository

https://github.com/rainstormstudio/nerd-icons-dired

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
