### PR TITLE
Add recipe for roc-ts-mode

### DIFF
--- a/recipes/roc-ts-mode
+++ b/recipes/roc-ts-mode
@@ -1,0 +1,2 @@
+(roc-ts-mode :repo "miilyn/roc-ts-mode"
+             :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Provide a major mode for the [Roc programming language](https://www.roc-lang.org/).

Version `0.0.1` aims to provide these initial features:

- Syntax highlighting (via [`tree-sitter`](https://github.com/faldor20/tree-sitter-roc))
- Indentation (partly via [`tree-sitter`](https://github.com/faldor20/tree-sitter-roc))
- A convenient way to install the `tree-sitter` [grammar for Roc](https://github.com/faldor20/tree-sitter-roc)

### Direct link to the package repository

https://github.com/miilyn/roc-ts-mode

### Your association with the package

I am the creator, contributor, maintainer and user of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

**Note**:
Unfortunately I wasn't able to successfully run `make recipes/roc-ts-mode` using my local Emacs build (version `30.0.50`):

```bash
Error: void-function (package--prepare-dependencies)
```

(this seems to be a related to [this issue](https://github.com/melpa/melpa/issues/8929))
