### PR TITLE
Add recipe for yank-indent

### DIFF
--- a/recipes/yank-indent
+++ b/recipes/yank-indent
@@ -1,0 +1,2 @@
+(yank-indent :fetcher github
+             :repo "jimeh/yank-indent")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs minor-mode that ensures pasted (yanked) text has the correct indentation level.

`yank-indent-mode` essentially just calls `indent-region` on any text that is pasted via `yank` or `yank-pop`, with a customizable max character threshold to avoid running it on excessively large chunks of pasted text.

The main attraction however is `global-yank-indent-mode` which is a fire-and-forget-style solution that enables `yank-indent-mode` in relevant buffers, and does not enable it in buffers where results are unpredictable. Like Python, YAML and Makefile buffers for example which are indentation sensitive.

How the global mode determines if yank-indent should be active or not is configurable.

Yank-indent is essentially a cleanup, rewrite and extraction of some random hacky advice/macro elisp snippets I've had floating around my personal config for over a decade.

### Direct link to the package repository

https://github.com/jimeh/yank-indent

### Your association with the package

I'm the author/maintainer of the project.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
