### PR TITLE
Add recipe for nushell-ts-mode

### DIFF
--- a/recipes/nushell-ts-mode
+++ b/recipes/nushell-ts-mode
@@ -1,0 +1,1 @@
+(nushell-ts-mode :fetcher github :repo "herbertjones/nushell-ts-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A mode for Nushell that uses tree-sitter. (treesit introduced in Emacs 29)

### Direct link to the package repository

https://github.com/herbertjones/nushell-ts-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
