### PR TITLE
Add compile multi extension packages

### DIFF
--- a/recipes/compile-multi-all-the-icons
+++ b/recipes/compile-multi-all-the-icons
@@ -1,0 +1,3 @@
+(compile-multi-all-the-icons
+ :fetcher github :repo "mohkale/compile-multi"
+ :files ("extensions/compile-multi-all-the-icons/*.el"))

--- a/recipes/consult-compile-multi
+++ b/recipes/consult-compile-multi
@@ -1,0 +1,3 @@
+(consult-compile-multi
+ :fetcher github :repo "mohkale/compile-multi"
+ :files ("extensions/consult-compile-multi/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

They add optional extra features on top of the base `compile-multi` package. See related [extensions section](https://github.com/mohkale/compile-multi#extensions).

### Direct link to the package repository

https://github.com/mohkale/compile-multi

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [Z] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
