### PR TITLE
Add recipe for gpr-ts-mode

### DIFF
--- a/recipes/gpr-ts-mode
+++ b/recipes/gpr-ts-mode
@@ -1,0 +1,3 @@
+(gpr-ts-mode
+ :fetcher github
+ :repo "brownts/gpr-ts-mode")


### PR DESCRIPTION
### Brief summary of what the package does

gpr-ts-mode is a major mode for editing GNAT Project (GPR) files using the tree-sitter library support available in the upcoming Emacs 29.

### Direct link to the package repository

https://github.com/brownts/gpr-ts-mode

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
