### PR TITLE
Add index file to rom-party package

### DIFF
--- a/recipes/rom-party
+++ b/recipes/rom-party
@@ -1,1 +1,4 @@
-(rom-party :repo "LaurenceWarne/rom-party.el" :fetcher github)
+(rom-party
+ :repo "LaurenceWarne/rom-party.el"
+ :fetcher github
+ :files (:defaults "index.extmap.gz"))


### PR DESCRIPTION
### Brief summary of what the package does

Hi, this PR is a follow up to discussion in https://github.com/melpa/melpa/pull/8898.  It adds the index used by the package to `:files` so that it doesn't need to be installed when the package is first used.

### Direct link to the package repository

https://github.com/LaurenceWarne/rom-party.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
