### PR TITLE
Add recipe for cc-isearch-menu

### DIFF
--- a/recipes/cc-isearch-menu
+++ b/recipes/cc-isearch-menu
@@ -1,0 +1,1 @@
+(cc-isearch-menu :fetcher github :repo "kickingvegas/cc-isearch-menu")


### PR DESCRIPTION
### Brief summary of what the package does

This package contains a Transient menu for isearch. When in basic isearch mode, this menu can be raised by pressing the `<f2>` key.

### Direct link to the package repository

https://github.com/kickingvegas/cc-isearch-menu

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
