### PR TITLE
Add recipe for elfeed-webkit

### DIFF
--- a/recipes/elfeed-webkit
+++ b/recipes/elfeed-webkit
@@ -1,0 +1,1 @@
+(elfeed-webkit :fetcher github :repo "fritzgrabo/elfeed-webkit")


### PR DESCRIPTION
### Brief summary of what the package does

Render elfeed entries in embedded webkit widgets.

### Direct link to the package repository

https://github.com/fritzgrabo/elfeed-webkit

### Your association with the package

I am the author and the maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly, **but see below**
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Note that on Emacs 290.50 and higher, you'll get these byte-compile warnings:

```
Warning (bytecomp): ‘point’ is an obsolete generalized variable; use ‘goto-char’ instead. [14 times]
```

They stem from the `elfeed` package (which this package requires) and are discussed over in the related Github repo: https://github.com/skeeto/elfeed/pull/472

Thank you!