### PR TITLE
Add recipe for vterm-hotkey

### DIFF
--- a/recipes/vterm-hotkey
+++ b/recipes/vterm-hotkey
@@ -1,0 +1,1 @@
+(vterm-hotkey :repo "rootatpixel/vterm-hotkey" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Allows the user to switch between vterm buffers quickly using hotkeys.

### Direct link to the package repository

https://github.com/rootatpixel/vterm-hotkey

### Your association with the package

Author/Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
