### PR TITLE
Add recipes for Universal Sidecar and Related Packages

### DIFF
--- a/recipes/universal-sidecar
+++ b/recipes/universal-sidecar
@@ -1,0 +1,4 @@
+(universal-sidecar
+ :fetcher sourcehut
+ :repo "swflint/universal-sidecar"
+ :files ("universal-sidecar.el" "universal-sidecar-sections.el"))

--- a/recipes/universal-sidecar-elfeed-related
+++ b/recipes/universal-sidecar-elfeed-related
@@ -1,0 +1,4 @@
+(universal-sidecar-elfeed-related
+ :fetcher sourcehut
+ :repo "swflint/universal-sidecar"
+ :files ("universal-sidecar-elfeed-related.el"))

--- a/recipes/universal-sidecar-elfeed-score
+++ b/recipes/universal-sidecar-elfeed-score
@@ -1,0 +1,4 @@
+(universal-sidecar-elfeed-score
+ :fetcher sourcehut
+ :repo "swflint/universal-sidecar"
+ :files ("universal-sidecar-elfeed-score.el"))

--- a/recipes/universal-sidecar-roam
+++ b/recipes/universal-sidecar-roam
@@ -1,0 +1,4 @@
+(universal-sidecar-roam
+ :fetcher sourcehut
+ :repo "swflint/universal-sidecar"
+ :files ("universal-sidecar-roam.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Universal Sidecar is a package that implements a more general "sidecar" buffer than is available in Org Roam (i.e., the `*org-roam*` buffer).  In particular it allows for one buffer per frame, and supports fairly general section creation (several sections are provided as examples).

### Direct link to the package repository

https://git.sr.ht/~swflint/emacs-universal-sidecar

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed.**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)