### PR TITLE
Added recipe fixed-page-mode.

### DIFF
--- a/recipes/fixed-page-mode
+++ b/recipes/fixed-page-mode
@@ -1,0 +1,1 @@
+(fixed-page-mode :fetcher gitlab :repo "igorwojnicki/fixed-page-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A page-based text editing/note taking/concept thinking Emacs minor mode.  Presents buffer's content as pages of predefined number of lines (50 by default).  It is an analog of pages in a notebook.

### Direct link to the package repository

https://gitlab.com/igorwojnicki/fixed-page-mode

### Your association with the package

Maintainer and author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
