### PR TITLE
Add sub folders missing from recipe

### DIFF
--- a/recipes/hyperbole
+++ b/recipes/hyperbole
@@ -6,11 +6,11 @@
             "HY-WHY.kotl" "INSTALL" "DEMO" "DEMO-ROLO.otl" "FAST-DEMO"
             "README.md" "TAGS" "_hypb" ".hypb" "smart-clib-sym" "topwin.py"
             "hyperbole-banner.png"
-            ("kotl" "MANIFEST" "EXAMPLE.kotl" "kotl/*.el")
+            ("kotl" "kotl/MANIFEST" "kotl/EXAMPLE.kotl" "kotl/*.el")
             ("man" "man/hyperbole.texi" "man/version.texi" "man/hyperbole.css"
              "man/hkey-help.txt" "man/hyperbole.info" "man/hyperbole.html"
              "man/hyperbole.pdf")
             ("man/im" "man/im/*.png")
             ("HY-TALK" "HY-TALK/.hypb" "HY-TALK/HYPB" "HY-TALK/HY-TALK.org"
              "HY-TALK/HYPERAMP.org" "HY-TALK/HYPERORG.org")
-            ("test" "MANIFEST" "test/*tests.el" "test/hy-test-*.el")))
+            ("test" "test/MANIFEST" "test/*tests.el" "test/hy-test-*.el")))


### PR DESCRIPTION
# What

Add sub folders missing from recipe.

# Why

We missed to specify properly the paths to some of the files in the sub folders `kotl` and `test.` This PR corrects this.  Sorry for not testing this properly before. We now have at least an install test that post a melpa release verifies that an install from melpa works properly. That test spotted the problem. 
