### PR TITLE
Update url for rustic's repository

### DIFF
--- a/recipes/rustic
+++ b/recipes/rustic
@@ -1,3 +1,3 @@
 (rustic
-    :repo "brotzeit/rustic"
+    :repo "emacs-rustic/rustic"
     :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Rust mode for Emacs

### Direct link to the package repository

https://github.com/emacs-rustic/rustic

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

@brotzeit is the owner of the original package at https://github.com/brotzeit/rustic. However it has not been maintained in over a year, and has built a large backlog of issues and PR's. No one has been able to reach the repo owner. One of the maintainers @psibi of the original package created a new organization with a community maintained fork (https://github.com/psibi/rustic/issues/23 and https://github.com/emacs-rustic/rustic/issues/1). We shared this with the community [here](https://www.reddit.com/r/emacs/comments/1csa4wv/new_home_for_rustic/).

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
