### PR TITLE
Add Universal Sidecar Citeproc

### DIFF
--- a/recipes/universal-sidecar-citeproc
+++ b/recipes/universal-sidecar-citeproc
@@ -1,0 +1,4 @@
+(universal-sidecar-citeproc
+ :fetcher sourcehut
+ :repo "swflint/emacs-universal-sidecar"
+ :files ("universal-sidecar-citeproc.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`universal-sidecar-citeproc` adds some common utility functions to use citation data in `universal-sidecar` sections.

### Direct link to the package repository

https://git.sr.ht/~swflint/universal-sidecar

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None Needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->