### PR TITLE
add recipe for fedi.el

### DIFF
--- a/recipes/fedi
+++ b/recipes/fedi
@@ -1,0 +1,1 @@
+(fedi :fetcher codeberg :repo "martianh/fedi.el")


### PR DESCRIPTION
### Brief summary of what the package does

provides utilities for writing fediverse clients. code adapted from mastodon.el, currently used in lem.el (lemmy client)

### Direct link to the package repository

https://codeberg.org/martianh/fedi.el

### Your association with the package
 author

### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

I'm unable to build locally from my recipes, due to an error with straight.el that i don't understand. perhaps there's a way to build it outside of straight entirely?