### PR TITLE
Add recipe for ivy-hoogle

### DIFF
--- a/recipes/ivy-hoogle
+++ b/recipes/ivy-hoogle
@@ -1,0 +1,1 @@
+(ivy-hoogle :fetcher github :repo "aartamonau/ivy-hoogle")


### PR DESCRIPTION
### Brief summary of what the package does

The package provides an interface to the Hoogle search engine (https://github.com/ndmitchell/hoogle) using `ivy` (similar to `helm-hoogle` that already has a recipe, except using `ivy`).

### Direct link to the package repository

https://github.com/aartamonau/ivy-hoogle

### Your association with the package

I'm the author/maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
