### PR TITLE
Add recipe for bufferbin

### DIFF
--- a/recipes/bufferbin
+++ b/recipes/bufferbin
@@ -1,0 +1,1 @@
+(bufferbin :fetcher github :repo "blueridge-data/bufferbin")


### PR DESCRIPTION
### Brief summary of what the package does

Bufferbin is a small tool to provide visibility and control over buffers. Like Treemacs, it resides in a side-window that lists available buffers and enables mouse-movements to open them in selected windows.

### Direct link to the package repository

https://github.com/blueridge-data/bufferbin

### Your association with the package

I am the creator, devoted maintainer, and enthusiastic user.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Note: byte-compiles with one warning: ```docstring exceeds 80 characters```; when I force the comment to use two lines, I then get an error from ```checkdoc``` that the first line is not a complete sentence.

<!-- After submitting, please fix any problems the CI reports. -->
