### PR TITLE
Add recipe for ob-chatgpt-shell

### DIFF
--- a/recipes/ob-chatgpt-shell
+++ b/recipes/ob-chatgpt-shell
@@ -1,0 +1,4 @@
+(ob-chatgpt-shell
+ :fetcher github
+ :repo "xenodium/chatgpt-shell"
+ :files ("ob-chatgpt-shell.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package is part of https://github.com/xenodium/chatgpt-shell and a follow-up PR to #8479 splitting the packages from the same repository.

ob-chatgot-shell is the org babel counterpart to chatgpt-shell (already on MELPA).

![ob-shell-pr](https://user-images.githubusercontent.com/8107219/235304782-e8b0ac6f-0b93-46ee-b3fd-12e90710c06e.gif)

### Direct link to the package repository

https://github.com/xenodium/chatgpt-shell

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
