### PR TITLE
Add recipe for kanagawa-theme

### DIFF
--- a/recipes/kanagawa-theme
+++ b/recipes/kanagawa-theme
@@ -1,0 +1,1 @@
+(kanagawa-theme :repo "Meritamen/kanagawa-theme" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A retro dark theme for Emacs.

### Direct link to the package repository

https://github.com/Meritamen/kanagawa-theme

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
