### PR TITLE
Add recipe for markdown-join

### DIFF
--- a/recipes/markdown-join
+++ b/recipes/markdown-join
@@ -1,0 +1,3 @@
+(markdown-join
+ :fetcher git
+ :url "https://gist.github.com/tonyg/c951be93656b45027ed7d15e79f07c01")


### PR DESCRIPTION
### Brief summary of what the package does

Pulls in cells from a markdown table in another buffer, searching by the contents of the current cell in the current table in this buffer. Use this to do something like a SQL JOIN for an individual row; repeat (using a macro, perhaps) to do a whole table.

### Direct link to the package repository

https://gist.github.com/tonyg/c951be93656b45027ed7d15e79f07c01

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
