### PR TITLE
Add recipe for verilog-ts-mode

### DIFF
--- a/recipes/verilog-ts-mode
+++ b/recipes/verilog-ts-mode
@@ -1,0 +1,3 @@
+(verilog-ts-mode :fetcher github
+                 :repo "gmlarumbe/verilog-ext"
+                 :files ("ts-mode/verilog-ts-*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Tree-sitter major-mode for SystemVerilog.

### Direct link to the package repository

https://github.com/gmlarumbe/verilog-ext

### Your association with the package

Author/maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
  - There are some byte compile errors caused by unused lexical arguments 
  - These arguments are required even though they are not used since these are matcher/anchor functions for indentation  
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
