### PR TITLE
Add recipe for meow-tree-sitter

### DIFF
--- a/recipes/meow-tree-sitter
+++ b/recipes/meow-tree-sitter
@@ -1,0 +1,4 @@
+(meow-tree-sitter
+ :fetcher github
+ :repo "skissue/meow-tree-sitter"
+ :files (:defaults "queries"))


### PR DESCRIPTION
### Brief summary of what the package does

Integrates the `treesit` library in Emacs 29+ with [Meow](https://github.com/meow-edit/meow)’s motions.

### Direct link to the package repository

https://github.com/skissue/meow-tree-sitter

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
