### PR TITLE
Add recipe for quickroam

### DIFF
--- a/recipes/quickroam/quickroam
+++ b/recipes/quickroam/quickroam
@@ -1,0 +1,1 @@
+(quickroam :fetcher github :repo "meedstrom/quickroam")


### PR DESCRIPTION
### Brief summary of what the package does

Provide a ripgrep-based mechanism to find org-roam nodes.

Lots of people run into performance issues with org-roam, it's a real head-scratcher as seen on https://org-roam.discourse.group/t/improving-performance-of-node-find-et-al/3326.

I take a page from orgrr/denote/zk, which also use simple filesystem searches, but they have a different on-disk format than org-roam does (they disallow nesting nodes while org-roam allows it, and they identify nodes by filename while org-roam identifies them by text strings inside the file), so I saw no way to integrate with these.

### Direct link to the package repository

https://github.com/meedstrom/quickroam

### Your association with the package

I am the maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

I ran into an odd snag when testing the install because it says "package unavailable org-roam". But it tries to get version 2.2.2, which does exist: https://stable.melpa.org/#/org-roam.