### PR TITLE
Add recipe for sink

### DIFF
--- a/recipes/sink
+++ b/recipes/sink
@@ -1,0 +1,3 @@
+(sink
+ :fetcher github
+ :repo "alcah/sink.el")


### PR DESCRIPTION
### Brief summary of what the package does

sink-mode is a global minor mode enabling emacs to receive and act on messages from the Plan9 plumber via the latter's ports interface. 

### Direct link to the package repository

https://github.com/alcah/sink.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
