### PR TITLE
Add recipe for trimspace-mode

### DIFF
--- a/recipes/trimspace-mode
+++ b/recipes/trimspace-mode
@@ -1,0 +1,1 @@
+(trimspace-mode :fetcher sourcehut :repo "bkhl/trimspace-mode")


### PR DESCRIPTION
A minor mode to trim trailing whitespace/newlines.

### Brief summary of what the package does

This is a package I have used myself for a couple of years now and think is quite useful.

The main component is a minor mode that simply sets local variables/hooks to enable Emacs' own automatic trimming of trailing space/newlines on save.

It has a function `trimspace-mode-unless-trailing-whitespace` which can be used as a hook for all file modes to enable it if you open a file that already is "clean" of trailing whitespace.

To use it on a file that has trailing whitespace since earlier you just manually enable the mode. 

### Direct link to the package repository

https://git.sr.ht/~bkhl/trimspace-mode/

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
