### PR TITLE
Add recipe for helm-comint

### DIFF
--- a/recipes/helm-comint
+++ b/recipes/helm-comint
@@ -1,0 +1,1 @@
+(helm-comint :fetcher github :repo "emacs-helm/helm-comint")


### PR DESCRIPTION
### Brief summary of what the package does

Comint prompts navigation for helm.

### Direct link to the package repository

https://github.com/emacs-helm/helm-comint.git

### Your association with the package

I am a user.

Author: Pierre Neidhardt <mail@ambrevar.xyz>
Proposed Maintainer: Benedict Wang <foss@bhw.name>

### Relevant communications with the upstream package maintainer

The package was removed from helm 3.9.5 and the author notified.
https://github.com/emacs-helm/helm/issues/2615

I wrote to Mr. Neidhardt at the above electronic mailing address.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

helm-comint.el with byte-compile using Emacs 29.1:

``` shell
Compiling /home/ben/helm-comint/helm-comint.el...done
Wrote /home/ben/helm-comint/helm-comint.elc
```

helm-comint.el with checkdoc 0.6.2:

"prompts" is used as a noun instead of a verb.

``` shell
*** helm-comint.el: checkdoc-current-buffer
helm-comint.el:96: Probably "prompts" should be imperative "prompt"
helm-comint.el:119: Probably "prompts" should be imperative "prompt"
helm-comint.el:125: Probably "prompts" should be imperative "prompt"
helm-comint.el:182: Probably "prompts" should be imperative "prompt"
helm-comint.el:195: Probably "prompts" should be imperative "prompt"
```

helm-comint.el with package-lint 20230905.629

Other helm extension packages also do not prefix the 'helm-source' variable with
the package prefix. E.g. 'helm-bibtex'

``` shell
1 issue found:

221:0: error: "helm-source-comint-input-ring" doesn't start with package's prefix "helm-comint".
```

I have tried building and installing the package.

``` shell
ben@BHW-THINKPAD:~/melpa/recipes$ cd ..
ben@BHW-THINKPAD:~/melpa$ make recipes/helm-comint
 • Building package helm-comint ...
Package: helm-comint
Fetcher: github
Source:  https://github.com/emacs-helm/helm-comint.git

Cloning https://github.com/emacs-helm/helm-comint.git to /home/ben/melpa/working/helm-comint/
Checking out 5f435ede181818b6f8c58ad7b45f47acd2721daf
Copying files (->) and directories (=>)
  from /home/ben/melpa/working/helm-comint/
  to /tmp/helm-comintafvlJJ/helm-comint-20230909.445
    helm-comint.el -> helm-comint.el
    helm-shell.el -> helm-shell.el
Created helm-comint-20230909.445.tar containing:
  helm-comint-20230909.445/
  helm-comint-20230909.445/helm-comint-pkg.el
  helm-comint-20230909.445/helm-comint.el
  helm-comint-20230909.445/helm-shell.el
 ✓ Success:
  2023-09-09T04:52:25+0000  helm-comint-20230909.445.entry
  2023-09-09T04:52:25+0000  helm-comint-20230909.445.tar
Built helm-comint in 0.625s, finished at 2023-09-09T04:52:25+0000
```