### PR TITLE
Add retraction-viewer

### DIFF
--- a/recipes/retraction-viewer
+++ b/recipes/retraction-viewer
@@ -1,0 +1,3 @@
+(retraction-viewer :fetcher sourcehut
+                   :repo "swflint/retraction-viewer"
+                   :files ("retraction-viewer.el"))

--- a/recipes/retraction-viewer-section
+++ b/recipes/retraction-viewer-section
@@ -1,0 +1,3 @@
+(retraction-viewer-section :fetcher sourcehut
+                           :repo "swflint/retraction-viewer"
+                           :files ("retraction-viewer-section.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`retraction-viewer` provides a way to show links to retraction notices for bibliographic items using the CrossRef API (experimental, based on RetractionWatch data).
It provides integration with `bibtex-mode` and [`ebib`](http://joostkremers.github.io/ebib/) (also on MELPA), and will show retraction notices through either a [universal sidecar](https://git.sr.ht/~swflint/emacs-universal-sidecar) section or `eldoc`.

### Direct link to the package repository

https://git.sr.ht/~swflint/retraction-viewer

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->