### PR TITLE
Add insert-pair-edit recipe

### DIFF
--- a/recipes/insert-pair-edit
+++ b/recipes/insert-pair-edit
@@ -1,9 +1,0 @@
-(insert-pair-edit :fetcher github
-                  :branch  "melpa"
-                  :repo    "BriansEmacs/insert-pair-edit.el"
-                  :files   ("*.el"
-                            "modes/*.el"
-                            "ipe.texi"
-                            "DEPENDENCIES.txt"
-                            "README.md"
-                            (:exclude "ipe-mc.el")))

--- a/recipes/insert-pair-edit
+++ b/recipes/insert-pair-edit
@@ -1,0 +1,9 @@
+(insert-pair-edit :fetcher github
+                  :branch  "melpa"
+                  :repo    "BriansEmacs/insert-pair-edit.el"
+                  :files   ("*.el"
+                            "modes/*.el"
+                            "ipe.texi"
+                            "DEPENDENCIES.txt"
+                            "README.md"
+                            (:exclude "ipe-mc.el")))

--- a/recipes/ipe
+++ b/recipes/ipe
@@ -1,0 +1,6 @@
+(ipe :fetcher github
+     :repo    "BriansEmacs/insert-pair-edit.el"
+     :files   ("ipe*.el"
+               "modes/ipe-*.el"
+               "ipe.texi"
+               "LICENSE"))

--- a/recipes/ipe
+++ b/recipes/ipe
@@ -1,6 +1,3 @@
 (ipe :fetcher github
      :repo    "BriansEmacs/insert-pair-edit.el"
-     :files   ("ipe*.el"
-               "modes/ipe-*.el"
-               "ipe.texi"
-               "LICENSE"))
+     :files   (:defaults "modes/ipe-*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package defines a command, `ipe-insert-pair-edit`, which offers a more feature rich alternative to the standard `M-(` **Emacs**
keybinding, `insert-parentheses`.  The `ipe-insert-pair-edit` command allows for the interactive insertion, update and deletion of `customize`-able PAIRs via the use of _overlays_.

Executing the `ipe-insert-pair-edit` command will first prompt the user to enter a `customize`-able **MNEMONIC**, that selects a _major-mode dependent_ **PAIR** to be inserted around point.  It will then enter `ipe-edit-mode` to move the **OPEN** and **CLOSE** strings into the correct positions. Screenshots are available in package repository the link below.

### Direct link to the package repository

https://github.com/BriansEmacs/insert-pair-edit.el

### Your association with the package

The maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
