### PR TITLE
Added flux-themes repository

### DIFF
--- a/recipes/flux-themes
+++ b/recipes/flux-themes
@@ -1,0 +1,3 @@
+(flux-themes
+ :repo "convict-real/Flux-Themes"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

It provides the users to install and use the default packages from my emacs distribution called flux emacs

### Direct link to the package repository

https://github.com/convict-real/Flux-Dark-Theme

### Your association with the package

I am the owner and the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
