### PR TITLE
Add recipe for org-newtab

### DIFF
--- a/recipes/org-newtab
+++ b/recipes/org-newtab
@@ -1,0 +1,3 @@
+(org-newtab :fetcher github
+            :repo "Zweihander-Main/org-newtab"
+            :files ("lisp/org-newtab*.el"))

--- a/recipes/org-newtab
+++ b/recipes/org-newtab
@@ -1,3 +1,1 @@
-(org-newtab :fetcher github
-            :repo "Zweihander-Main/org-newtab"
-            :files ("lisp/org-newtab*.el"))
+(org-newtab :repo "Zweihander-Main/org-newtab" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Displays an org-agenda task as your browser's new tab page. 

### Direct link to the package repository

https://github.com/Zweihander-Main/org-newtab

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
