### PR TITLE
add recipe for toggle-term.el

### DIFF
--- a/recipes/toggle-term
+++ b/recipes/toggle-term
@@ -1,0 +1,1 @@
+(toggle-term :repo "justinlime/toggle-term.el" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

toggle-term.el provides a means of quick access to some commonly used buffers, such as `terms`, `shells`, `eshells`, and `ielms`. These buffers can be given a set size, and toggled with a keybind. Multiple toggles can be active and users have the ability to switch between them.

### Direct link to the package repository

https://github.com/justinlime/toggle-term.el

### Your association with the package

Package maintainer

### Relevant communications with the upstream package maintainer

None Needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
