### PR TITLE
Add org-drawio for handling drawio image in orgmode

### DIFF
--- a/recipes/org-drawio
+++ b/recipes/org-drawio
@@ -1,0 +1,1 @@
+(org-drawio :repo "kimim/org-drawio" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Add a keyword #+drawio for handling drawio image in orgmode.

### Direct link to the package repository

https://github.com/kimim/org-drawio

### Your association with the package

I'm the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
