### PR TITLE
Add recipe for communinfo

### DIFF
--- a/recipes/communinfo
+++ b/recipes/communinfo
@@ -1,0 +1,3 @@
+(communinfo
+ :fetcher codeberg
+ :repo "mekeor/communinfo")


### PR DESCRIPTION
### Brief summary of what the package does

Version 30 of GNU Emacs introduces a user option variable `Info-url-alist` that allows to associate Info manuals to URLs.  Its default value only associates those Info manuals that are part of Emacs.  This package provides the variable `communinfo-url-alist` which can be used as value for `Info-url-alist' that provides URL-associations for many more free, libre and open source software projects.

### Direct link to the package repository

https://codeberg.org/mekeor/communinfo

### Your association with the package

I'm the author and maintainer of the package.

Also note that I do have a valid, intact, confirmed copyright-assignment to the FSF.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)