### PR TITLE
Add org-sliced-images

### DIFF
--- a/recipes/org-sliced-images
+++ b/recipes/org-sliced-images
@@ -1,0 +1,1 @@
+(org-sliced-images :fetcher github :repo "jcfk/org-sliced-images")


### PR DESCRIPTION
### Brief summary of what the package does

Display images as sliced images in org-mode, just like `insert-sliced-image`. This makes scrolling nicer. It overrides a number of the default image-display functions.

### Direct link to the package repository

https://github.com/jcfk/org-sliced-images

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
