### PR TITLE
Add recipe for typewriter-roll-mode

### DIFF
--- a/recipes/typewriter-roll-mode
+++ b/recipes/typewriter-roll-mode
@@ -1,0 +1,4 @@
+(typewriter-roll-mode
+ :fetcher github
+ :repo "keyweeusr/typewriter-roll-mode"
+ :commit "53ebead9c230454d51b9532c839943b95b15a8f8")

--- a/recipes/typewriter-roll-mode
+++ b/recipes/typewriter-roll-mode
@@ -1,4 +1,4 @@
 (typewriter-roll-mode
  :fetcher github
  :repo "keyweeusr/typewriter-roll-mode"
- :commit "53ebead9c230454d51b9532c839943b95b15a8f8")
+ :commit "0d4184c5e0f113a957b6700be458511ba299ff46")

--- a/recipes/typewriter-roll-mode
+++ b/recipes/typewriter-roll-mode
@@ -1,4 +1,4 @@
 (typewriter-roll-mode
  :fetcher github
  :repo "keyweeusr/typewriter-roll-mode"
- :commit "0d4184c5e0f113a957b6700be458511ba299ff46")
+ :commit "3114d05731517d40972e2ed896806b25bdc0d8c2")


### PR DESCRIPTION
### Brief summary of what the package does

This minor mode attempts to remove distraction of seeing the previous lines of text while dumping an uninterrupted stream of thoughts, hence preventing focus jumping to revisions whether to handle typos, spacing or complete rewording and losing such a thought in the process.

### Direct link to the package repository

https://github.com/KeyWeeUsr/typewriter-roll-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
