### PR TITLE
Add recipe for sly-overlay

### DIFF
--- a/recipes/sly-overlay
+++ b/recipes/sly-overlay
@@ -1,0 +1,1 @@
+(sly-overlay :fetcher sourcehut :repo "fosskers/sly-overlay")


### PR DESCRIPTION
### Brief summary of what the package does

`sly-overlay` adds evaluation overlays for Common Lisp in the spirit of CIDER and EROS.

### Direct link to the package repository

https://git.sr.ht/~fosskers/sly-overlay

### Your association with the package

Maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
