### PR TITLE
Add qwen-chat-shell package

### DIFF
--- a/recipes/qwen-chat-shell
+++ b/recipes/qwen-chat-shell
@@ -1,0 +1,4 @@
+(qwen-chat-shell
+ :fetcher github
+ :repo "Pavinberg/qwen-chat-shell"
+ :files ("qwen-chat-shell.el"))

--- a/recipes/qwen-chat-shell
+++ b/recipes/qwen-chat-shell
@@ -1,4 +1,3 @@
 (qwen-chat-shell
- :fetcher github
  :repo "Pavinberg/qwen-chat-shell"
- :files ("qwen-chat-shell.el"))
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A chat shell in Emacs for [Qwen](https://github.com/QwenLM/Qwen) language model series, because Qwen models, APIs and recommended prompts differ from the OpenAI.

This package is inspired by [chatgpt-shell](https://github.com/xenodium/chatgpt-shell).

### Direct link to the package repository

https://github.com/Pavinberg/qwen-chat-shell

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
