### PR TITLE
Add wildcharm-theme

### DIFF
--- a/recipes/wildcharm-theme
+++ b/recipes/wildcharm-theme
@@ -1,0 +1,1 @@
+(wildcharm-theme :repo "habamax/wildcharm-theme" :fetcher github)

--- a/recipes/wildcharm-theme
+++ b/recipes/wildcharm-theme
@@ -1,1 +1,4 @@
-(wildcharm-theme :repo "habamax/wildcharm-theme" :fetcher github)
+(wildcharm-theme
+ :repo "habamax/wildcharm-theme"
+ :fetcher github
+ :files ("wildcharm-theme.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Port of my vim-wildcharm colorscheme.

Contrast dark colorscheme (wildcharm).
Works reasonably good with TUI (256c support).

### Direct link to the package repository

https://github.com/habamax/wildcharm-theme

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
