### PR TITLE
Add recipe for mermaid-docker-mode

### DIFF
--- a/recipes/mermaid-docker-mode
+++ b/recipes/mermaid-docker-mode
@@ -1,4 +1,4 @@
 (mermaid-docker-mode
  :fetcher github
  :repo "keyweeusr/mermaid-docker-mode"
- :commit "1a47776e0a51580e3dc67ac223cc3b2ff0827b5e")
+ :commit "35596832f0a8dd29d376f9b96c2cf4d7863b23db")

--- a/recipes/mermaid-docker-mode
+++ b/recipes/mermaid-docker-mode
@@ -1,4 +1,3 @@
 (mermaid-docker-mode
  :fetcher github
- :repo "keyweeusr/mermaid-docker-mode"
- :commit "35596832f0a8dd29d376f9b96c2cf4d7863b23db")
+ :repo "keyweeusr/mermaid-docker-mode")

--- a/recipes/mermaid-docker-mode
+++ b/recipes/mermaid-docker-mode
@@ -1,4 +1,4 @@
 (mermaid-docker-mode
  :fetcher github
  :repo "keyweeusr/mermaid-docker-mode"
- :commit "1409a5be0ab55e3f59e9e297272c8e4f80764999")
+ :commit "f1e0a4fb0ae569c10e0cc0811d0a67de7097160b")

--- a/recipes/mermaid-docker-mode
+++ b/recipes/mermaid-docker-mode
@@ -1,4 +1,4 @@
 (mermaid-docker-mode
  :fetcher github
  :repo "keyweeusr/mermaid-docker-mode"
- :commit "f1e0a4fb0ae569c10e0cc0811d0a67de7097160b")
+ :commit "1a47776e0a51580e3dc67ac223cc3b2ff0827b5e")

--- a/recipes/mermaid-docker-mode
+++ b/recipes/mermaid-docker-mode
@@ -1,4 +1,4 @@
 (mermaid-docker-mode
  :fetcher github
  :repo "keyweeusr/mermaid-docker-mode"
- :commit "6e74d7d651f1a6131a19b14889eb7e81ad332a96")
+ :commit "1409a5be0ab55e3f59e9e297272c8e4f80764999")

--- a/recipes/mermaid-docker-mode
+++ b/recipes/mermaid-docker-mode
@@ -1,0 +1,4 @@
+(mermaid-docker-mode
+ :fetcher github
+ :repo "keyweeusr/mermaid-docker-mode"
+ :commit "6e74d7d651f1a6131a19b14889eb7e81ad332a96")


### PR DESCRIPTION
### Brief summary of what the package does

This library attempts to create Mermaid graphs via mermaid-ink aka mermaid as an API via a custom locally-built Docker image with restricted network access, so that you are sure nothing gets out and your system is kept isolated from random Node.js deps/files noise all around the filesystem.

### Direct link to the package repository

https://github.com/KeyWeeUsr/mermaid-docker-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
