### PR TITLE
Recipes for lognav-mode and multi-project now use GitHub

### DIFF
--- a/recipes/lognav-mode
+++ b/recipes/lognav-mode
@@ -1,1 +1,1 @@
-(lognav-mode :fetcher hg :url "https://hg.osdn.net/view/lognav-mode/lognav-mode")
+(lognav-mode :fetcher github :repo "ellisvelo/lognav-mode")

--- a/recipes/multi-project
+++ b/recipes/multi-project
@@ -1,1 +1,1 @@
-(multi-project :fetcher hg :url "https://hg.osdn.net/view/multi-project/multi-project")
+(multi-project :fetcher github :repo "ellisvelo/multi-project")


### PR DESCRIPTION
### Brief summary of what the package does

lognav-mode is used for navigating errors within log files
multi-project is a convenience tool for working with different projects

### Direct link to the package repository
https://github.com/ellisvelo/lognav-mode
https://github.com/ellisvelo/multi-project

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
