### PR TITLE
Add recipe for elcute

### DIFF
--- a/recipes/elcute
+++ b/recipes/elcute
@@ -1,0 +1,4 @@
+(elcute
+ :fetcher codeberg
+ :repo "vilij/slurpbarf-elcute"
+ :files ("elcute.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Slurpbarf and Elcute are Emacs minor modes together providing a Paredit-like experience in Lisp Data and nXML modes.

Elcute remaps `kill-line` to a killing command respecting expression structure.

### Direct link to the package repository

https://codeberg.org/vilij/slurpbarf-elcute

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
