### PR TITLE
Update vhdl-ext recipe

### DIFF
--- a/recipes/vhdl-ext
+++ b/recipes/vhdl-ext
@@ -1,3 +1,3 @@
 (vhdl-ext :fetcher github
           :repo "gmlarumbe/vhdl-ext"
-          :files ("vhdl-ext.el"))
+          :files (:defaults "snippets"))


### PR DESCRIPTION
Hi,

I would like to update the recipe for `vhdl-ext` to be able to separate the package into several files to make it easier for contributors and maintenance.

Related PR: https://github.com/melpa/melpa/pull/8392

Thanks a lot!