### PR TITLE
Update memento-mori maintainer

### DIFF
--- a/recipes/memento-mori
+++ b/recipes/memento-mori
@@ -1,1 +1,1 @@
-(memento-mori :fetcher github :repo "lassik/emacs-memento-mori")
+(memento-mori :fetcher github :repo "gvol/emacs-memento-mori")


### PR DESCRIPTION
### Brief summary of what the package does

Update the repository URL due to it being transferred to a new maintainer (namely me).

### Direct link to the package repository

https://github.com/gvol/emacs-memento-mori

### Your association with the package

I am now the maintainer.

### Relevant communications with the upstream package maintainer

As noted in https://github.com/gvol/emacs-memento-mori/issues/12, the repository was transferred to me to be the new maintainer.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)