### PR TITLE
Add recipe for auto-olivetti

### DIFF
--- a/recipes/auto-olivetti
+++ b/recipes/auto-olivetti
@@ -1,0 +1,1 @@
+(auto-olivetti :fetcher sourcehut :repo "ashton314/auto-olivetti")


### PR DESCRIPTION
### Brief summary of what the package does

This package will automatically turn on [Olivetti](https://github.com/rnkn/olivetti) in specified buffers. This makes it act kind of like [perfect-margin](https://github.com/mpwang/perfect-margin) but less aggressive and IMO easier to configure.

### Direct link to the package repository

https://sr.ht/~ashton314/auto-olivetti

### Your association with the package

Creator and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
