### PR TITLE
Add recipe for org-bulletproof

### DIFF
--- a/recipes/org-bulletproof
+++ b/recipes/org-bulletproof
@@ -1,0 +1,1 @@
+(org-bulletproof :fetcher github :repo "pondersson/org-bulletproof")


### PR DESCRIPTION
### Brief summary of what the package does

Modifies the default bullet cycling behavior for Org mode plain lists. Instead of choosing the specific bullet, the user only chooses between `unordered` and `ordered`. Nested bullets are automatically cycled.

### Direct link to the package repository

https://github.com/pondersson/org-bulletproof

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)