### PR TITLE
change prettify-math project url

### DIFF
--- a/recipes/prettify-math
+++ b/recipes/prettify-math
@@ -1,4 +1,4 @@
 (prettify-math :fetcher git
-               :url "https://gitee.com/shaqxu/prettify-math.git"
+               :url "https://github.com/shaqtsui/prettify-math.git"
                :files (:defaults
                        "mathjax-jsonrpc.js"))


### PR DESCRIPTION
### Brief summary of what the package does

N.A. 
As not a new package, just change existing package url

### Direct link to the package repository

https://github.com/shaqtsui/prettify-math.git

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

N.A. 
As not a new package, just change existing package url

### Checklist

N.A. 
As not a new package, just change existing package url

<!-- After submitting, please fix any problems the CI reports. -->
