### PR TITLE
Add recipe for kanagawa-theme.

### DIFF
--- a/recipes/kanagawa-theme
+++ b/recipes/kanagawa-theme
@@ -1,7 +1,3 @@
 (kanagawa-theme
- :fetcher git
- :url "https://github.com/Fabiokleis/emacs-kanagawa-theme"
- :repo "Fabiokleis/emacs-kanagawa-theme"
- :commit "b06003ec44472af136dfa7d07b862525c74dd39c"
- :branch "main"
- :files ("kanagawa-theme.el"))
+ :fetcher github
+ :repo "Fabiokleis/emacs-kanagawa-theme")

--- a/recipes/kanagawa-theme
+++ b/recipes/kanagawa-theme
@@ -1,0 +1,7 @@
+(kanagawa-theme
+ :fetcher git
+ :url "https://github.com/Fabiokleis/emacs-kanagawa-theme"
+ :repo "Fabiokleis/emacs-kanagawa-theme"
+ :commit "b06003ec44472af136dfa7d07b862525c74dd39c"
+ :branch "main"
+ :files ("kanagawa-theme.el"))


### PR DESCRIPTION
### Brief summary of what the package does

 kanagawa-theme.el --- An elegant theme inspired by The Great Wave off Kanagawa by Katsushika Hokusa. From new github source.

### Direct link to the package repository

https://github.com/Fabiokleis/emacs-kanagawa-theme

### Your association with the package

I'm openning this pr cause the old maintainer Shira Filianore <meritamen@sdf.org> disappeared, I didn't modify
anything, just re adding emacs package of kanagawa theme.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
