### PR TITLE
add org-clock-agenda-daytime-mode

### DIFF
--- a/recipes/org-clock-agenda-daytime-mode
+++ b/recipes/org-clock-agenda-daytime-mode
@@ -1,0 +1,1 @@
+(org-clock-agenda-daytime-mode :repo "ArneBab/emacs-org-clock-daytime" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

display the time clocked today in the modeline

### Direct link to the package repository

https://github.com/ArneBab/emacs-org-clock-daytime

### Your association with the package

Creator

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
