### PR TITLE
Update verilog-ext recipe

### DIFF
--- a/recipes/verilog-ext
+++ b/recipes/verilog-ext
@@ -1,3 +1,3 @@
 (verilog-ext :fetcher github
              :repo "gmlarumbe/verilog-ext"
-             :files ("verilog-ext.el" "snippets"))
+             :files (:defaults "snippets"))


### PR DESCRIPTION
Hi,

I would like to update the recipe for `verilog-ext` to be able to separate the package into several files to make it easier for contributors and maintenance.

Related PR: #8390

There will be some errors with `melpazoid` GitHub action (https://github.com/melpa/melpa/pull/8390#issuecomment-1435731428), but I guess it should be fine.

Thanks a lot!