### PR TITLE
Add recipe for ISO 639

### DIFF
--- a/recipes/iso-639
+++ b/recipes/iso-639
@@ -1,0 +1,1 @@
+(iso-639 :fetcher codeberg :repo "WammKD/emacs-iso-639")


### PR DESCRIPTION
### Brief summary of what the package does

Allows users to lookup ISO 639-1–3 language codes, namely. I couldn't seem to find anything in-built in Emacs (though definitely let me know if I've just missed it) and most packages which use such codes seem to roll their own, simplified versions.

I figured having a library to access the whole standardized nomenclature would be useful.

### Direct link to the package repository

https://codeberg.org/WammKD/emacs-iso-639

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
  - So this builds fine but it keeps failing to install; the only error I get back is `tar--check-descriptor: Wrong type argument: arrayp, nil` but it's not clear to be as to why. The package definition seems correct and I'm at a loss as to what the issue may be. As I've done all the other steps, I figured opening a PR so actual Melpa maintainers could look at my package and, perhaps, have better insight would be acceptable.

<!-- After submitting, please fix any problems the CI reports. -->
