### PR TITLE
Add recipe for dehyphenate.

### DIFF
--- a/recipes/dehyphenate
+++ b/recipes/dehyphenate
@@ -1,0 +1,1 @@
+(dehyphenate :fetcher sourcehut :repo "breadbox/dehyphenate")


### PR DESCRIPTION
### Brief summary of what the package does

This file provides two functions for finding words in a buffer that have been hyphenated across lines (such as appear in books and other printed text) and fixing them up so that they are no longer hyphenated.

### Direct link to the package repository

https://git.sr.ht/~breadbox/dehyphenate

### Your association with the package

Author and maintaner.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
