### PR TITLE
make the PR template play nice with emacs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,13 +16,13 @@ https://github.com/your/awesome_package
 
 ### Checklist
 
-<!-- Please confirm by replacing `[]` with `[x]`: -->
+<!-- Please confirm by replacing `[ ]` with `[x]`: -->
 
-- [] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
-- [] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
-- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
-- [] My elisp byte-compiles cleanly
-- [] I've used `M-x checkdoc` to check the package's documentation strings
-- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
+- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
+- [ ] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
+- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
+- [ ] My elisp byte-compiles cleanly
+- [ ] I've used `M-x checkdoc` to check the package's documentation strings
+- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
 
 <!-- After submitting, please fix any problems the CI reports. -->


### PR DESCRIPTION
This is not related to any recipe.

Currently, in the PR template, the items are shown as `[]`. If we change that to `[ ]` (with a space), which is what this PR does, if you are opening the PR from emacs, you can then use C-c C-c to check the items rather than manually going to insert an `x`.
