### PR TITLE
Add new recipe for JMESPath quering of JSON

### DIFF
--- a/recipes/jmespath
+++ b/recipes/jmespath
@@ -1,1 +1,1 @@
-(jmespath :fetcher github :repo "UnresolvedCold/jmespath" :files ("*.el"))
+(jmespath :repo "UnresolvedCold/jmespath" :fetcher github)

--- a/recipes/jmespath
+++ b/recipes/jmespath
@@ -1,0 +1,1 @@
+(jmespath :fetcher github :repo "UnresolvedCold/jmespath" :files ("*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

[JMESPath](https://jmespath.org/) is a quick way to query your JSON data and derive useful insights from it.
I created a small wrapper around [jamespath](https://github.com/jmespath/jp) command line utility to query a `JSON` buffer and display the queryed result in a new buffer named `*JMESPath Result*`.

### Direct link to the package repository

https://github.com/UnresolvedCold/jmespath

### Your association with the package

I am a **maintainer** and **contributor** of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
