### PR TITLE
Add recipe for clang-format-remote

### DIFF
--- a/recipes/clang-format-lite
+++ b/recipes/clang-format-lite
@@ -1,0 +1,3 @@
+(clang-format-lite
+ :fetcher github
+ :repo "arteen1000/clang-format-lite")


### PR DESCRIPTION
### Brief summary of what the package does

It provides a configurable hook into any major-mode that allows for clang-format upon saving a file. It is distinct from the other packages because it also works with tramp/remote files. I created this package through extending my own configuration, which I needed this for.

### Direct link to the package repository

https://github.com/arteen1000/clang-format-remote

### Your association with the package

I am the maintainer/creator. 

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
