### PR TITLE
Add recipe for completing-read-geiser

### DIFF
--- a/recipes/completing-read-geiser
+++ b/recipes/completing-read-geiser
@@ -1,0 +1,3 @@
+(completing-read-geiser
+ :fetcher github
+ :repo "enzuru/completing-read-geiser")


### PR DESCRIPTION
### Brief summary of what the package does

This package lets you search through Scheme symbols defined in Geiser using Emacs' built-in competing-read function.

### Direct link to the package repository

https://github.com/enzuru/completing-read-geiser

### Your association with the package

I am the original author and current maintainer.

### Relevant communications with the upstream package maintainer

**None needed*

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

My only concern is that `package-lint` complained that Geiser is not installable, but I am guessing that's a bug related to Geiser being hosted on ELPA?