### PR TITLE
Add recipe for occurx-mode

### DIFF
--- a/recipes/occurx-mode
+++ b/recipes/occurx-mode
@@ -1,0 +1,2 @@
+(occurx-mode :repo "k32/occurx-mode"
+             :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs plugin for filtering large log files.

Improvements over the built-in `occur`:
- Patterns are specified using rx notation in a regular buffer rather than  the minibuffer.
- Patterns can be easily saved and restored.
- It is possible to specify multiple patterns, and `occurx` will highlight them with different colors.
- Searches are not limited to a single line; it is possible to use a custom delimiter.
- It is possible to match multiple regular expressions for each entry and to negate regular expressions.


### Direct link to the package repository

https://github.com/k32/occurx-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
