### PR TITLE
Add recipe for orgnote

### DIFF
--- a/recipes/orgnote
+++ b/recipes/orgnote
@@ -1,0 +1,1 @@
+(orgnote :repo "Artawower/orgnote.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

orgnote.el is a package for synchronizing org roam notes or just org files with property id from emacs with an external application - [orgnote](https://org-note.com/) and vice versa.

### Direct link to the package repository

https://github.com/artawower/orgnote.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
