### PR TITLE
Add recipe for swift-ts-mode

### DIFF
--- a/recipes/swift-ts-mode
+++ b/recipes/swift-ts-mode
@@ -1,0 +1,1 @@
+(swift-ts-mode :fetcher github :repo "rechsteiner/swift-ts-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A tree-sitter based major-mode for [Swift](https://swift.org), with support for font-locking, imenu and indentation.

### Direct link to the package repository

https://github.com/rechsteiner/swift-ts-mode

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
