### PR TITLE
Remove "asn1-mode" package

### DIFF
--- a/recipes/asn1-mode
+++ b/recipes/asn1-mode
@@ -1,1 +1,0 @@
-(asn1-mode :fetcher github :repo "kawabata/asn1-mode")


### PR DESCRIPTION
This [package](https://github.com/kawabata/asn1-mode) was last updated 5 years ago and just doesn't work.

<details>

<summary>
Figure. 
</summary>

![image](https://github.com/melpa/melpa/assets/4840430/0fa1e9a5-d00d-4948-8efa-ecb6f38ddad8)

</details>

Left window shows error in empty buffer due to incorrect SMIE configuration. Right window shows incorrect indentation with the mode.