### PR TITLE
Add recipe for org-epa-gpg

### DIFF
--- a/recipes/org-epa-gpg
+++ b/recipes/org-epa-gpg
@@ -1,0 +1,3 @@
+(org-epa-gpg
+ :fetcher github
+ :repo "KeyWeeUsr/org-epa-gpg")


### PR DESCRIPTION
### Brief summary of what the package does

This is a patch that attempts to fix image inlining (C-c C-x C-v) in the org-mode for images that are encrypted AND end with ".gpg" extension.

### Direct link to the package repository

https://github.com/KeyWeeUsr/org-epa-gpg

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
