### PR TITLE
ert-results - filter and display ert test results

### DIFF
--- a/recipes/ert-results/ert-results
+++ b/recipes/ert-results/ert-results
@@ -1,0 +1,2 @@
+(ert-results :repo "rswgnu/ert-results"
+            :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

ert-results extends the Emacs Regression Test library, ert.el, with two new commands:

  {f} - (ert-results-filter) - filters display of test results based on point

  {t} - (ert-results-toggle) - toggles display/hiding of all selected tests

### Direct link to the package repository

https://github.com/rswgnu/ert-results

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

 **None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
