### PR TITLE
Adding recipe for embark-org-roam.

### DIFF
--- a/recipes/embark-org-roam
+++ b/recipes/embark-org-roam
@@ -1,0 +1,1 @@
+(embark-org-roam :fetcher github :repo "bramadams/embark-org-roam")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides an embark export buffer for org roam nodes, which is super-useful when “harvesting” your org-roam knowledge base for sources to be used for a specific paper, diary entry, development task, etc. The buffer uses org-mode, and by default lists the selected org roam nodes in a checklist, allowing to check off items as you are processing them.

### Direct link to the package repository

https://github.com/bramadams/embark-org-roam

### Your association with the package

Main author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
