### PR TITLE
Update hyperbole recipe - Drop version.texi

### DIFF
--- a/recipes/hyperbole
+++ b/recipes/hyperbole
@@ -7,7 +7,7 @@
             "README.md" "TAGS" "_hypb" ".hypb" "smart-clib-sym" "topwin.py"
             "hyperbole-banner.png"
             ("kotl" "kotl/MANIFEST" "kotl/EXAMPLE.kotl" "kotl/*.el")
-            ("man" "man/hyperbole.texi" "man/version.texi" "man/hyperbole.css"
+            ("man" "man/hyperbole.texi" "man/hyperbole.css"
              "man/hkey-help.txt" "man/hyperbole.info" "man/hyperbole.html"
              "man/hyperbole.pdf")
             ("man/im" "man/im/*.png")


### PR DESCRIPTION
## What

Drop version.texi

## Why

version.texi has been removed from hyperbole git repository.
