### PR TITLE
Add recipe for ibrowse-core.

### DIFF
--- a/recipes/ibrowse-core
+++ b/recipes/ibrowse-core
@@ -1,0 +1,4 @@
+(ibrowse-core
+ :fetcher sourcehut
+ :repo "ngraves/ibrowse.el"
+ :files ("ibrowse-core.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package is part of ibrowse.el : 

ibrowse stands for interactive browse, its goal is to be able to control your browser through common actions, be it on browser tabs, history or bookmarks using Emacs.

It relies on the completing-read built-in interface, and thus benefits greatly from integration with consult, marginalia and vertico.

Currently this package is only the part which allows to identify which browser is currently being used, and contains some code used by other subpackages. 

### Direct link to the package repository

https://git.sr.ht/~ngraves/ibrowse.el

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

Since the first inclusion in MELPA, I have reworked on the proper independence of functionality, which makes the package able to be split in different components, hence the recipe update.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
