### PR TITLE
Add recipe for flymake-eldev

### DIFF
--- a/recipes/flymake-eldev
+++ b/recipes/flymake-eldev
@@ -1,0 +1,2 @@
+(flymake-eldev :repo "emacs-eldev/flymake-eldev"
+               :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Make [Flymake](https://www.gnu.org/software/emacs/manual/html_node/emacs/Flymake.html) use proper dependencies in [Eldev](https://github.com/emacs-eldev/eldev) projects. Similar to existing `flycheck-eldev`, only for Flymake rather than Flycheck.

### Direct link to the package repository

https://github.com/emacs-eldev/flymake-eldev

### Your association with the package

Creator and maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- - _There are two warnings about autoloads used, but those are exactly the same as in `flycheck-eldev` that is already in MELPA._

- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
