### PR TITLE
Create weblorg-ng recipe

### DIFF
--- a/recipes/weblorg
+++ b/recipes/weblorg
@@ -1,1 +1,1 @@
-(weblorg :fetcher github :repo "emacs-love/weblorg" :files (:defaults "themes"))
+(weblorg :fetcher github :repo "markokocic/weblorg" :files (:defaults "themes"))


### PR DESCRIPTION
weblorg-ng is a soft-fork of weblorg which adds patches that restores compatibility with the latest org-mode 9.7

This fork will be deleted as soon as the original weblorg project is brought up to date.

### Brief summary of what the package does

This is a weblorg fork that fixes issues with the latest org-mode versions 9.7+

### Direct link to the package repository

https://github.com/markokocic/weblorg

### Your association with the package

I am maintaining a fork.

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
