### PR TITLE
Add recipe for oauth2-auto

### DIFF
--- a/recipes/oauth2-auto
+++ b/recipes/oauth2-auto
@@ -1,0 +1,1 @@
+(oauth2-auto :fetcher github :repo "telotortium/emacs-oauth2-auto")


### PR DESCRIPTION
-------

### Brief summary of what the package does

Authenticate yourself to an OAuth2 provider from inside Emacs.

### Direct link to the package repository

[telotortium/emacs-oauth2-auto: Automatically stored and configured OAuth2 for Emacs](https://github.com/telotortium/emacs-oauth2-auto)

### Your association with the package

Recipe author/package user

### Relevant communications with the upstream package maintainer

- [Add to Melpa · Issue #3 · telotortium/emacs-oauth2-auto](https://github.com/telotortium/emacs-oauth2-auto/issues/3)
- [fix byte-compile warning by MartinNowak · Pull Request #18 · telotortium/emacs-oauth2-auto](https://github.com/telotortium/emacs-oauth2-auto/pull/18)

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly (telotortium/emacs-oauth2-auto#18 fixes docstring warning)
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->