### PR TITLE
Add wat-ts-mode recipe

### DIFF
--- a/recipes/wat-ts-mode
+++ b/recipes/wat-ts-mode
@@ -1,0 +1,1 @@
+(wat-ts-mode :repo "nverno/wat-ts-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provides tree-sitter major modes for webassembly text format buffers, wat and wast.

### Direct link to the package repository

https://github.com/nverno/wat-ts-mode

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
