### PR TITLE
Add recipe for org-agenda-files-track-ql

### DIFF
--- a/recipes/org-agenda-files-track
+++ b/recipes/org-agenda-files-track
@@ -1,0 +1,4 @@
+(org-agenda-files-track
+ :fetcher sourcehut
+ :repo "ngraves/org-agenda-files-track"
+ :files ("org-agenda-files-track.el"))

--- a/recipes/org-agenda-files-track-ql
+++ b/recipes/org-agenda-files-track-ql
@@ -1,0 +1,4 @@
+(org-agenda-files-track-ql
+ :fetcher sourcehut
+ :repo "ngraves/org-agenda-files-track"
+ :files ("org-agenda-files-track-ql.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Use `before-save-hook` on org files to dynamically build `org-agenda-files` and speed up org-agenda.

### Direct link to the package repository

https://git.sr.ht/~ngraves/org-dynamic-agenda/

### Your association with the package

Author and maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
