### PR TITLE
Add recipe for project-treemacs

### DIFF
--- a/recipes/project-treemacs
+++ b/recipes/project-treemacs
@@ -1,0 +1,1 @@
+(project-treemacs :repo "cmccloud/project-treemacs" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
 Simple Treemacs backend for project.el: 
- Projects in Treemacs map to project.el projects.
- Workspaces in Treemacs map to project.el projects + their external roots.
- `project-find-file`, `project-switch-to-buffer`, `project-find-regexp` et al operate on the current treemacs project.
- `project-or-external-find-file`, `project-or-external-find-regexp` operate on the current treemacs workspace.

### Direct link to the package repository
https://github.com/cmccloud/project-treemacs

### Your association with the package
I'm the author of both the package and the recipe.

### Relevant communications with the upstream package maintainer
None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
