### PR TITLE
Update files for org-caldav

### DIFF
--- a/recipes/org-caldav
+++ b/recipes/org-caldav
@@ -1,4 +1,3 @@
 (org-caldav
  :repo "dengste/org-caldav"
- :fetcher github
- :files ("org-caldav.el"))
+ :fetcher github)


### PR DESCRIPTION
Hello, I am maintaining https://github.com/dengste/org-caldav. I've added a texinfo manual (`doc/org-caldav.texi`) that I would like MELPA to install.

Since I believe `*.texi` is automatically picked up by the default value of `:files`, I've simply reset `:files` to the default value. Also note I renamed `org-caldav-testsuite.el` so it would be automatically excluded ([commit](https://github.com/dengste/org-caldav/commit/f5559ddd6a56c9129902933f111be1a7a05119bd)).

However let me know if it would be better to manually set `:files ("org-caldav.el" "doc/org-caldav.texi")` instead of removing `:files` altogether.

UPDATE: After opening this PR, I renamed `org-caldav-manual.texi` to `doc/org-caldav.texi`, otherwise the Info entry created by `package-build-current-recipe` couldn't find the manual