### PR TITLE
Add recipe for open-color

### DIFF
--- a/recipes/open-color
+++ b/recipes/open-color
@@ -1,1 +1,1 @@
-(open-color :repo "a13/open-color.el" :fetcher github :files "open-color.el")
+(open-color :repo "a13/open-color.el" :fetcher github)

--- a/recipes/open-color
+++ b/recipes/open-color
@@ -1,0 +1,1 @@
+(open-color :repo "a13/open-color.el" :fetcher github :files "open-color.el")


### PR DESCRIPTION
### Brief summary of what the package does

The package is an Emacs lisp port of the popular https://github.com/yeun/open-color color scheme. I use it for writing color schemes, so probably it will be useful for other theme makers as well.

### Direct link to the package repository

https://github.com/a13/open-color.el

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
