### PR TITLE
Add recipe for org-node

### DIFF
--- a/recipes/org-node
+++ b/recipes/org-node
@@ -1,5 +1,4 @@
 (org-node :repo "meedstrom/org-node"
           :fetcher github
           :branch "melpa"
-          :version-regexp "a^" ;; Opt out of Melpa Stable
           :files (:defaults (:exclude "org-node-fakeroam.el")))

--- a/recipes/org-node
+++ b/recipes/org-node
@@ -1,0 +1,5 @@
+(org-node :repo "meedstrom/org-node"
+          :fetcher github
+          :branch "melpa"
+          :version-regexp "a^" ;; Opt out of Melpa Stable
+          :files (:defaults (:exclude "org-node-fakeroam.el")))


### PR DESCRIPTION
### Brief summary of what the package does

How to summarize briefly... it's yet another zettelkasten/notetaking package, highly compatible with org-roam but the internals are very different.  

What excites me the most is its sheer speed on constrained systems.  I also like that it stays close to upstream Org things.

### Direct link to the package repository

https://github.com/meedstrom/org-node

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


There's a couple of warnings from the byte-compiler I can't fix.