### PR TITLE
Add recipe for org-nix-shell

### DIFF
--- a/recipes/org-nix-shell
+++ b/recipes/org-nix-shell
@@ -1,0 +1,1 @@
+(org-nix-shell :repo "AntonHakansson/org-nix-shell" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Use nix shells directly in org-mode source blocks. `org-nix-shell' works
by seamlessly inheriting a nix shell environment using direnv before
executing org-babel source blocks.


### Direct link to the package repository

https://github.com/AntonHakansson/org-nix-shell

### Your association with the package

I am the contributor, maintainer and user of the package.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
