### PR TITLE
feat: add markdown-ts-mode

### DIFF
--- a/recipes/markdown-ts-mode
+++ b/recipes/markdown-ts-mode
@@ -1,0 +1,3 @@
+(markdown-ts-mode
+  :repo "LionyxML/markdown-ts-mode"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for Emacs providing really BASIC syntax highlight for
markdown files using treesitter.

### Direct link to the package repository

https://github.com/LionyxML/markdown-ts-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
