### PR TITLE
The :old-names list should not be quoted

### DIFF
--- a/recipes/opencl-c-mode
+++ b/recipes/opencl-c-mode
@@ -1,4 +1,4 @@
 (opencl-c-mode
  :fetcher github
  :repo "salmanebah/opencl-mode"
- :old-names '(opencl-mode))
+ :old-names (opencl-mode))


### PR DESCRIPTION
This breaks some of my down-stream processing

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
