### PR TITLE
Add clang-format-on-save

### DIFF
--- a/recipes/clang-format-on-save
+++ b/recipes/clang-format-on-save
@@ -1,0 +1,3 @@
+(clang-format-on-save
+  :fetcher codeberg
+  :repo "ideasman42/emacs-clang-format-on-save")


### PR DESCRIPTION
### Brief summary of what the package does

Minimal minor mode to run clang-format on save.

Notes:

- I checked `clang-format+` package however this adds many other hooks which I'm not keen on, instead this minor mode **only** runs `clang-format-buffer` on save.
- This package was prompted by this Q&A: https://emacs.stackexchange.com/a/78998/2418
- The package `clang-format` has no version, so I couldn't reference a valid version.

----

An alternative solution could be to contribute this to the `clang-format` package, since I think it's reasonable to include this as an off-by-default minor-mode with the existing clang-format package.

This is currently orphaned?  - it's maintained on emacsmirror at least: https://melpa.org/#/clang-format

I could fork this package into my own repository, keep it as-is besides including this minor mode.

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-clang-format-on-save

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
