### PR TITLE
Transfer tab-jump-out to new maintainer.

### DIFF
--- a/recipes/tab-jump-out
+++ b/recipes/tab-jump-out
@@ -1,1 +1,1 @@
-(tab-jump-out :repo "victorteokw/tab-jump-out" :fetcher github)
+(tab-jump-out :fetcher github :repo "mkleehammer/tab-jump-out")


### PR DESCRIPTION
### Brief summary of what the package does

Please note that this package is already on MELPA, but I am taking over maintenance from the author who no longer uses Emacs.  See https://github.com/victorteokw/tab-jump-out/issues/3#issuecomment-1772603430

This pakage provides a minor mode that causes the tab key to jump out
of pairs like quotes, parentheses, braces, etc.  This is a feature of some other editors and is
very handy when using electric pair mode.

### Direct link to the package repository

https://github.com/mkleehammer/tab-jump-out

### Your association with the package

I am the new maintainer.  See https://github.com/victorteokw/tab-jump-out/issues/3#issuecomment-1772603430

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
