### PR TITLE
Add dtext-mode

### DIFF
--- a/recipes/dtext-mode
+++ b/recipes/dtext-mode
@@ -1,0 +1,1 @@
+(dtext-mode :fetcher github :repo "JohnDevlopment/dtext-mode.el")

--- a/recipes/dtext-mode
+++ b/recipes/dtext-mode
@@ -1,4 +1,1 @@
-(dtext-mode
- :fetcher github
- :repo "JohnDevlopment/dtext-mode.el"
- :version-regexp "[^0-9]*\\(.*\\(?:\\(?:\\(?:alph\\|bet\\)a\\)\\)?\\)")
+(dtext-mode :fetcher github :repo "JohnDevlopment/dtext-mode.el")

--- a/recipes/dtext-mode
+++ b/recipes/dtext-mode
@@ -1,1 +1,4 @@
-(dtext-mode :fetcher github :repo "JohnDevlopment/dtext-mode.el")
+(dtext-mode
+ :fetcher github
+ :repo "JohnDevlopment/dtext-mode.el"
+ :version-regexp "[^0-9]*\\(.*\\(?:\\(?:\\(?:alph\\|bet\\)a\\)\\)?\\)")


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for editing DText files, the markup language used on Danbooru and other Booru sites. It implements syntax highlighting and keyboard commands for the most basic tags.

### Direct link to the package repository

https://github.com/JohnDevlopment/dtext-mode.el

### Your association with the package

I'm the maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
