### PR TITLE
Update url for for anki-editor's repository

### DIFF
--- a/recipes/anki-editor
+++ b/recipes/anki-editor
@@ -1,1 +1,1 @@
-(anki-editor :fetcher github :repo "louietan/anki-editor")
+(anki-editor :fetcher github :repo "anki-editor/anki-editor")


### PR DESCRIPTION
The original maintainer, @louietan, has not been responsive for a number of years, see for example [l/anki-editor#101]. As such, several people have now banded together to create `anki-editor/anki-editor` as a place to communally continue developing this package; see [anki-editor#31]. I hope changing ownership on MELPA is acceptable under these circumstances.

Cc.: @orgtre @renatgalimov

Closes: https://github.com/anki-editor/anki-editor/issues/20

[l/anki-editor#101]: https://github.com/louietan/anki-editor/issues/101
[anki-editor#31]: https://github.com/anki-editor/anki-editor/issues/31

### Brief summary of what the package does

Emacs minor mode for making Anki cards with Org Mode

### Direct link to the package repository

https://github.com/anki-editor/anki-editor

### Your association with the package

One of the maintainers—of the new repository, that is.

### Relevant communications with the upstream package maintainer

E.g., https://github.com/louietan/anki-editor/issues/101 as well as several other communication attempts in other issues.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings

  Checkdoc gives tons of errors, but these would seem to require some time to fix. I'd much rather do this later, when cleaning up bits of spaghetti off the floor anyways :)

- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)