### PR TITLE
Update url of memento-mori's repository

### DIFF
--- a/recipes/memento-mori
+++ b/recipes/memento-mori
@@ -1,1 +1,1 @@
-(memento-mori :fetcher github :repo "lassik/emacs-memento-mori")
+(memento-mori :fetcher github :repo "gvol/emacs-memento-mori")


### PR DESCRIPTION
I have stopped maintaining the `memento-mori` package. Ivan Andrus (@gvol) is taking over as the new maintainer.

Thank you very much to Ivan for continuing the work.

New repo: https://github.com/gvol/emacs-memento-mori