### PR TITLE
Restore geiser server for STklos

### DIFF
--- a/recipes/geiser-stklos
+++ b/recipes/geiser-stklos
@@ -1,1 +1,4 @@
-(geiser-stklos :fetcher gitlab :repo "emacs-geiser/stklos")
+(geiser-stklos
+ :fetcher gitlab
+ :repo "emacs-geiser/stklos"
+ :files (:defaults "geiser.stk"))


### PR DESCRIPTION
(This is an update to Geiser-STklos, not a new package)

Geiser is a collection of Emacs modes that works with different Scheme implementations. Each implementation (for each specific Scheme system) needs one Emacs Lisp frontend, and one Scheme backend -- and the backend for STklos is the file `geiser.stk`, which is needed for geiser-stklos to work (otherwise the package just won't work).

Version 1.4 of geiser-stklos in MELPA had `geiser.stk`, but this file was removed in commit ad320d60e2c95881f31628c19ad3b9ece7e3d165.

This commit resotres that file.

### Brief summary of what the package does

Geiser (https://www.nongnu.org/geiser/) is a collection of Emacs
major and minor modes for Scheme development.


STklos (http://stklos.net) is a free Scheme system mostly compliant
with the languages features defined in R7RS small. The aim of this
implementation is to be fast as well as light. The implementation is
based on an ad-hoc Virtual Machine. STklos can also be compiled as a
library and embedded in an application.

Geiser-Stklos adds STklos Scheme support to the Geiser package.

### Direct link to the package repository

https://gitlab.com/emacs-geiser/stklos

### Your association with the package

I am the author and maintainer of Geiser-STklos (but not of Geiser)

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


