### PR TITLE
Add recipe for doctest

### DIFF
--- a/recipes/doctest
+++ b/recipes/doctest
@@ -1,0 +1,3 @@
+(doctest
+ :fetcher github
+ :repo "ag91/doctest")


### PR DESCRIPTION
### Brief summary of what the package does

Doctest introduces the possibility of writing (unit) tests directly in the comments of Elisp functions.

### Direct link to the package repository

https://github.com/ag91/doctest

### Your association with the package

I maintain a fork of the original repository, the author allowed me to submit the package to Melpa as they don't plan to work on it further https://github.com/riscy/doctest/issues/4

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
