### PR TITLE
Add recipe for pinyin-isearch

### DIFF
--- a/recipes/pinyin-isearch
+++ b/recipes/pinyin-isearch
@@ -1,0 +1,1 @@
+(pinyin-isearch :fetcher github :repo "Anoncheg1/pinyin-isearch")


### PR DESCRIPTION
### Brief summary of what the package does

Preview pull requests: https://github.com/melpa/melpa/pull/8859

Provide replacement for isearch-forward, isearch-backward.
Allow to search with pinyin in pinyin and a Chinese text and ignore diacritical tone marks for speed.

Difference with pinyin-search.el: we search in pinyin text and ignore tones.

> but I'm not too familiar with quail or setting input methods. Maybe you can point me to a reference for this, so I can learn more about this loading-in of quail/sisheng?

About (load "quail/sisheng"): I was unable to determinate reason of args-out-of-range error and just suppress it. I need only constants from this files. Emacs don't support partial loading, so there is not other way to do it cheaper.



All tests succeed: https://github.com/Anoncheg1/pinyin-isearch/actions/runs/

### Direct link to the package repository

https://github.com/Anoncheg1/pinyin-isearch

### Your association with the package

I am the maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used `M-x package-lint-current-buffer` to check package stylistic errors.