### PR TITLE
Add smart-tab-over

### DIFF
--- a/recipes/smart-tab-over
+++ b/recipes/smart-tab-over
@@ -1,0 +1,1 @@
+(mark-yank :fetcher github :repo "mkleehammer/smart-tab-over")


### PR DESCRIPTION
### Brief summary of what the package does

Allow tab key to "jump over" closing parens, quotes, semicolons, etc.  If not on any of these characters, execute original target of tab key.

Also identify strings and do not jump over beginning quotes to ensure it remains easy to indent a line when on a quote, but do jump over ending quotes.

### Direct link to the package repository

https://github.com/mkleehammer/smart-tab-over

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- []x I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
