### PR TITLE
Remove mu4e-maildirs-extension package

### DIFF
--- a/recipes/mu4e-maildirs-extension
+++ b/recipes/mu4e-maildirs-extension
@@ -1,1 +1,0 @@
-(mu4e-maildirs-extension :repo "agpchil/mu4e-maildirs-extension" :fetcher github)


### PR DESCRIPTION
This package is deprecated.

Users should use the official mu4e package which now have this feature built-in: https://github.com/djcb/mu/pull/1586 