### PR TITLE
Package org-cite-sidecar

### DIFF
--- a/recipes/org-cite-sidecar
+++ b/recipes/org-cite-sidecar
@@ -1,0 +1,4 @@
+(org-cite-sidecar
+ :fetcher sourcehut
+ :repo "swflint/emacs-universal-sidecar"
+ :files ("org-cite-sidecar.el"))


### PR DESCRIPTION
This package implements a [universal-sidecar](https://git.sr.ht/~swflint/emacs-universal-sidecar) section to display bibliographic references in the present buffer. 

### Direct link to the package repository

https://git.sr.ht/~swflint/emacs-universal-sidecar

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->