### PR TITLE
Update url of eglot-signature-eldoc-talkative's repository

### DIFF
--- a/recipes/eglot-signature-eldoc-talkative
+++ b/recipes/eglot-signature-eldoc-talkative
@@ -1,3 +1,3 @@
 (eglot-signature-eldoc-talkative
  :fetcher codeberg
- :repo "mekeor/emacs-eglot-signature-eldoc-talkative")
+ :repo "mekeor/eglot-signature-eldoc-talkative")


### PR DESCRIPTION
I want to drop the `emacs-` prefix of the repository name. For smooth transition, there are currently both of these repositories with equal content:

- https://codeberg.org/mekeor/emacs-eglot-signature-eldoc-talkative
- https://codeberg.org/mekeor/eglot-signature-eldoc-talkative

### Brief summary of what the package does

Alternative to `eglot-signature-eldoc-function` that echos active-parameter and signature information.

### Direct link to the package repository

https://codeberg.org/mekeor/eglot-signature-eldoc-talkative

### Your association with the package

Maintainer and author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)