### PR TITLE
Remove package-safe-delete

### DIFF
--- a/recipes/package-safe-delete
+++ b/recipes/package-safe-delete
@@ -1,1 +1,0 @@
-(package-safe-delete :fetcher github :repo "Fanael/package-safe-delete")


### PR DESCRIPTION
It has been superseded by built-in `package-autoremove`, introduced in Emacs 25.1.