### PR TITLE
Add recipe for git-grep-transient

### DIFF
--- a/recipes/git-grep-transient
+++ b/recipes/git-grep-transient
@@ -1,0 +1,1 @@
+(git-grep-transient :repo "adelplanque/git-grep-transient" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Small transient interface for git-grep command.
There is already a [git-grep](https://github.com/tychoish/git-grep.el) package, but it does not allow searching on a revision other than the current worktree.

### Direct link to the package repository

https://github.com/adelplanque/git-grep-transient

### Your association with the package

I am the author of this package.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
