### PR TITLE
[fix] add missing file to emacsql-sqlite recipe

### DIFF
--- a/recipes/emacsql-sqlite
+++ b/recipes/emacsql-sqlite
@@ -1,4 +1,4 @@
 (emacsql-sqlite
  :fetcher github
  :repo "magit/emacsql"
- :files ("emacsql-sqlite.el" "sqlite"))
+ :files ("emacsql-sqlite.el" "emacsql-sqlite-common.el" "sqlite"))


### PR DESCRIPTION
### Brief summary of what the package does
This is a bugfix, not a new package. A recent refactor in `emacsql` added a new file, and the MELPA recipe hasn't been updated yet.

https://github.com/magit/emacsql/commit/7a725e1910619c360e358cb24a069f051b1ffebe

### Direct link to the package repository

https://github.com/magit/emacsql

### Your association with the package

I am an enthusiastic user whose `org-roam` config broke this morning ;) 

### Relevant communications with the upstream package maintainer

No communications.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
