### PR TITLE
add pinyin-isearch recipe

### DIFF
--- a/recipes/pinyin-isearch
+++ b/recipes/pinyin-isearch
@@ -1,0 +1,1 @@
+(pinyin-isearch :fetcher github :repo "Anoncheg1/pinyin-isearch")


### PR DESCRIPTION
### Brief summary of what the package does

Provide replacement for isearch-forward, isearch-backward.
Allow to search with pinyin in pinyin but ignore tone marks for speed.

Difference with pinyin-search.el: we search in pinyin text and ignore tones.

### Direct link to the package repository

https://github.com/your/awesome_package

### Your association with the package

I am the maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)