### PR TITLE
Maintenance of ox-tufte

### DIFF
--- a/recipes/ox-tufte
+++ b/recipes/ox-tufte
@@ -1,1 +1,1 @@
-(ox-tufte :fetcher github :repo "dakrone/ox-tufte")
+(ox-tufte :fetcher github :repo "ox-tufte/ox-tufte")


### PR DESCRIPTION
The repository https://github.com/dakrone/ox-tufte has moved to the `ox-tufte` organization and now resides at https://github.com/ox-tufte/ox-tufte .
