### PR TITLE
Add recipe for org-side-tree

### DIFF
--- a/recipes/org-side-tree
+++ b/recipes/org-side-tree
@@ -1,0 +1,1 @@
+(org-side-tree :fetcher github :repo "localauthor/org-side-tree")


### PR DESCRIPTION
### Brief summary of what the package does

Creates a side-window with an outline view of a current Org mode buffer, for easy navigation and manipulation.

### Direct link to the package repository

https://github.com/localauthor/org-side-tree

### Your association with the package

Author/maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
