### PR TITLE
add recipe for flexoki-themes

### DIFF
--- a/recipes/flexoki-themes
+++ b/recipes/flexoki-themes
@@ -1,0 +1,3 @@
+(flexoki-themes :fetcher github
+                :repo "crmsnbleyd/flexoki-emacs-theme"
+                :branch "trunk")

--- a/recipes/flexoki-themes
+++ b/recipes/flexoki-themes
@@ -1,3 +1,2 @@
 (flexoki-themes :fetcher github
-                :repo "crmsnbleyd/flexoki-emacs-theme"
-                :branch "trunk")
+                :repo "crmsnbleyd/flexoki-emacs-theme")


### PR DESCRIPTION
### Brief summary of what the package does

This package includes a dark and light theme variant of the [Flexoki](https://stephango.com/flexoki) colour scheme.

### Direct link to the package repository

[https://github.com/crmsnbleyd/flexoki-emacs-theme](https://github.com/crmsnbleyd/flexoki-emacs-theme)

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
