### PR TITLE
Update CONTRIBUTING.org: fix description of testing stable builds

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -192,7 +192,7 @@ via ~make recipes/<NAME>~, or with ~C-c C-c~ (~M-x package-build-current-recipe~
 in the recipe file buffer.
 
 If the repository contains tags for releases, confirm that the correct
-version is detected by running ~STABLE=t make recipes/<NAME>~.  The
+version is detected by running ~MELPA_CHANNEL=stable make recipes/<NAME>~.  The
 version detection can be adjusted by specifying ~:version-regexp~ in
 the recipe (see [[file:README.md#recipe-format][recipe format]] in the README).
 


### PR DESCRIPTION
This PR fixes `CONTRIBUTING.org` to match the use of `MELPA_CHANNEL` rather than `STABLE` in the build system.