### PR TITLE
Drop `:commit` from `decor` and `typewriter-roll-mode` recipe

### DIFF
--- a/recipes/decor
+++ b/recipes/decor
@@ -1,4 +1,3 @@
 (decor
  :fetcher github
- :repo "KeyWeeUsr/decor"
- :commit "add132447ade02afef1328bf50040f77cbd86087")
+ :repo "KeyWeeUsr/decor")

--- a/recipes/decor
+++ b/recipes/decor
@@ -1,4 +1,4 @@
 (decor
  :fetcher github
  :repo "KeyWeeUsr/decor"
- :commit "aad4fa9f4e0d4140e2707f4cc678b1dc3c0672fa")
+ :commit "add132447ade02afef1328bf50040f77cbd86087")

--- a/recipes/typewriter-roll-mode
+++ b/recipes/typewriter-roll-mode
@@ -1,4 +1,3 @@
 (typewriter-roll-mode
  :fetcher github
- :repo "KeyWeeUsr/typewriter-roll-mode"
- :commit "3114d05731517d40972e2ed896806b25bdc0d8c2")
+ :repo "KeyWeeUsr/typewriter-roll-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This library attempts to simplify removal of all frame (window) decorations via two simple functions and possibly some constants later for customization.

### Direct link to the package repository

https://github.com/KeyWeeUsr/decor

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
