### PR TITLE
Add recipe for zone-tmux-clock

### DIFF
--- a/recipes/zone-tmux-clock
+++ b/recipes/zone-tmux-clock
@@ -1,0 +1,1 @@
+(zone-tmux-clock :fetcher git :url "https://depp.brause.cc/zone-tmux-clock.git")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a zone program that displays a tmux style clock when run. It can be used as a screen saver in combination with `M-x zone-when-idle`.

### Direct link to the package repository

https://depp.brause.cc/zone-tmux-clock/

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
