### PR TITLE
Add recipe for teleport.el

### DIFF
--- a/recipes/teleport
+++ b/recipes/teleport
@@ -1,0 +1,1 @@
+(teleport :repo "caramelhooves/teleport.el" :fetcher github)


### PR DESCRIPTION
teleport.el is an Emacs wrapper for goteleport.com reverse ssh server.

### Brief summary of what the package does

teleport.el is an Emacs wrapper for command line tool tsh[1], a part of teleport [2]. You can think of teleport is of "ssh on steroids". teleport.el lets users to list all nodes(hosts) connected to their teleport cluster and run operations on those hosts. like inspecting their filesystem with dired or running ssh-like sessions with vterm.

[1] https://github.com/gravitational/teleport
[2] https://goteleport.com/

### Direct link to the package repository

https://github.com/caramelhooves/teleport.el

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
