### PR TITLE
change source of `equake' package

### DIFF
--- a/recipes/equake
+++ b/recipes/equake
@@ -1,1 +1,1 @@
-(equake :fetcher gitlab :repo "emacsomancer/equake")
+(equake :fetcher github :repo "emacsomancer/equake")


### PR DESCRIPTION
changing the source of `equake' from gitlab to github.

(I'm the developer and packager for equake.)

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
