### PR TITLE
add recipe for treemacs-nerd-icons

### DIFF
--- a/recipes/treemacs-nerd-icons
+++ b/recipes/treemacs-nerd-icons
@@ -1,0 +1,3 @@
+(treemacs-nerd-icons
+ :fetcher github
+ :repo "rainstormstudio/treemacs-nerd-icons")


### PR DESCRIPTION
### Brief summary of what the package does

This is a [nerd-icons](https://github.com/rainstormstudio/nerd-icons.el) theme for treemacs. It is inspired by [treemacs-all-the-icons](https://github.com/Alexander-Miller/treemacs/blob/master/src/extra/treemacs-all-the-icons.el).

note:
package-lint will give 
```
1:0: warning: The word "emacs" is redundant in Emacs package names.
```
but clearly its "treemacs" ;P

### Direct link to the package repository

https://github.com/rainstormstudio/treemacs-nerd-icons

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] `M-x checkdoc` is happy with my docstrings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
