### PR TITLE
Add recipe for gemtext-mode

### DIFF
--- a/recipes/gemtext-mode
+++ b/recipes/gemtext-mode
@@ -1,0 +1,1 @@
+(gemtext-mode :fetcher sourcehut :repo "arjca/gemtext-mode.el")


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for editing Gemtext files.

### Direct link to the package repository

https://git.sr.ht/~arjca/gemtext-mode.el

### Your association with the package

Author & Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)