### PR TITLE
Add recipe for Casual Info

### DIFF
--- a/recipes/casual-info
+++ b/recipes/casual-info
@@ -1,0 +1,1 @@
+(casual-info :fetcher github :repo "kickingvegas/casual-info")


### PR DESCRIPTION
### Brief summary of what the package does

Casual Info is a Transient menu for the Emacs [Info](https://www.gnu.org/software/emacs/manual/html_node/info/) reader.

### Direct link to the package repository

https://github.com/kickingvegas/casual-info

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
