### PR TITLE
dslide

### DIFF
--- a/recipes/dslide
+++ b/recipes/dslide
@@ -1,0 +1,1 @@
+(dslide :fetcher github :repo "positron-solutions/dslide")


### PR DESCRIPTION
### Brief summary of what the package does

Domain Specific sLIDEs, a more configurable, extensible re-write of org-tree-slide, taking an approach appropriate for integrating with other all of the other buffers of Emacs.   It integrates org babel blocks into the same forward-backward interface.  Try it by calling `dslides-deck-start` on test/demo.org for a preview.

It's in heavy development, but the releases I cut should run the demo well.

### Direct link to the package repository

https://github.com/positron-solutions/dslide

### Your association with the package

Author.  I forked from org-tree-slide but ended up completely re-writing about 95% using the org element API and EIEIO.

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
