### PR TITLE
Add recipe for org-upcoming-modeline

### DIFF
--- a/recipes/org-upcoming-modeline
+++ b/recipes/org-upcoming-modeline
@@ -1,0 +1,2 @@
+(org-upcoming-modeline :fetcher github
+               :repo "unhammer/org-upcoming-modeline")


### PR DESCRIPTION
Show next org event in mode line

### Brief summary of what the package does

Shows the next upcoming org-mode event in your mode-line. You can click it to go to the event, or right-click for a menu of goto/snooze/clock in.

### Direct link to the package repository

https://github.com/unhammer/org-upcoming-modeline

### Your association with the package

Maintainer / responsible for all bugs.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist


- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

