### PR TITLE
Change repo location for ride-mode package

### DIFF
--- a/recipes/ride-mode
+++ b/recipes/ride-mode
@@ -1,1 +1,1 @@
-(ride-mode :fetcher github :repo "deadblackclover/ride-mode")
+(ride-mode :fetcher codeberg :repo "deadblackclover/ride-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This package implements a major-mode for editing smart contracts written in RIDE.

### Direct link to the package repository

https://codeberg.org/deadblackclover/ride-mode

### Your association with the package

Creator and maintaner

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
