### PR TITLE
Add recipe for tab-bar-notch

### DIFF
--- a/recipes/tab-bar-notch
+++ b/recipes/tab-bar-notch
@@ -1,0 +1,2 @@
+(tab-bar-notch :fetcher github
+               :repo "jimeh/tab-bar-notch")


### PR DESCRIPTION
### Brief summary of what the package does

Adjust tab-bar height for MacBook Pro notch.

When using the non-native fullscreen mode of Emacs on modern MacBook Pro machines, it ends up rendering buffer content behind the camera notch. This package attempts to solve this by way of resizing the tab-bar to fill the vertical space taken up by the camera notch.

### Direct link to the package repository

https://github.com/jimeh/tab-bar-notch

### Your association with the package

I'm the author/maintainer of the project.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
