### PR TITLE
Add recipe for selected-window-accent-mode

### DIFF
--- a/recipes/selected-window-accent-mode
+++ b/recipes/selected-window-accent-mode
@@ -1,0 +1,3 @@
+(selected-window-accent-mode
+ :fetcher github
+ :repo "captainflasmr/selected-window-accent-mode")


### PR DESCRIPTION
### Brief summary of what the package does

The Selected Window Accent Mode is an Emacs package designed to visually distinguish the currently selected window by applying a unique accent color to its fringes, mode line, header line, and margins.

### Direct link to the package repository

https://github.com/captainflasmr/selected-window-accent-mode

### Your association with the package

maintainer
