### PR TITLE
Add recipe for `unique-dir-name`

### DIFF
--- a/recipes/unique-dir-name
+++ b/recipes/unique-dir-name
@@ -1,0 +1,1 @@
+(unique-dir-name :fetcher github :repo "abougouffa/unique-dir-name")


### PR DESCRIPTION
### Brief summary of what the package does

This is a simple package to derive unique names from paths. This can be seen as `uniquify`, but for files/buffers. The main purpose of the package is to provide unique tab names for project-based workspaces management. It is a dependency of the `one-tab-per-project` package (MELPÄ MR: #9110).

### Direct link to the package repository

https://github.com/abougouffa/unique-dir-name

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
