### PR TITLE
Migrate json-process-client

### DIFF
--- a/recipes/json-process-client
+++ b/recipes/json-process-client
@@ -1,3 +1,3 @@
 (json-process-client
- :fetcher git
- :url "https://gitea.petton.fr/nico/json-process-client.git")
+ :fetcher github
+ :repo "DamienCassou/json-process-client")


### PR DESCRIPTION
The repository at https://gitea.petton.fr/nico/json-process-client
moved to https://github.com/DamienCassou/json-process-client.