### PR TITLE
company-emoji: move to codeberg repository

### DIFF
--- a/recipes/company-emoji
+++ b/recipes/company-emoji
@@ -1,1 +1,1 @@
-(company-emoji :repo "dunn/company-emoji" :fetcher github)
+(company-emoji :repo "egirl/company-emoji" :fetcher codeberg)


### PR DESCRIPTION
i've moved the repository to codeberg: https://codeberg.org/egirl/company-emoji

i've noted this on the old repository and archived it: https://github.com/dunn/company-emoji
