### PR TITLE
Update khoj repository location to new khoj-ai organization

### DIFF
--- a/recipes/khoj
+++ b/recipes/khoj
@@ -1,4 +1,4 @@
 (khoj
  :fetcher github
- :repo "debanjum/khoj"
+ :repo "khoj-ai/khoj"
  :files ("src/interface/emacs/*.el"))


### PR DESCRIPTION
The khoj repository is being moved to the khoj-ai organization to allow for easier collaboration and to collect all khoj related projects in one place

### Brief summary of what the package does

Khoj provides a natural, incremental chat, search interface to your second brain.
Currently this includes your org-mode notes, markdown files, beancount transactions, images, PDF files and github repositories

### Direct link to the package repository

https://github.com/debanjum/khoj

### Your association with the package

Author, Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
