### PR TITLE
Add buffer-name-relative

### DIFF
--- a/recipes/buffer-name-relative
+++ b/recipes/buffer-name-relative
@@ -1,0 +1,3 @@
+(buffer-name-relative
+  :fetcher codeberg
+  :repo "ideasman42/emacs-buffer-name-relative")


### PR DESCRIPTION
### Brief summary of what the package does

A small package that names buffers based on project-relative-paths, with optional path-abbreviation. (especially useful for working on Python projects with multiple `__init__.py` files).

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-buffer-name-relative

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
