### PR TITLE
Add recipe for unspecified-theme

### DIFF
--- a/recipes/unspecified-theme
+++ b/recipes/unspecified-theme
@@ -1,0 +1,3 @@
+(unspecified-theme
+ :fetcher codeberg
+ :repo "mekeor/unspecified-theme")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a theme that sets all attributes of most (if not all) faces from most (if not all) Emacs packages to `unspecified`.

> [!NOTE]  
> This package (*unspecified-theme*) depends on the package *most-faces* for which I submitted [this PR](https://github.com/melpa/melpa/pull/9051) to add its recipe.

### Direct link to the package repository

https://codeberg.org/mekeor/unspecified-theme

### Your association with the package

I'm the author and maintainer. (I have an intact, confirmed copyright-assignment to the FSF.)

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)