### PR TITLE
feat: add flymake-margin

### DIFF
--- a/recipes/flymake-margin
+++ b/recipes/flymake-margin
@@ -1,0 +1,3 @@
+(flymake-margin
+  :repo "LionyxML/flymake-margin"
+  :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A package to provide Emacs Flymake marks into the margin world.

### Direct link to the package repository

https://github.com/LionyxML/flymake-margin

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
