### PR TITLE
Update repository of julia-ts-mode

### DIFF
--- a/recipes/julia-ts-mode
+++ b/recipes/julia-ts-mode
@@ -1,2 +1,2 @@
-(julia-ts-mode :repo "ronisbr/julia-ts-mode"
+(julia-ts-mode :repo "JuliaEditorSupport/julia-ts-mode"
                :fetcher github)


### PR DESCRIPTION
The package `julia-ts-mode` was moved to the organization JuliaEditorSupport. This PR updates the link of this package in MELPA.