### PR TITLE
Add auth-source-1password recipe

### DIFF
--- a/recipes/auth-source-1password
+++ b/recipes/auth-source-1password
@@ -1,0 +1,1 @@
+(auth-source-1password :fetcher github :repo "dlobraico/auth-source-1password")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides Emacs [auth-source](https://www.gnu.org/software/emacs/manual/html_mono/auth.html#Top) integration for 1Password using [secret references](https://developer.1password.com/docs/cli/secret-references) and the op command-line tool. It’s handy for use with things like smtpmail and other Emacs packages which expect to be able to lookup login credentials. It should be a drop-in replacement for the default auth-info source.

### Direct link to the package repository

https://github.com/dlobraico/auth-source-1password

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
