### PR TITLE
Add homepage URL to RSS

### DIFF
--- a/html/updates.rss.erb
+++ b/html/updates.rss.erb
@@ -41,6 +41,7 @@
         end
         package.url = "#{base_url}/packages/#{pkgname}-#{version}." + (pkgtype == "single" ? "el" : "tar")
         package.info_url = "#{base_url}/#/#{pkgname}"
+        package.homepage = info["props"]["url"]
         package
       end
       packages.sort_by { |p| p.version }.reverse[0..200].each do |package|
@@ -51,6 +52,7 @@
         <pubDate><%= package.build_time.rfc822 %></pubDate>
         <guid isPermaLink="true"><%= package.url %></guid>
         <link><%= package.info_url %></link>
+        <homepage><%= package.homepage %></homepage>
       </item>
     <% end %>
   </channel>


### PR DESCRIPTION
This simply reads the URL from `archive.json` and includes it in the generate RSS feed. The main reason I want this is to help get direct links in the [Emacs.ch Melpa bot](https://fosstodon.org/@melpa@emacs.ch) toots to save a click from Melpa's website, but I'm sure it could come in handy elsewhere.

A problem I noticed is that some packages don't include a homepage. I'm assuming this is gathered from comment headers in the source file itself. But the package I was specifically looking at that was missing a homepage url (`abc-mode`) had a valid Homepage URL on the Melpa website. It looks like this is generated from the [`calculateSourceURL` function in melpa.js](https://github.com/melpa/melpa/blob/master/html/js/melpa.js#L108).

Before I spend time trying to replicate this in Elisp (the regex probably won't translate directly)... should I? I could just omit the field (or leave it empty as it is now) if no home url is provided. Or is there a better solution I'm missing?

And if rewriting in Elisp this is deemed necessary, would there be a better approach for this without writing the same code twice in 2 different languages. For example, the json bit could potentially be remove in favor of always falling back to the calculated URL in the package metadata.

Thank you for your time and consideration.