### PR TITLE
change repo location for 0x0 package

### DIFF
--- a/recipes/0x0
+++ b/recipes/0x0
@@ -1,1 +1,1 @@
-(0x0 :fetcher gitlab :repo "willvaughn/emacs-0x0")
+(0x0 :fetcher sourcehut :repo "willvaughn/emacs-0x0")


### PR DESCRIPTION
### Brief summary of what the package does

Integration with https://0x0.st from emacs. Intended for use in ERC to share images, files, and blocks of code.

### Direct link to the package repository

https://git.sr.ht/~willvaughn/emacs-0x0

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
