### PR TITLE
Adding org-roam-ql-ql

### DIFF
--- a/recipes/org-roam-ql-ql
+++ b/recipes/org-roam-ql-ql
@@ -1,0 +1,4 @@
+(org-roam-ql-ql
+ :fetcher github
+ :repo "ahmed-shariff/org-roam-ql"
+ :files ("org-roam-ql-ql.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This pacakge provides an interface between `org-roam-ql` and `org-ql`s view.

### Direct link to the package repository

https://github.com/ahmed-shariff/org-roam-ql

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly  (ish)
  - I get the following warning with melpazoid, to my knowledge, it's intentional:
```sh
`org-roam-ql-ql.el` with byte-compile using Emacs 28.1:
    org-roam-ql-ql.el:84:33: Warning: Unused lexical argument `query'
```
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
