### PR TITLE
Add recipe for transducers

### DIFF
--- a/recipes/transducers
+++ b/recipes/transducers
@@ -1,0 +1,1 @@
+(transducers :fetcher sourcehut :repo "fosskers/transducers.el")


### PR DESCRIPTION
### Brief summary of what the package does

Transducers are a pattern invented in Clojure but since ported to other Lisps. This is the Emacs Lisp variant. They allow for efficient streaming of data without laziness.

### Direct link to the package repository

https://git.sr.ht/~fosskers/transducers.el

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

A preemptive note about naming conventions. Although the library's name is `transducers`, all symbols in the library are prefixed with `t-` for brevity's sake. The motivations for this are as follows:

- The Common Lisp variant encourages a `:local-nickname` of `t:`
- The Fennel variant encourages importing as `t` so that functions are referenced as `t.`
- The (WIP) Clojure variant similarly encourages `t/`
- While `package-lint` does warn about this, the Elisp documentation itself doesn't seem to strictly mandate that the exact name be used
- There is no library named `t` (probably to avoid conflict with the built-in symbol)

So I would like to request that the prefix of `t-` be allowed in this case. Here's an example of how it looks:
```emacs-lisp
(let ((xf (t-comp (t-map #'split-string)
                  #'t-concatenate
                  (t-filter (lambda (w) (string-match-p "^[a-zA-Z]+$" w)))
                  (t-map #'length))))
  (t-transduce xf (t-fold #'max) (t-file-read "README.org")))
```

Cheers!