### PR TITLE
Add recipe for evil-tutor-sc

### DIFF
--- a/recipes/evil-tutor-sc
+++ b/recipes/evil-tutor-sc
@@ -1,0 +1,3 @@
+(evil-tutor-sc :repo "clsty/evil-tutor-sc"
+	:fetcher github
+	:files (:defaults "tutor-sc.txt"))


### PR DESCRIPTION
### Brief summary of what the package does

[evil-tutor](https://github.com/syl20bnr/evil-tutor) in Simplified Chinese.

### Direct link to the package repository

https://github.com/clsty/evil-tutor-sc

### Your association with the package

Author.
- `tutor-sc.txt` is translated from `tutor.txt` of [evil-tutor](https://github.com/syl20bnr/evil-tutor).
This part is also the main effort worked on this package by myself.
- `evil-tutor-sc.el` is directly from `evil-tutor-ja.el` of [evil-tutor-ja](https://github.com/kenjimyzk/evil-tutor-ja).

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] (o) I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] (o) I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

(o): Not needed because the only elisp file `evil-tutor-sc.el` is directly modified from `evil-tutor-ja.el` of [evil-tutor-ja](https://github.com/kenjimyzk/evil-tutor-ja) , which is already in MELPA .

In other words, `evil-tutor-ja` already did it "for" this project.

P.S. modification on `evil-tutor-ja.el` : ONLY 2 things below:
- Metadata (Author, Keywords, Created date, URL) modified accordingly (which surely affects nothing in functionality).
- "ja" replaced to "sc"(naturally because this is Simplified Chinese version, not Japanese version; won't affect any functionality either).