### PR TITLE
Add recipe for compile-multi-embark

### DIFF
--- a/recipes/compile-multi-embark
+++ b/recipes/compile-multi-embark
@@ -1,3 +1,3 @@
 (compile-multi-embark
  :fetcher github :repo "mohkale/compile-multi"
- :files ("extensions/compile-multi-embark/*compile-multi-embark*.el"))
+ :files ("extensions/compile-multi-embark/compile-multi-embark*.el"))

--- a/recipes/compile-multi-embark
+++ b/recipes/compile-multi-embark
@@ -1,0 +1,3 @@
+(compile-multi-embark
+ :fetcher github :repo "mohkale/compile-multi"
+ :files ("extensions/compile-multi-embark/*.el"))

--- a/recipes/compile-multi-embark
+++ b/recipes/compile-multi-embark
@@ -1,3 +1,3 @@
 (compile-multi-embark
  :fetcher github :repo "mohkale/compile-multi"
- :files ("extensions/compile-multi-embark/*.el"))
+ :files ("extensions/compile-multi-embark/*compile-multi-embark*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds embark support to compile-multi so actions like kill-new yank the underlying command instead of just what's presented in the minibuffer.

### Direct link to the package repository

https://github.com/mohkale/compile-multi

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
