### PR TITLE
Add recipe for `pacdiff`

### DIFF
--- a/recipes/pacdiff
+++ b/recipes/pacdiff
@@ -1,0 +1,1 @@
+(pacdiff :fetcher github :repo "fbrosda/pacdiff.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a small wrapper around the pacdiff utility used on Arch Linux systems to update configuration files after package updates.  The respective `.pacnew` files are listed and can be compared with `ediff`. 

### Direct link to the package repository

https://github.com/fbrosda/pacdiff.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
