### PR TITLE
Add recipe for vhdl-ts-mode

### DIFF
--- a/recipes/vhdl-ts-mode
+++ b/recipes/vhdl-ts-mode
@@ -1,0 +1,3 @@
+(vhdl-ts-mode :fetcher github
+              :repo "gmlarumbe/vhdl-ext"
+              :files ("ts-mode/vhdl-ts-*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Tree-sitter major-mode for VHDL.

### Direct link to the package repository

https://github.com/gmlarumbe/vhdl-ext

### Your association with the package

Author/maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

