### PR TITLE
ox-tufte: Update recipe to include the "src" directory with additional files

### DIFF
--- a/recipes/ox-tufte
+++ b/recipes/ox-tufte
@@ -1,1 +1,1 @@
-(ox-tufte :fetcher github :repo "ox-tufte/ox-tufte")
+(ox-tufte :fetcher github :repo "ox-tufte/ox-tufte" :files (:defaults "src"))


### PR DESCRIPTION
[The upcoming version of ox-tufte](https://github.com/ox-tufte/ox-tufte/milestone/1) will include some supporting first-party non-lisp files that will reside in the `src/` directory.

### Brief summary of what the package does

This is an export backend for Org-mode that exports buffers to HTML that is compatible with Tufte CSS - <https://edwardtufte.github.io/tufte-css/>.

### Direct link to the package repository

https://github.com/ox-tufte/ox-tufte/tree/main

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
