### PR TITLE
Add recipe for password-menu.

### DIFF
--- a/recipes/password-menu
+++ b/recipes/password-menu
@@ -1,0 +1,1 @@
+(password-menu :repo "rnadler/password-menu" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

password-menu is a UI wrapper for the built-in Emacs `auth-source' library.

### Direct link to the package repository

https://github.com/rnadler/password-menu

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a The MIT License (MIT).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
