### PR TITLE
Remove mu4e-crypto

### DIFF
--- a/recipes/mu4e-crypto
+++ b/recipes/mu4e-crypto
@@ -1,1 +1,0 @@
-(mu4e-crypto :repo "meritamen/mu4e-crypto" :fetcher github)


### PR DESCRIPTION
I'm the author of this package. I think it's a little bit redundant as few use it and I not longer use mu4e.