### PR TITLE
Update recipe for json-mode to reflect moving to a organization

### DIFF
--- a/recipes/json-mode
+++ b/recipes/json-mode
@@ -1,1 +1,1 @@
-(json-mode :fetcher github :repo "joshwnj/json-mode")
+(json-mode :fetcher github :repo "json-emacs/json-mode")


### PR DESCRIPTION
`json-mode` is transferred to a new organization.

### Brief summary of what the package does

Major mode for JSON files.

### Direct link to the package repository

https://github.com/json-emacs/json-mode

### Your association with the package

I'm a maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
