### PR TITLE
Add recipe for haki-theme

### DIFF
--- a/recipes/haki-theme
+++ b/recipes/haki-theme
@@ -1,0 +1,3 @@
+(haki-theme
+ :fetcher github
+ :repo "idlip/haki")


### PR DESCRIPTION
A dark theme for emacs

### Brief summary of what the package does

haki is an pleasant, dark theme for emacs.
Inspired by modus-vivendi, I have tailored it for some modern ui like.

### Direct link to the package repository

https://github.com/idlip/haki

### Your association with the package

I'm the author of the package/theme

### Relevant communications with the upstream package maintainer



### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

Actually there is an error.
I have added a function here [haki-modal-mode-line](https://github.com/idlip/haki/blob/26588e05a4668d98cae1e99e9f36db2e6dae38c5/haki-theme.el#L207) which changes mode-line border according to meow/evil state.

But i get these [errors](http://dpaste.com/CAM2XQGHP) with flycheck, Im not sure what will be the easy way to fix this.
Ik i can use `(declare-function meow-insert-state-p "ext:meow")
` but im not sure if its the best way to use it for all 12 functions..

I'm still a novice in emacs-lisp (that is why i have only did theme)
Please let me know what is the better way for this.

