### PR TITLE
Only fetch repositories once per update cycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@ TOP := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 -include ./config.mk
 
+# Users should usually prefer this over other *_CONFIG variables.
+# We recommend that the value is set in the included "config.mk".
+USER_CONFIG ?= '()'
+
+# Only intended for "docker/builder/run.sh" and similar scripts.
+# That is also why we add extra quoting when setting EVAL below,
+# instead of here.  Not doing it like that would complicate the
+# quoting needed in scripts.
+BUILD_CONFIG ?= ()
+
 SLEEP ?= 0
 
 SHELL         := bash
@@ -20,21 +30,20 @@ PKGDIR  := packages-stable
 HTMLDIR := html-stable
 endif
 
-LISP_CONFIG ?= '(progn\
+# You probably don't want to change this.
+LOCATION_CONFIG ?= '(progn\
   (setq package-build--melpa-base "$(TOP)/")\
   (setq package-build-working-dir "$(TOP)/$(WORKDIR)/")\
   (setq package-build-archive-dir "$(TOP)/$(PKGDIR)/")\
-  (setq package-build-recipes-dir "$(TOP)/$(RCPDIR)/")\
-  (setq package-build-stable $(STABLE))\
-  (setq package-build-write-melpa-badge-images t)\
-  (setq package-build-timeout-secs \
-        (and (string= "linux" (symbol-name system-type)) 600)))'
+  (setq package-build-recipes-dir "$(TOP)/$(RCPDIR)/"))'
 
 LOAD_PATH ?= $(TOP)/package-build
 
 EVAL := $(EMACS_COMMAND) --no-site-file --batch \
 $(addprefix -L ,$(LOAD_PATH)) \
---eval $(LISP_CONFIG) \
+--eval $(LOCATION_CONFIG) \
+--eval "$(BUILD_CONFIG)" \
+--eval $(USER_CONFIG) \
 --load package-build.el \
 --eval
 

--- a/docker/builder/parallel_build_all
+++ b/docker/builder/parallel_build_all
@@ -2,22 +2,14 @@
 
 export LANG=en_US.UTF-8
 
-function unix_timestamp {
-    date "+%s"
-}
-
 function kill_all_jobs { jobs -p | xargs kill; }
 trap kill_all_jobs SIGINT SIGTERM
-
 
 function build_all {
     PATH=$HOME/.cabal/bin:$HOME/usr/bin:$HOME/bin:$PATH
 
-    ## run the script
     cd "/mnt/store/melpa"
     make -k -j8 $(find recipes/ -type f | sort) || true
-
-    echo '{"completed":' "$(unix_timestamp)" '}' > html/build-status.json
 }
 
 build_all

--- a/docker/builder/run.sh
+++ b/docker/builder/run.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+# Break taken between runs, in seconds.
+BUILD_DELAY=3600
+
+# A timeout is only needed for unattended builds, so we set this
+# here instead of forcing it on everyone in the Makefile or even
+# by giving the lisp variable a non-nil default value.
+LISP_CONFIG="(setq package-build-timeout-secs 600)"
+
 MELPA_REPO=/mnt/store/melpa
 cd "${MELPA_REPO}"
 MELPA_BRANCH=$( git rev-parse --abbrev-ref HEAD )
