### PR TITLE
Add recipe for org-window-habit

### DIFF
--- a/recipes/org-window-habit
+++ b/recipes/org-window-habit
@@ -1,1 +1,1 @@
-(org-window-habit :fetcher github :repo "colonelpanic8/org-window-habit.el")
+(org-window-habit :fetcher github :repo "colonelpanic8/org-window-habit")

--- a/recipes/org-window-habit
+++ b/recipes/org-window-habit
@@ -1,0 +1,1 @@
+(org-window-habit :fetcher github :repo "colonelpanic8/org-window-habit.el")


### PR DESCRIPTION
### Brief summary of what the package does

The `org-habit-window` package extends the capabilities of org-habit to
include habits that are not strictly daily. It allows users to define
habits that need to be completed a certain number of times within a
given time window, for example, 5 times every 7 days.

### Direct link to the package repository

https://github.com/colonelpanic8/org-window-habit


### Your association with the package

Maintainer


### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

