### PR TITLE
Update url of flycheck-eglot's repository

### DIFF
--- a/recipes/flycheck-eglot
+++ b/recipes/flycheck-eglot
@@ -1,1 +1,1 @@
-(flycheck-eglot :fetcher github :repo "intramurz/flycheck-eglot")
+(flycheck-eglot :fetcher github :repo "flycheck/flycheck-eglot")


### PR DESCRIPTION
The `flycheck-eglot`'s repository has been moved to the [flycheck](https://github.com/flycheck) organization.