### PR TITLE
Add recipe for roc-mode

### DIFF
--- a/recipes/roc-ts-mode
+++ b/recipes/roc-ts-mode
@@ -1,0 +1,3 @@
+(roc-ts-mode
+ :fetcher gitlab
+ :repo "tad-lispy/roc-ts-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for the Roc programming language.

### Direct link to the package repository

https://gitlab.com/tad-lispy/roc-mode

### Your association with the package

I'm one of the maintainers (along with tad-lispy).

### Relevant communications with the upstream package maintainer

<!-- [e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.] -->
None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

Note that there's another open pull request (#8953) that adds a different package called `roc-ts-mode`. See [my comment there](https://github.com/melpa/melpa/pull/8953#issuecomment-2282905381) for why I opened a new one.

This major mode does use treesit as well,  so I'm not sure whether it would be better to rename this package to `roc-ts-mode`.