### PR TITLE
Add new recipe for mistty.

### DIFF
--- a/recipes/mistty
+++ b/recipes/mistty
@@ -1,0 +1,2 @@
+(mistty :fetcher github
+        :repo "szermatt/mistty")


### PR DESCRIPTION
Fetched from https://github.com/szermatt/mistty

### Brief summary of what the package does

MisTTY is a major mode for Emacs 29.1 and up that runs a shell inside of a buffer, similarly to comint mode. It is built on top of term.el. 

M-x mistty creates a buffer with an interactive shell. Inside that buffer, you can move freely and use the usual Emacs commands and editing tools to run shell command and work with their output.

In addition to these, you also have access to your shell’s native command and editing tools, including TAB-completion and autosuggestions. Commands that take over the entire screen, such as less or vi are also available.

### Direct link to the package repository

https://github.com/szermatt/mistty

### Your association with the package

Original author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

Note: package-lint reports lots of 
"This key sequence is reserved"
but this is in a map that's not used for key bindings, but for translating keys into terminal sequences (the reverse of input-decode-map).

- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
