### PR TITLE
add zero-input-panel-posframe package.

### DIFF
--- a/recipes/zero-input-panel-posframe
+++ b/recipes/zero-input-panel-posframe
@@ -1,0 +1,3 @@
+(zero-input-panel-posframe
+ :fetcher git
+ :url "https://gitlab.emacsos.com/sylecn/zero-input-panel-posframe.git")


### PR DESCRIPTION
### Brief summary of what the package does
zero-input is a Chinese input method framework written as Emacs minor mode. This package provides an optional panel based on posframe package. A panel is used to show candidates for zero-input methods.

### Direct link to the package repository

https://gitlab.emacsos.com/sylecn/zero-input-panel-posframe.git

### Your association with the package

I am the author and maintainer of this new package and the original zero-input package, which this package depends on.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
