### PR TITLE
Add recipe for nerd-icons-corfu

### DIFF
--- a/recipes/nerd-icons-corfu
+++ b/recipes/nerd-icons-corfu
@@ -1,0 +1,1 @@
+(nerd-icons-corfu :fetcher github :repo "LuigiPiucco/nerd-icons-corfu")


### PR DESCRIPTION
### Brief summary of what the package does

It augments [corfu](https://github.com/minad/corfu) completions with icons, from [nerd-icons](https://github.com/rainstormstudio/nerd-icons.el). There's already [kind-icon](https://github.com/jdtsmith/kind-icon) with similar intent, the difference here is particularly nerd-icons itself, which uses icon fonts, as opposed to cached image icons from [svg-lib](https://github.com/rougier/svg-lib). This makes it work everywhere the Nerd Fonts work, including terminal, and plays better with the scale of other characters (see [here](https://github.com/doomemacs/doomemacs/pull/7002#issuecomment-1416321038) for a cropping issue encountered with kind-icon).

### Direct link to the package repository

https://github.com/LuigiPiucco/nerd-icons-corfu

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed, I can address anything mentioned here.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
