### PR TITLE
Add media-progress, media-progress-dired and media-progress-dirvish

### DIFF
--- a/recipes/media-progress
+++ b/recipes/media-progress
@@ -1,0 +1,4 @@
+(media-progress
+ :repo "jumper047/media-progress"
+ :fetcher github
+ :files ("media-progress.el"))

--- a/recipes/media-progress-dired
+++ b/recipes/media-progress-dired
@@ -1,0 +1,4 @@
+(media-progress-dired
+ :repo "jumper047/media-progress"
+ :fetcher github
+ :files ("media-progress-dired.el"))

--- a/recipes/media-progress-dirvish
+++ b/recipes/media-progress-dirvish
@@ -1,0 +1,4 @@
+(media-progress-dirvish
+ :repo "jumper047/media-progress"
+ :fetcher github
+ :files ("media-progress-dirvish.el"))


### PR DESCRIPTION
### Brief summary of what the package does
Packages displays progress of the video file in dired/dirvish buffer. Useful when you have directory with lots of videos and you forgot where you stopped last time.

### Direct link to the package repository
https://github.com/jumper047/media-progress

### Your association with the package
Author and maintainer

### Relevant communications with the upstream package maintainer
None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
