### PR TITLE
Add magit-file-icons recipe

### DIFF
--- a/recipes/magit-file-icons
+++ b/recipes/magit-file-icons
@@ -1,0 +1,3 @@
+(magit-file-icons
+ :fetcher github
+ :repo "gekoke/magit-file-icons")


### PR DESCRIPTION
-------

### Brief summary of what the package does

Hooks into Magit with [el-patch](https://github.com/radian-software/el-patch) to prefix file names with [nerd-icons](https://github.com/rainstormstudio/nerd-icons.el) icons.

### Direct link to the package repository

https://github.com/gekoke/magit-file-icons

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->