### PR TITLE
Update url of howm's repository

### DIFF
--- a/recipes/howm
+++ b/recipes/howm
@@ -1,4 +1,4 @@
 (howm
- :fetcher git
- :url "https://scm.osdn.net/gitroot/howm/howm.git"
+ :fetcher github
+ :repo "kaorahi/howm"
  :files (:defaults (:exclude "*.el.in")))


### PR DESCRIPTION
The repository of "howm" has been moved. You can confirm the new repository by the following steps.

1. Click "Homepage" button in https://melpa.org/#/howm
2. Click "git" link in https://howm.osdn.jp/
3. Confirm the repository https://github.com/kaorahi/howm