### PR TITLE
New recipe: fmo-mode

### DIFF
--- a/recipes/fmo-mode
+++ b/recipes/fmo-mode
@@ -1,0 +1,1 @@
+(fmo-mode :fetcher github :repo "xeechou/fmo-mode.el")


### PR DESCRIPTION
### Brief summary of what the package does

A simple package to allow you run formatters like (clang-format) only on changed lines instead of whole file before saving buffer.

### Direct link to the package repository

https://github.com/xeechou/fmo-mode.el

### Your association with the package
Maintainer


### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
