### PR TITLE
Add recipe for dumber-jump

### DIFF
--- a/recipes/dumber-jump
+++ b/recipes/dumber-jump
@@ -1,0 +1,3 @@
+(dumber-jump :fetcher github
+             :repo "zenspider/dumber-jump"
+             :branch "dumber-jump")


### PR DESCRIPTION
### Brief summary of what the package does

Dumber Jump is a fork from dumb-jump that removes as many
configuration options as possible to go back to the roots of being a
fairly config-free "dumb" jump. This version doesn't support other
searchers, doesn't support alternative display methods, and only
interfaces through xref.

Note: while this package is a "fork", it is a massive divergence at
this point:

```
$ git diff master.. | lc
    5699
```

byte-compile is mostly complaining about 80 char widths at this point.

checkdoc... ugh. this tool. working on it.

### Direct link to the package repository

https://github.com/zenspider/dumber-jump

### Your association with the package

I am the maintainer (of this fork)

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->