### PR TITLE
Add recipe for 'shortcuts-mode'

### DIFF
--- a/recipes/shortcuts-mode
+++ b/recipes/shortcuts-mode
@@ -1,0 +1,3 @@
+(shortcuts-mode
+ :fetcher github
+ :repo "tetron/shortcuts-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Shortcut bar for Emacs

This is a minor mode which adds a sticky window to the top of the frame listing the last ten buffers that were accessed.  You can then instantly switch the current window to one of the recent buffers using C-1 through C-0.  Think of it as an extremely lightweight tab bar oriented around keyboard navigation.

The shortcut bar also supports basic mouse navigation.  Left click switches the current window to the selected buffer, and middle click kills the selected buffer.

### Direct link to the package repository

https://github.com/tetron/shortcuts-mode

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
