### PR TITLE
Recipe for totp-auth.el - Time-based One Time Password support

### DIFF
--- a/recipes/base32
+++ b/recipes/base32
@@ -1,5 +1,4 @@
 (base32
  :fetcher gitlab
- :files ("base32.el"
-         (:exclude ".dir-locals.el"))
+ :files ("base32.el")
  :repo "fledermaus/totp.el")

--- a/recipes/base32
+++ b/recipes/base32
@@ -1,5 +1,5 @@
-(totp-auth
+(base32
  :fetcher gitlab
- :files ("totp-*.el"
+ :files ("base32.el"
          (:exclude ".dir-locals.el"))
  :repo "fledermaus/totp.el")

--- a/recipes/totp-auth
+++ b/recipes/totp-auth
@@ -1,4 +1,4 @@
 (totp-auth
  :fetcher gitlab
- :files ("totp-*.el")
+ :files (:defaults (:exclude "base32.el"))
  :repo "fledermaus/totp.el")

--- a/recipes/totp-auth
+++ b/recipes/totp-auth
@@ -1,0 +1,3 @@
+(totp-auth
+ :fetcher gitlab
+ :repo "fledermaus/totp.el")

--- a/recipes/totp-auth
+++ b/recipes/totp-auth
@@ -1,5 +1,4 @@
 (totp-auth
  :fetcher gitlab
- :files ("totp-*.el"
-         (:exclude ".dir-locals.el"))
+ :files ("totp-*.el")
  :repo "fledermaus/totp.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package generates RFC6238 Time-based One Time Passwords and displays them (as well as optionally copying them to the clipboard/primary selection), updating them as they expire.

### Direct link to the package repository

[fledermaus/totp.el](https://gitlab.com/fledermaus/totp.el/)

### Your association with the package

Author & Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  - package lint complains about the prefix to my symbols being totp- rather than totp-auth - there turned out to be a more basic package called totp.el which I hadn't spotted because I only looked in melpa stable, and I didn't want to rename everything if the package was going to be rejected anyway. I can adress this if it's important (and the package is otherwise acceptable). 
- [x] My elisp byte-compiles cleanly
  - there's one warning about a deprecated function but I'm looking into it 
- [x] I've used `M-x checkdoc` to check the package's documentation string
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
