### PR TITLE
Fix geiser-stklos :files property

### DIFF
--- a/recipes/geiser-stklos
+++ b/recipes/geiser-stklos
@@ -1,1 +1,4 @@
-(geiser-stklos :fetcher gitlab :repo "emacs-geiser/stklos")
+(geiser-stklos
+ :fetcher gitlab
+ :repo "emacs-geiser/stklos"
+ :files (:defaults "geiser.stk"))


### PR DESCRIPTION
It seems that the property has never had the correct value.

The initial recipe had

    :files (:defaults ("geiser.stk"))

which is correct, except that the parentheses around "geiser.stk" make that file unrecognized. The property was interpreted as equal to

    :files (:defaults)

which caused it to be removed in the batch maintenance commit ad320d60e2c95881f31628c19ad3b9ece7e3d165.

The present commit adds back "geiser.stk" without the parentheses.

cc @jpellegrini