### PR TITLE
Add recipe for deno-ts-mode

### DIFF
--- a/recipes/deno-ts-mode
+++ b/recipes/deno-ts-mode
@@ -1,0 +1,3 @@
+(deno-ts-mode
+ :fetcher sourcehut
+ :repo "mgmarlow/deno-ts-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Adds a major mode for [Deno](https://deno.com/) derived from `typescript-ts-mode`. Includes features for `auto-mode` detection (since TypeScript and Deno share a file extension), Eglot configuration, and task automation.

### Direct link to the package repository

https://git.sr.ht/~mgmarlow/deno-ts-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
