### PR TITLE
Adding gofmt-tag recipe

### DIFF
--- a/recipes/gofmt-tag
+++ b/recipes/gofmt-tag
@@ -1,0 +1,1 @@
+(gofmt-tag :fetcher github :repo "m1ndo/gofmt-tag")


### PR DESCRIPTION
### Brief summary of what the package does
This package is a simple wrapper for [formattag](https://github.com/momaek/formattag/) to quickly align golang struct tags in go-mode.
### Direct link to the package repository

https://github.com/M1ndo/gofmt-tag

### Your association with the package
Author
### Relevant communications with the upstream package maintainer
Not needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
