### PR TITLE
Add recipe for `one-tab-per-project`

### DIFF
--- a/recipes/one-tab-per-project
+++ b/recipes/one-tab-per-project
@@ -1,1 +1,0 @@
-(one-tab-per-project :fetcher github :repo "abougouffa/one-tab-per-project")

--- a/recipes/one-tab-per-project
+++ b/recipes/one-tab-per-project
@@ -1,0 +1,1 @@
+(one-tab-per-project :fetcher github :repo "abougouffa/one-tab-per-project")

--- a/recipes/otpp
+++ b/recipes/otpp
@@ -1,0 +1,1 @@
+(otpp :fetcher github :repo "abougouffa/one-tab-per-project")


### PR DESCRIPTION
### Brief summary of what the package does

This is a lightweight workspace management package that provides a thin layer between built-in packages project and tab-bar. The whole idea consists of creating a tab per opened project, while ensuring unique names for the created tabs (when multiple opened projects have the same name).

~Depends on `unique-dir-name`, MR opened here: https://github.com/melpa/melpa/pull/9109~ (`unique-dif-name` is now integrated into `one-tab-per-project`).

### Direct link to the package repository

https://github.com/abougouffa/one-tab-per-project

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
