### PR TITLE
Add recipe for leader-key

### DIFF
--- a/recipes/leader-key
+++ b/recipes/leader-key
@@ -1,0 +1,3 @@
+(leader-key
+ :fetcher github
+ :repo "havner/leader-key")


### PR DESCRIPTION
### Brief summary of what the package does

Simple helper to add leader key functionality (e.g. for god-mode)

The idea is to replicate a vim/evil leader key concept, but be independent of
any other mode.  This has been developed and tested together with god-mode
but should work without it or even without any modal mode.  It works together
with which-key, but the dependency is optional.

### Direct link to the package repository

https://github.com/havner/leader-key

### Your association with the package

I'm an author and maintainer.

### Relevant communications with the upstream package maintainer

I'm both author and maintainer so I guess: None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
