### PR TITLE
Add corfu-candidate-overlay recipe

### DIFF
--- a/recipes/corfu-candidate-overlay
+++ b/recipes/corfu-candidate-overlay
@@ -1,3 +1,2 @@
-(corfu-candidate-overlay :fetcher git
-                 :url "https://code.bsdgeek.org/adam/corfu-candidate-overlay"
-                 :files ("corfu-candidate-overlay.el"))
+(corfu-candidate-overlay :url "https://code.bsdgeek.org/adam/corfu-candidate-overlay"
+                         :fetcher git)

--- a/recipes/corfu-candidate-overlay
+++ b/recipes/corfu-candidate-overlay
@@ -1,0 +1,3 @@
+(corfu-candidate-overlay :fetcher git
+                 :url "https://code.bsdgeek.org/adam/corfu-candidate-overlay"
+                 :files ("corfu-candidate-overlay.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Simple [corfu](https://github.com/minad/corfu) as-you-type auto-suggestion candidate overlay with a visual indication of whether there are many or exactly one candidate available. Meant to be used with corfu-auto set to nil (i.e. no auto popup).

### Direct link to the package repository

https://code.bsdgeek.org/adam/corfu-candidate-overlay
### Your association with the package

I'm author and maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

(had problems with make sandbox itself, probably because I have emacs built from git repository, but managed with package-install-file manually)