### PR TITLE
Add recipe for sourcepawn-mode

### DIFF
--- a/recipes/sourcepawn-mode
+++ b/recipes/sourcepawn-mode
@@ -1,0 +1,1 @@
+(sourcepawn-mode :fetcher github :repo "agrif/sourcepawn-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This is an emacs major mode for SourcePawn plugin development. It has Pawn syntax aware code highlighting, in addition to highlighting of SourceMode-specific constants and function names.

### Direct link to the package repository

https://github.com/agrif/sourcepawn-mode

### Your association with the package

I am the original author.

### Relevant communications with the upstream package maintainer

I have cleaned up the docstrings a bit and added autoloads to make installation nicer for the user. I can make more changes as necessary, but I'm reluctant to make large changes as this code is 12 years old and still works fine (somehow).

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
