### PR TITLE
Add recipe for sumibi

### DIFF
--- a/recipes/sumibi
+++ b/recipes/sumibi
@@ -1,0 +1,4 @@
+(sumibi
+ :fetcher github
+ :repo "kiyoka/Sumibi"
+ :files ("emacs/sumibi.el"))

--- a/recipes/sumibi
+++ b/recipes/sumibi
@@ -1,4 +1,3 @@
 (sumibi
  :fetcher github
- :repo "kiyoka/Sumibi"
- :files ("emacs/sumibi.el"))
+ :repo "kiyoka/Sumibi")


### PR DESCRIPTION
### Brief summary of what the package does

Japanese input system (IME) for Emacs. Sumibi is modeless, so you can input Japanese without switching to Japanese input mode.

### Direct link to the package repository`

https://github.com/kiyoka/Sumibi

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
~~However, since the document is in Japanese, I ignored the warning about punctuation.~~
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
