### PR TITLE
Add recipe for vsh-mode

### DIFF
--- a/recipes/vsh-mode
+++ b/recipes/vsh-mode
@@ -1,0 +1,9 @@
+(vsh-mode
+ :fetcher github
+ :repo "hardenedapple/vsh"
+ :files ("vsh-mode-1.0/vsh-mode.el"
+         "vsh-mode-1.0/integration_with_gdb.py"
+         "vsh-mode-1.0/vsh_tell_editor_bindings.py"
+         "vsh-mode-1.0/vsh_editor_prog"
+         "vsh-mode-1.0/vsh_man_pager"
+         "vsh-mode-1.0/vsh_shell_start"))

--- a/recipes/vsh-mode
+++ b/recipes/vsh-mode
@@ -4,6 +4,5 @@
  :files ("vsh-mode-1.0/vsh-mode.el"
          "vsh-mode-1.0/integration_with_gdb.py"
          "vsh-mode-1.0/vsh_tell_editor_bindings.py"
-         "vsh-mode-1.0/vsh_editor_prog"
          "vsh-mode-1.0/vsh_man_pager"
          "vsh-mode-1.0/vsh_shell_start"))


### PR DESCRIPTION
### Brief summary of what the package does

Alternate PTY interface that can be thought of as a cross between `M-x shell` and a Jupyter notebook.

### Direct link to the package repository

https://github.com/hardenedapple/vsh

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

N.b. when talking about "latest version" I used the version on MELPA in the belief that would get me the latest version.
W.r.t. `checkdoc` I did not fix everything it suggested -- didn't seem to actually be helping.

Some other points of note that a reviewer may care about:
1) This package has some shell scripts and python code.
    That is necessary for the functioning of the package (shell script to set special environment in underlying bash when starting, python code to send messages back to the emacs server -- e.g. from within GDB using the GDB python API).
2) This repo holds the Emacs package alongside the vim and neovim packages.
    This is not 100% necessary, but makes things neater -- shell and python code is shared.

I hope those points are not problematic 🤞 

<!-- After submitting, please fix any problems the CI reports. -->
