### PR TITLE
Add recipe for org-xlatex

### DIFF
--- a/recipes/org-xlatex
+++ b/recipes/org-xlatex
@@ -1,0 +1,1 @@
+(org-xlatex :fetcher github :repo "ksqsf/org-xlatex" :files (:defaults "org-xlatex.html"))


### PR DESCRIPTION
### Brief summary of what the package does

Org-xlatex creates instant previews for Org LaTeX formulae using MathJax in xwidget.

### Direct link to the package repository

https://github.com/ksqsf/org-xlatex

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