@@ -52,6 +60,7 @@ flux_capacitor() {
 
 echo '>>>> STARTING UNSTABLE BUILD'
 unset STABLE
+export BUILD_CONFIG="$LISP_CONFIG"
 
 BUILD_STATUS_JSON=${STATUS_JSON}
 BUILD_LAST_DURATION_FILE=${LAST_DURATION_FILE}
@@ -63,6 +72,7 @@ flux_capacitor
 
 echo '>>>> STARTING STABLE BUILD'
 export STABLE=t
+export BUILD_CONFIG="$LISP_CONFIG"
 
 BUILD_STATUS_JSON=${STABLE_STATUS_JSON}
 BUILD_LAST_DURATION_FILE=${STABLE_LAST_DURATION_FILE}
@@ -72,4 +82,4 @@ fi
 
 flux_capacitor
 
-sleep 3600  # give the server an hour break. it's working hard.
+sleep $BUILD_DELAY

--- a/docker/builder/run.sh
+++ b/docker/builder/run.sh
@@ -10,76 +10,51 @@ LISP_CONFIG="(setq package-build-timeout-secs 600)"
 
 MELPA_REPO=/mnt/store/melpa
 cd "${MELPA_REPO}"
-MELPA_BRANCH=$( git rev-parse --abbrev-ref HEAD )
 
-STATUS_JSON=${MELPA_REPO}/html/build-status.json
-LAST_DURATION_FILE=${MELPA_REPO}/html/.last-build-duration
-STABLE_STATUS_JSON=${MELPA_REPO}/html-stable/build-status.json
-STABLE_LAST_DURATION_FILE=${MELPA_REPO}/html-stable/.last-build-duration
-
-## update MELPA repo
+echo ">>> Pulling MELPA repository"
+MELPA_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git fetch origin
 git reset --hard "origin/${MELPA_BRANCH}"
 git pull origin "${MELPA_BRANCH}"
 echo
 
-update_json() {
-    cat <<EOF > $BUILD_STATUS_JSON
+record_build_status() {
+    local file="${MELPA_REPO}/html/build-status.json"
+    echo "Recording build status in $file"
+    cat <<EOF > $file
 {
   "started": $BUILD_STARTED,
   "completed": ${BUILD_COMPLETED-null},
+  "duration": ${BUILD_DURATION-null},
   "next": ${BUILD_NEXT-null},
-  "duration": ${BUILD_DURATION-null}
 }
 EOF
-    echo "Writing $BUILD_STATUS_JSON"
-    cat "$BUILD_STATUS_JSON"
+    cat "$file"
+    # FIXME "melpa.js" expects this file in a channel-specific
+    # location, but we no longer record this per channel.  For
+    # now just duplicate the file.
+    cp "$file" "${MELPA_REPO}/html-stable/build-status.json"
 }
 
-flux_capacitor() {
+# Indicate that the build is in progress
+BUILD_STARTED=$(date "+%s")
+record_build_status
 
-    if [ -f "$BUILD_LAST_DURATION_FILE" ]; then
-        BUILD_DURATION=$(cat "$BUILD_LAST_DURATION_FILE")
-    fi
-
-
-    BUILD_STARTED=$(date "+%s")
-    update_json
-
-    # Build all the packages.
-    docker/builder/parallel_build_all
-
-    # Store completed date
-    BUILD_COMPLETED=$(date "+%s")
-    BUILD_DURATION=$((BUILD_COMPLETED - BUILD_STARTED))
-    echo -n "$BUILD_DURATION" > $BUILD_LAST_DURATION_FILE
-    BUILD_NEXT=$((BUILD_COMPLETED + BUILD_DELAY))
-    update_json
-
-}
-
-echo '>>>> STARTING UNSTABLE BUILD'
+echo ">>> Starting UNSTABLE build"
 unset STABLE
 export BUILD_CONFIG="$LISP_CONFIG"
+docker/builder/parallel_build_all
 
-BUILD_STATUS_JSON=${STATUS_JSON}
-BUILD_LAST_DURATION_FILE=${LAST_DURATION_FILE}
-if [ -f "$STABLE_LAST_DURATION_FILE" ]; then
-    BUILD_DELAY=$(cat "$STABLE_LAST_DURATION_FILE")
-fi
-
-flux_capacitor
-
-echo '>>>> STARTING STABLE BUILD'
+echo ">>> Starting STABLE build"
 export STABLE=t
-export BUILD_CONFIG="$LISP_CONFIG"
+export BUILD_CONFIG="(progn $LISP_CONFIG
+  (setq package-build-fetch-function 'ignore))"
+docker/builder/parallel_build_all
 
-BUILD_STATUS_JSON=${STABLE_STATUS_JSON}
-BUILD_LAST_DURATION_FILE=${STABLE_LAST_DURATION_FILE}
-if [ -f "$LAST_DURATION_FILE" ]; then
-    BUILD_DELAY=$(cat "$LAST_DURATION_FILE")
-fi
-
-flux_capacitor
+# Indicate that the build has completed
+BUILD_COMPLETED=$(date "+%s")
+BUILD_DURATION=$((BUILD_COMPLETED - BUILD_STARTED))
+BUILD_NEXT=$((BUILD_COMPLETED + BUILD_DELAY))
+record_build_status
 
 sleep $BUILD_DELAY


### PR DESCRIPTION
Fetching the project repositories takes a long time, whether a given
repository actually contains any new data or not.  Actually building a
package takes less time than fetching and we only ever need to build a
new package for a small subset of projects in once cycle.

Continue to fetch when updating the "unstable" flavor, but forgo doing
it again when immediately afterwards updating the "stable" flavor.

This also helps keeping the flavors/channels more in sync.

----

@milkypostman I was looking at how the MELPA server actually uses `package-build`, in order to replace the `STABLE` variable.  In the process I ran into this performance tweak and also some things that needed cleaning up.  ~~The cleanup is also included in this pull-request.~~  Please review all changes.  Actually removing the `STABLE` variable will come at a later time, when an updated `package-build` is merged.