### PR TITLE
Add nushell-mode

### DIFF
--- a/recipes/nushell-mode
+++ b/recipes/nushell-mode
@@ -1,0 +1,3 @@
+(nushell-mode
+ :fetcher github
+ :repo "mrkkrp/emacs-nushell")


### PR DESCRIPTION
### Brief summary of what the package does

Add a major mode for editing Nushell scripts written in the Nu langauge.

### Direct link to the package repository

https://github.com/mrkkrp/emacs-nushell

### Your association with the package

I'm the maintainer of the package.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Close mrkkrp/nushell-mode#3.