### PR TITLE
Maintenance of oauth

### DIFF
--- a/recipes/oauth
+++ b/recipes/oauth
@@ -1,3 +1,3 @@
 (oauth
- :fetcher github
+ :fetcher gitlab
  :repo "fvdbeek/emacs-oauth")

--- a/recipes/oauth
+++ b/recipes/oauth
@@ -1,1 +1,3 @@
-(oauth :fetcher github :repo "psanford/emacs-oauth")
+(oauth
+ :fetcher github
+ :repo "fvdbeek/emacs-oauth")


### PR DESCRIPTION
The [emacs-oauth](https://github.com/psanford/emacs-oauth) repository has been archived (see also #8510), and I would like to adopt the oauth package.