### PR TITLE
Update URL of fish-completion's repository

### DIFF
--- a/recipes/fish-completion
+++ b/recipes/fish-completion
@@ -1,3 +1,3 @@
 (fish-completion
- :repo "Ambrevar/emacs-fish-completion"
- :fetcher gitlab)
+ :repo "LemonBreezes/emacs-fish-completion"
+ :fetcher github)


### PR DESCRIPTION
Hi. Ambrevar has archived his [emacs-fish-completion](https://gitlab.com/ambrevar/emacs-fish-completion) repository and handed the project to me. This is updating MELPA to point to [my repository](https://github.com/LemonBreezes/emacs-fish-completion).