### PR TITLE
Add recipe for projection-multi-embark

### DIFF
--- a/recipes/projection-multi-embark
+++ b/recipes/projection-multi-embark
@@ -1,4 +1,4 @@
 (projection-multi-embark
  :fetcher github
  :repo "mohkale/projection"
- :files ("src/projection-multi-embark/*.el"))
+ :files ("src/projection-multi-embark/*projection-multi-embark*.el"))

--- a/recipes/projection-multi-embark
+++ b/recipes/projection-multi-embark
@@ -1,4 +1,4 @@
 (projection-multi-embark
  :fetcher github
  :repo "mohkale/projection"
- :files ("src/projection-multi-embark/*projection-multi-embark*.el"))
+ :files ("src/projection-multi-embark/projection-multi-embark*.el"))

--- a/recipes/projection-multi-embark
+++ b/recipes/projection-multi-embark
@@ -1,0 +1,4 @@
+(projection-multi-embark
+ :fetcher github
+ :repo "mohkale/projection"
+ :files ("src/projection-multi-embark/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Allows you to set a command from a compile-multi or projection-multi-compile session as the projects associated compile, test, etc. command for subsequent invocations.

Note: Build for this will probably fail until after https://github.com/melpa/melpa/pull/8703 is merged.

### Direct link to the package repository

https://github.com/mohkale/projection

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
