### PR TITLE
Add recipe for projection-multi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MELPA
 
+
 [![Build Status](https://github.com/melpa/melpa/workflows/CI/badge.svg)](https://github.com/melpa/melpa/actions)
 
 MELPA is a growing collection of `package.el`-compatible Emacs Lisp

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # MELPA
 
-
 [![Build Status](https://github.com/melpa/melpa/workflows/CI/badge.svg)](https://github.com/melpa/melpa/actions)
 
 MELPA is a growing collection of `package.el`-compatible Emacs Lisp

--- a/recipes/projection-multi
+++ b/recipes/projection-multi
@@ -1,0 +1,4 @@
+(projection-multi
+ :fetcher github
+ :repo "mohkale/projection"
+ :files ("src/projection-multi/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds support between projection and compile-multi.

Note: This was previously a required part of projection. I've extracted it into an optional component. It's still in the same repo but in a separate directory.

### Direct link to the package repository

https://github.com/mohkale/projection

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
