### PR TITLE
Add hyperstitional-themes

### DIFF
--- a/recipes/hyperstitional-themes
+++ b/recipes/hyperstitional-themes
@@ -1,0 +1,1 @@
+(hyperstitional-themes :fetcher github :repo "precompute/hyperstitional-themes")


### PR DESCRIPTION
### Brief summary of what the package does

Themes with weird colors

### Direct link to the package repository

https://github.com/precompute/hyperstitional-themes

### Your association with the package

Maintainer, contributor and an enthusiastic user.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

Melpazoid says:
`hyperstitional-themes-digitalsear-inverted-theme.el` with package-lint 20240330.1458:
```
1 issue found:
172:5: error: `eldoc-highlight-function-argument' was removed in Emacs version 25.1.
```

`hyperstitional-themes-digitalsear-theme.el` with package-lint 20240330.1458:
```
1 issue found:
172:5: error: `eldoc-highlight-function-argument' was removed in Emacs version 25.1.
```

However, this face exists:
https://github.com/emacs-mirror/emacs/blob/a3f6d92714c31ccb87f56b13ee2606c05493c87d/lisp/emacs-lisp/eldoc.el#L141

So I haven't removed it.