### PR TITLE
Add perspective-project-bridge

### DIFF
--- a/recipes/perspective-project-bridge
+++ b/recipes/perspective-project-bridge
@@ -1,0 +1,2 @@
+(perspective-project-bridge :repo "arunkmv/perspective-project-bridge"
+                            :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does
This package adds the missing bridge between perspective.el and project.el.

It creates a perspective for each project.el project. Based on [persp-mode-projectile-bridge](https://github.com/Bad-ptr/persp-mode-projectile-bridge.el).

### Direct link to the package repository

https://github.com/arunkmv/perspective-project-bridge

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

**NOTE:** I've built the package successfully, but installing it gives the error ```Package does not untar cleanly into directory perspective-project-bridge-20231021.1853/```. Manually untarring it works fine. Please let me know what the issue could be.

