### PR TITLE
Add kagi recipe

### DIFF
--- a/recipes/kagi
+++ b/recipes/kagi
@@ -1,0 +1,3 @@
+(kagi
+ :fetcher codeberg
+ :repo "bram85/kagi.el")


### PR DESCRIPTION
### Brief summary of what the package

This Emacs package provides the following functionalities from the [Kagi search engine](https://www.kagi.com):

-   **FastGPT:** Kagi's open source LLM offering, as a shell inspired by [xenodium's chatgpt-shell](https://github.com/xenodium/chatgpt-shell).
-   **Universal Summarizer:** Summarizes texts, webpages, videos and more.

Both functions are accessed through an [API](https://help.kagi.com/kagi/api/overview.html).

### Direct link to the package repository

https://codeberg.org/bram85/kagi.el/

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
