### PR TITLE
Update recipe for evil-textobj-tree-sitter

### DIFF
--- a/recipes/evil-textobj-tree-sitter
+++ b/recipes/evil-textobj-tree-sitter
@@ -1,5 +1,5 @@
 (evil-textobj-tree-sitter
   :fetcher github
   :repo "meain/evil-textobj-tree-sitter"
-  :files (:defaults "queries")
+  :files (:defaults "queries" "treesit-queries")
   :old-names (evil-textobj-treesitter))


### PR DESCRIPTION
Add an additional folder used for treesit queries.

The changes are currently good to go in https://github.com/meain/evil-textobj-tree-sitter/pull/93 . I'm thinking this should go in before the PR as melpa IIRC fails to build the package if all the files mentioned are not available and so it will never have a bad state on the user's system, but If I merge my PR first, then I'm guessing it is possible that someone would end up with the newer version of the package without the queries needed for treesit.

Let me know if anyone has any other thoughts on this.

### Brief summary of what the package does

Tree-sitter powered text objects for evil mode

### Direct link to the package repository

https://github.com/meain/evil-textobj-tree-sitter
https://github.com/meain/evil-textobj-tree-sitter/pull/93

### Your association with the package

Author

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
