### PR TITLE
Add recipe for dired-open-with

### DIFF
--- a/recipes/dired-open-with
+++ b/recipes/dired-open-with
@@ -1,0 +1,3 @@
+(dired-open-with
+ :fetcher github
+ :repo "FrostyX/dired-open-with")


### PR DESCRIPTION
### Brief summary of what the package does

Right-clicking a file in most GUI file managers provides an “Open with” menu for choosing which application should be used. This package implements such functionality for Dired.

It looks like this:

![dired-open-with](https://github.com/melpa/melpa/assets/2151771/21d37958-6073-4b53-aa65-f39c5d98d9ab)

### Direct link to the package repository

https://github.com/FrostyX/dired-open-with

### Your association with the package

Package author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
