### PR TITLE
Add in ebib-sidecar

### DIFF
--- a/recipes/ebib-sidecar
+++ b/recipes/ebib-sidecar
@@ -1,0 +1,4 @@
+(ebib-sidecar
+ :fetcher sourcehut
+ :repo "swflint/emacs-universal-sidecar"
+ :files ("ebib-sidecar.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package implements a sidecar section to show a formatted reference for the bibliography entry at point in Ebib.

### Direct link to the package repository

https://git.sr.ht/~swflint/emacs-universal-sidecar

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->