### PR TITLE
Add recipe for jtsx

### DIFF
--- a/recipes/jtsx
+++ b/recipes/jtsx
@@ -1,0 +1,3 @@
+(jtsx
+ :fetcher github
+ :repo "llemaitre19/jtsx")


### PR DESCRIPTION
### Brief summary of what the package does

`jtsx` extends Emacs default support for editing `JSX` and `TSX` files. It provides 2 major modes implemented respectively on top of the built-in `js-ts-mode` and `tsx-ts-mode` modes, benefiting thus from the new built-in [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) feature.

### Direct link to the package repository

https://github.com/llemaitre19/jtsx

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

### Comments

I am aware of these 2 `package-lint` errors :

```
628:0: error: "jsx-mode" doesn't start with package's prefix "jtsx".
647:0: error: "tsx-mode" doesn't start with package's prefix "jtsx".
```

Fixing them (eg replacing by `jtsx-jsx-mode` and `jtsx-tsx-mode`), would result in a breaking change for users. A smoother solution could be to start a deprecation process for  `jsx-mode` and `tsx-mode` (ie using `defalias` until a next major release).

Thanks !
