### PR TITLE
Add vimscript-ts-mode

### DIFF
--- a/recipes/vimscript-ts-mode
+++ b/recipes/vimscript-ts-mode
@@ -1,0 +1,1 @@
+(vimscript-ts-mode :repo "nverno/vimscript-ts-mode" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for vim script using tree-sitter.

### Direct link to the package repository

https://github.com/nverno/vimscript-ts-mode

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
