### PR TITLE
Add mark-yank

### DIFF
--- a/recipes/mark-yank
+++ b/recipes/mark-yank
@@ -1,0 +1,1 @@
+(mark-yank :fetcher github :repo "mkleehammer/mark-yank")


### PR DESCRIPTION
### Brief summary of what the package does

This simple Emacs minor mode provides the command mark-yank that marks the last yank / paste in the current buffer.

When the mode is enabled, it advises the yank command and records the location. When the mark-yank command is invoked, it sets the mark and point to the recorded location and activates the region.

### Direct link to the package repository

https://github.com/mkleehammer/mark-yank

### Your association with the package

Author & maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
