### PR TITLE
Remove ac-cider

### DIFF
--- a/recipes/ac-cider
+++ b/recipes/ac-cider
@@ -1,3 +1,0 @@
-(ac-cider :fetcher github
-          :repo "clojure-emacs/ac-cider"
-          :old-names (ac-cider-compliment))


### PR DESCRIPTION
### Brief summary of what the package does

AC-cider was an early auto-complete extension for CIDER. It hasn't been updated since 2018 and very likely no longer works with the latest CIDER. Company-mode and Corfu are the preferred engines for CIDER autocompletions.

### Direct link to the package repository

https://github.com/clojure-emacs/ac-cider

### Your association with the package

I'm the author of the package.