### PR TITLE
Add eshell-command-not-found recipe

### DIFF
--- a/recipes/eshell-command-not-found
+++ b/recipes/eshell-command-not-found
@@ -1,0 +1,1 @@
+(eshell-command-not-found :fetcher github :repo "jaeyeom/eshell-command-not-found")


### PR DESCRIPTION
### Brief summary of what the package does

Integrate `command-not-found` in eshell. The `command-not-found` package suggests the installation of packages when a command isn't found.

### Direct link to the package repository

https://github.com/jaeyeom/eshell-command-not-found

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
