### PR TITLE
Add prog-face-refine

### DIFF
--- a/recipes/prog-face-refine
+++ b/recipes/prog-face-refine
@@ -1,0 +1,1 @@
+(prog-face-refine :fetcher codeberg :repo "ideasman42/emacs-prog-face-refine")


### PR DESCRIPTION
### Brief summary of what the package does

Small package to refine faces for comment, string types.

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-prog-face-refine

NOTE: checked if there is a package to do this and it seems not: https://www.reddit.com/r/emacs/comments/14pyf8x/package_to_customize_comment_faces/

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
