### PR TITLE
Add recipe for completing-read-sly

### DIFF
--- a/recipes/completing-read-sly
+++ b/recipes/completing-read-sly
@@ -1,0 +1,3 @@
+(completing-read-sly
+ :fetcher github
+ :repo "enzuru/completing-read-sly")


### PR DESCRIPTION
### Brief summary of what the package does

This package lets you search through Common Lisp symbols defined in SLY using Emacs' built-in competing-read function.

### Direct link to the package repository

https://github.com/enzuru/completing-read-sly

### Your association with the package

I am the original author and current maintainer.

### Relevant communications with the upstream package maintainer

**None needed*

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
