### PR TITLE
Add lazy-ruff recipe

### DIFF
--- a/recipes/lazy-ruff
+++ b/recipes/lazy-ruff
@@ -1,0 +1,2 @@
+(lazy-ruff :fetcher github
+           :repo "christophermadsen/emacs-lazy-ruff")


### PR DESCRIPTION
### Brief summary of what the package does

The package `lazy-ruff` integrates easy usage of the [**ruff** formatter and linter](https://github.com/astral-sh/ruff) in native (emacs-)lisp without any dependencies (besides **ruff** itself). It provides functions for formatting and linting org-babel Python code blocks, arbitary selected regions of Python code and whole Python major mode buffers. It also provides functionality for lazily using a single function that knows what to call based on the context the cursor/pointer is in (*dwim*).

`Lazy-ruff` is not meant to replace other Emacs **ruff** implementations, but simply provide an alternative sans dependencies with some *dwim* added to it.

### Direct link to the package repository

https://github.com/christophermadsen/emacs-lazy-ruff

### Your association with the package

I am the creator of the package and the sole developer for now.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
