### PR TITLE
Adapt the `cider` recipe to an upcoming code layout change

### DIFF
--- a/recipes/cider
+++ b/recipes/cider
@@ -1,7 +1,7 @@
 (cider :fetcher github
        :repo "clojure-emacs/cider"
        :files (;; new code layout:
-               "lisp/*.el" "script/*.sh"
+               "lisp/*.el" "bin/*.sh"
                ;; old code layout - will be kept for a while during the transition:
                "*.el" "clojure.sh" "lein.sh" (:exclude ".dir-locals.el"))
        :old-names (nrepl))

--- a/recipes/cider
+++ b/recipes/cider
@@ -1,4 +1,7 @@
 (cider :fetcher github
        :repo "clojure-emacs/cider"
-       :files ("*.el" "clojure.sh" "lein.sh" (:exclude ".dir-locals.el"))
+       :files (;; new code layout:
+               "lisp/*.el" "script/*.sh"
+               ;; old code layout - will be kept for a while during the transition:
+               "*.el" "clojure.sh" "lein.sh" (:exclude ".dir-locals.el"))
        :old-names (nrepl))


### PR DESCRIPTION
### Brief summary of what the change does

> Part of https://github.com/clojure-emacs/cider/issues/3477

Adapts the CIDER recipe to an upcoming code layout change.

I verified it works as intended against cider's [wip branch](https://github.com/clojure-emacs/cider/tree/lisp) by using `make recipe/cider` locally:

```
Copying files (->) and directories (=>)
  from /Users/vemv/melpa/working/cider/
  to /var/folders/yc/h50n8fgn0h79y848sfkr942h0000gn/T/cidersR36RD/cider-20231102.1248
  ! lisp/cider-apropos.el -> cider-apropos.el
  ! lisp/cider-browse-ns.el -> cider-browse-ns.el
  ! lisp/cider-browse-spec.el -> cider-browse-spec.el
  ! lisp/cider-cheatsheet.el -> cider-cheatsheet.el
  ! lisp/cider-classpath.el -> cider-classpath.el
  ! lisp/cider-client.el -> cider-client.el
  ! lisp/cider-clojuredocs.el -> cider-clojuredocs.el
  ! lisp/cider-common.el -> cider-common.el
  ! lisp/cider-completion-context.el -> cider-completion-context.el
  ! lisp/cider-completion.el -> cider-completion.el
  ! lisp/cider-connection.el -> cider-connection.el
  ! lisp/cider-debug.el -> cider-debug.el
  ! lisp/cider-doc.el -> cider-doc.el
  ! lisp/cider-docstring.el -> cider-docstring.el
  ! lisp/cider-eldoc.el -> cider-eldoc.el
  ! lisp/cider-eval.el -> cider-eval.el
  ! lisp/cider-find.el -> cider-find.el
  ! lisp/cider-format.el -> cider-format.el
  ! lisp/cider-inspector.el -> cider-inspector.el
  ! lisp/cider-jar.el -> cider-jar.el
  ! lisp/cider-log.el -> cider-log.el
  ! lisp/cider-macroexpansion.el -> cider-macroexpansion.el
  ! lisp/cider-mode.el -> cider-mode.el
  ! lisp/cider-ns.el -> cider-ns.el
  ! lisp/cider-overlays.el -> cider-overlays.el
  ! lisp/cider-popup.el -> cider-popup.el
  ! lisp/cider-profile.el -> cider-profile.el
  ! lisp/cider-repl-history.el -> cider-repl-history.el
  ! lisp/cider-repl.el -> cider-repl.el
  ! lisp/cider-resolve.el -> cider-resolve.el
  ! lisp/cider-scratch.el -> cider-scratch.el
  ! lisp/cider-selector.el -> cider-selector.el
  ! lisp/cider-stacktrace.el -> cider-stacktrace.el
  ! lisp/cider-test.el -> cider-test.el
  ! lisp/cider-tracing.el -> cider-tracing.el
  ! lisp/cider-util.el -> cider-util.el
  ! lisp/cider-xref-backend.el -> cider-xref-backend.el
  ! lisp/cider-xref.el -> cider-xref.el
  ! lisp/cider.el -> cider.el
  ! lisp/nrepl-client.el -> nrepl-client.el
  ! lisp/nrepl-dict.el -> nrepl-dict.el
  ! script/clojure.sh -> clojure.sh
  ! script/lein.sh -> lein.sh
```

This works identically even after deleting `"*.el" "clojure.sh" "lein.sh" (:exclude ".dir-locals.el")` from the recipe, guaranteeing a smooth transition.

### Direct link to the package repository

https://github.com/clojure-emacs/cider

### Your association with the package

Maintainer

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
