### PR TITLE
Add `"clojure.sh"` to `cider` package `:files`

### DIFF
--- a/recipes/cider
+++ b/recipes/cider
@@ -1,4 +1,4 @@
 (cider :fetcher github
        :repo "clojure-emacs/cider"
-       :files ("*.el" (:exclude ".dir-locals.el"))
+       :files ("*.el" "clojure.sh" (:exclude ".dir-locals.el"))
        :old-names (nrepl))


### PR DESCRIPTION
Introduced in https://github.com/clojure-emacs/cider/pull/3364

Already in master: https://github.com/clojure-emacs/cider/blob/master/clojure.sh

### Your association with the package

`clojure-emacs` member

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] I've used `M-x checkdoc` to check the package's documentation strings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
