### PR TITLE
Add org-web-track recipe

### DIFF
--- a/recipes/org-web-track
+++ b/recipes/org-web-track
@@ -1,0 +1,1 @@
+(org-web-track :fetcher github :repo "p-snow/org-web-track")


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs package to help users keep track of data snippets from web pages or web APIs in Org Mode

### Direct link to the package repository

https://github.com/p-snow/org-web-track

### Your association with the package

I'm the package author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)