### PR TITLE
Add persist-state package

### DIFF
--- a/recipes/persist-state
+++ b/recipes/persist-state
@@ -1,0 +1,3 @@
+(persist-state
+ :fetcher codeberg
+ :repo "bram85/emacs-persist-state")


### PR DESCRIPTION
### Brief summary of what the package does

This package saves your Emacs state regularly when idle for a brief
moment, to minimize disturbance of executing all save functions in
sequence. In case Emacs is idle for a longer time, no state is
saved.

### Direct link to the package repository

https://codeberg.org/bram85/emacs-persist-state

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
