### PR TITLE
Remove alchemist and add apprentice recipe

### DIFF
--- a/recipes/alchemist
+++ b/recipes/alchemist
@@ -1,4 +1,0 @@
-(alchemist
- :fetcher github
- :repo "tonini/alchemist.el"
- :files (:defaults "*.exs" "alchemist-server"))

--- a/recipes/apprentice
+++ b/recipes/apprentice
@@ -1,0 +1,1 @@
+(apprentice :fetcher github :repo "Sasanidas/Apprentice")


### PR DESCRIPTION
### Brief summary of what the package does

Apprentice is a fork [alchemist.el](https://github.com/tonini/alchemist.el), similar in some aspects but quite different in others.

Like alchemist, Apprentice comes with a bunch of features, which are:

    Mix integration (contributed by [Ayrat Badykov](https://github.com/ayrat555))
    Compile & Execution of Elixir code
    Inline code evaluation
    Powerful IEx integration
    Elixir project management
    Phoenix support


### Direct link to the package repository

https://github.com/Sasanidas/Apprentice

### Your association with the package

I am the maintainer 

### Relevant communications with the upstream package maintainer

*None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
