### PR TITLE
add recipe for nerd-icons-completion

### DIFF
--- a/recipes/nerd-icons-completion
+++ b/recipes/nerd-icons-completion
@@ -1,0 +1,3 @@
+(nerd-icons-completion
+ :repo "rainstormstudio/nerd-icons-completion"
+ :fetcher github)


### PR DESCRIPTION
add nerd-icons-completion to Melpa: rainstormstudio/nerd-icons-completion#2

### Brief summary of what the package does

This is an alternative to [all-the-icons-completion](https://github.com/iyefrat/all-the-icons-completion) that uses [nerd-icons](https://github.com/rainstormstudio/nerd-icons.el) for icons. It adds icons to completion candidates using the built in completion metadata functions.

### Direct link to the package repository

https://github.com/rainstormstudio/nerd-icons-completion

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
