### PR TITLE
Add recipe for `haproxy-mode`

### DIFF
--- a/recipes/haproxy-mode
+++ b/recipes/haproxy-mode
@@ -1,0 +1,1 @@
+(haproxy-mode :fetcher git :url "https://github.com/port19x/haproxy-mode")

--- a/recipes/haproxy-mode
+++ b/recipes/haproxy-mode
@@ -1,1 +1,1 @@
-(haproxy-mode :fetcher git :url "https://github.com/port19x/haproxy-mode")
+(haproxy-mode :fetcher github :repo "port19x/haproxy-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This package adds a major mode for editing [HAProxy](https://www.haproxy.com/) config files.
HAProxy is a popular reverse proxy and load balancer competing with the likes of Apache, Nginx and Traefik.

### Direct link to the package repository

https://github.com/port19x/haproxy-mode

### Your association with the package

I'm the author / maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
