### PR TITLE
Add ready-player

### DIFF
--- a/recipes/ready-player
+++ b/recipes/ready-player
@@ -1,0 +1,3 @@
+(ready-player
+ :fetcher github
+ :repo "xenodium/ready-player")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode to open media (audio/video) files in an Emacs buffer.

![Screengrab](https://github.com/melpa/melpa/assets/8107219/adeb124b-d848-41ab-88a0-41b47785e023)

### Direct link to the package repository

https://github.com/xenodium/ready-player

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)