### PR TITLE
Add recipe for CRC (Cyclic Redundancy Check)

### DIFF
--- a/recipes/crc
+++ b/recipes/crc
@@ -1,0 +1,1 @@
+(crc :fetcher codeberg :repo "WammKD/Emacs-CRC")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a bunch of functions for various CRC algorithms, making it unnecessary for Emacs libraries to implement them themselves (or understand how they work).

### Direct link to the package repository

https://codeberg.org/WammKD/Emacs-CRC

### Your association with the package

Creator and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
_`package-lint` does complain about my use of `/` in function names though I find they make it easier to skim and process all of the similar function prefixes (`crc-8` vs. `crc-16` vs. `crc-32`, etc.) and matches the usual naming convention for CRC algorithms; if it would be preferred these are switched to hyphens – though –, just let me know_
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
