### PR TITLE
[recipe]: Add `app-monochrome`

### DIFF
--- a/recipes/app-monochrome-themes
+++ b/recipes/app-monochrome-themes
@@ -1,0 +1,4 @@
+(app-monochrome-themes
+ :fetcher github
+ :repo "Greybeard-Entertainment/app-monochrome"
+ :branch "barba")

--- a/recipes/app-monochrome-themes
+++ b/recipes/app-monochrome-themes
@@ -1,4 +1,3 @@
 (app-monochrome-themes
  :fetcher github
- :repo "Greybeard-Entertainment/app-monochrome"
- :branch "barba")
+ :repo "Greybeard-Entertainment/app-monochrome")


### PR DESCRIPTION
### Brief summary of what the package does

Low contrast monochromatic theme suitable for OLED that uses font shapes rather than colour for highlighting.

### Direct link to the package repository
https://github.com/Greybeard-Entertainment/app-monochrome

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None

### Checklist


- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
