### PR TITLE
Add alternate-file recipe

### DIFF
--- a/recipes/alternate-file
+++ b/recipes/alternate-file
@@ -1,0 +1,3 @@
+(alternate-file :repo "tap349/alternate-file"
+                :fetcher github
+                :files ("alternate-file.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package allows to find alternate file - that is to toggle between implementation and test files. It provides functionality similar to `projectile-toggle-between-implementation-and-test` but aims to be simple and relies on user-supplied settings to find alternate files.

### Direct link to the package repository

https://github.com/tap349/alternate-file

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)