### PR TITLE
recipes/apparmor-mode: update location to upstream apparmor project

### DIFF
--- a/recipes/apparmor-mode
+++ b/recipes/apparmor-mode
@@ -1,1 +1,3 @@
-(apparmor-mode :fetcher github :repo "alexmurray/apparmor-mode")
+(apparmor-mode
+ :fetcher gitlab
+ :repo "apparmor/apparmor-mode")


### PR DESCRIPTION
The old location of github.com/alexmurray/apparmor-mode is now frozen and future development will occur directly in the upstream apparmor project repo on gitlab.

