### PR TITLE
Add consult-tex

### DIFF
--- a/recipes/consult-tex
+++ b/recipes/consult-tex
@@ -1,0 +1,3 @@
+(consult-tex
+  :repo "titus.pinta/consult-tex"
+  :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does
Provide consult based commands to work with tex citations and references.
Consult enables the preview of the text near the definition of a label in order
to facilitate the selection of the correct reference, based on information
obtained from the context.


### Direct link to the package repository
https://gitlab.com/titus.pinta/consult-tex

### Your association with the package
Maintainer

### Relevant communications with the upstream package maintainer
None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
