### PR TITLE
update recipe for yabaki-theme

### DIFF
--- a/recipes/yabaki-theme
+++ b/recipes/yabaki-theme
@@ -1,1 +1,1 @@
-(yabaki-theme :repo "seamacs/yabaki-theme" :fetcher github)
+(yabaki-theme :repo "seahorse/yabaki-theme" :fetcher codeberg)


### PR DESCRIPTION

Theme has moved from GitHub to Codeberg (Org name which the repo was under has also changed)

https://codeberg.org/seahorse/yabaki-theme