### PR TITLE
Update flymake-fennel, deno-ts-mode, and flymake-clippy from sourcehut to github

### DIFF
--- a/recipes/deno-ts-mode
+++ b/recipes/deno-ts-mode
@@ -1,3 +1,3 @@
 (deno-ts-mode
- :fetcher sourcehut
+ :fetcher github
  :repo "mgmarlow/deno-ts-mode")

--- a/recipes/flymake-clippy
+++ b/recipes/flymake-clippy
@@ -1,3 +1,3 @@
 (flymake-clippy
- :fetcher sourcehut
+ :fetcher github
  :repo "mgmarlow/flymake-clippy")

--- a/recipes/flymake-fennel
+++ b/recipes/flymake-fennel
@@ -1,3 +1,3 @@
 (flymake-fennel
- :fetcher sourcehut
+ :fetcher github
  :repo "mgmarlow/flymake-fennel")


### PR DESCRIPTION
I'm the maintainer of these packages and the Github source is now the primary. The username is the same between the two services, so just need to update the fetcher. Here are the new links:

- https://github.com/mgmarlow/flymake-fennel
- https://github.com/mgmarlow/flymake-clippy
- https://github.com/mgmarlow/deno-ts-mode

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
