### PR TITLE
Remove org project capture files from org projectile

### DIFF
--- a/recipes/org-projectile
+++ b/recipes/org-projectile
@@ -1,5 +1,4 @@
 (org-projectile
  :repo "colonelpanic8/org-project-capture"
  :fetcher github
- :files ("org-projectile.el" "org-project-capture.el"
-         "org-project-capture-backend.el"))
+ :files ("org-projectile*.el"))


### PR DESCRIPTION
### Brief summary of what happened

I've generalized org-projectile into org-project-capture which supports both projectile and project.el.

Ensuring that no one ever gets any broken versions of org-projectile going to require a 3 step process:

- #8680 we need to temporarily include files from what will eventually be a separate package org-project-capture to org-projectile
- Only then can I actually push the changes to the org-project-capture/org-projectile that actually use these new files
- #8681 Add the new package org-project-capture to melpa and wait for it to be publicly available
- (This PR) Remove the org-project-capture files from the org-projectile recipe and add a dependency on org-project-capture

### Direct link to the package repository

https://github.com/IvanMalison/org-projectile
https://github.com/colonelpanic8/org-project-capture

(same repository)

### Your association with the package

I'm the maintainer (though I have changed my username and the name of the repository)


### Relevant communications with the upstream package maintainer

you can check that this is an authentic continuation by seeing that https://github.com/IvanMalison/org-projectile redirects to https://github.com/colonelpanic8/org-project-capture


### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)