### PR TITLE
Add recipe for cue-sheet-mode

### DIFF
--- a/recipes/cue-sheet-mode
+++ b/recipes/cue-sheet-mode
@@ -1,0 +1,1 @@
+(cue-sheet-mode :repo "peterhoeg/cue-sheet-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Simple major mode for viewing/editing CUE sheets.

Recipe has been checked with melpazoid.

### Direct link to the package repository

https://github.com/peterhoeg/cue-sheet-mode

### Your association with the package

Author/maintainer

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
