### PR TITLE
Add recipe for zotra

### DIFF
--- a/recipes/zotra
+++ b/recipes/zotra
@@ -1,0 +1,1 @@
+(zotra :fetcher github :repo "mpedramfar/zotra")


### PR DESCRIPTION
### Brief summary of what the package does

This emacs library provides functions to get bibliographic information from a url and save it into a bibtex file. It also provides a way to obtain a list of attachments (e.g. PDF files) associated with a url. This is done using [Zotero translators](https://www.zotero.org/support/translators), but without using the Zotero client.

### Direct link to the package repository

https://github.com/mpedramfar/zotra

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
