### PR TITLE
Add receipe for crc.

### DIFF
--- a/recipes/crc
+++ b/recipes/crc
@@ -1,0 +1,1 @@
+(crc :fetcher github :repo "sthilaid/crc")


### PR DESCRIPTION
### Brief summary of what the package does

A simple library that adds a function that enables to calculate the region or at point text's crc value

### Direct link to the package repository

https://github.com/sthilaid/crc

### Your association with the package

Author / Maitainer

### Relevant communications with the upstream package maintainer

This is a follow up from the pull request: https://github.com/melpa/melpa/pull/8773

I don't know how to fix most of the package lint warnings such as adding depencies on certain version of emacs
There are some docstrings warning/errors that I couldn't care to fix either. Hopefully these are not showstoppers...

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
