### PR TITLE
Add receipe for init-dir

### DIFF
--- a/recipes/init-dir
+++ b/recipes/init-dir
@@ -1,0 +1,3 @@
+(init-dir
+ :fetcher github
+ :repo "chaosemer/init-dir")


### PR DESCRIPTION
### Brief summary of what the package does

Keep all Emacs configuration in a separate directory that can be under version control with a single line init.el change. Unlike other packages for managing init directories, this package does not require following particular file naming conventions.

### Direct link to the package repository

https://github.com/chaosemer/init-dir

### Your association with the package

Author, maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
