### PR TITLE
Positron forcibly adopting parrot

### DIFF
--- a/recipes/parrot
+++ b/recipes/parrot
@@ -1,4 +1,4 @@
 (parrot
  :fetcher github
- :repo "dp12/parrot"
+ :repo "positron-solutions/parrot"
  :files (:defaults "img"))


### PR DESCRIPTION
There's no action on d12's parrot since I forked over a year ago, so I figured it was time to point MELPA at my fork.

My fork has a progress implementation for running parrot on git pushes and a hook function for org todo state changes.  These are enabled by default.  I considered turning them off by default, but I figure most people want to see a parrot when they install parrot and configure via customize from there.

Emacs support bumped to 27, pretty reasonable.

### Parrot

XPM modeline animations on certain actions.  Commands for word rotation that incorporate these rotations.

### Direct link to the package repository

https://github.com/positron-solutions/parrot

### Your association with the package

Maintainer.  Contributed a bit and couldn't contact the maintainer until after I had detached my fork.  Never got around to pointing MELPA over.

### Relevant communications with the upstream package maintainer

None further needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
