### PR TITLE
Add recipe for org-node-fakeroam

### DIFF
--- a/recipes/org-node-fakeroam
+++ b/recipes/org-node-fakeroam
@@ -1,4 +1,3 @@
-(org-node-fakeroam :repo "meedstrom/org-node"
+(org-node-fakeroam :repo "meedstrom/org-node-fakeroam"
                    :fetcher github
-                   :branch "melpa"
-                   :files ("org-node-fakeroam.el"))
+                   :branch "melpa")

--- a/recipes/org-node-fakeroam
+++ b/recipes/org-node-fakeroam
@@ -1,0 +1,5 @@
+(org-node-fakeroam :repo "meedstrom/org-node"
+                   :fetcher github
+                   :branch "melpa"
+                   :version-regexp "a^" ;; Opt out of Melpa Stable
+                   :files ("org-node-fakeroam.el"))

--- a/recipes/org-node-fakeroam
+++ b/recipes/org-node-fakeroam
@@ -1,5 +1,4 @@
 (org-node-fakeroam :repo "meedstrom/org-node"
                    :fetcher github
                    :branch "melpa"
-                   :version-regexp "a^" ;; Opt out of Melpa Stable
                    :files ("org-node-fakeroam.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This is an extension developed in tandem with `org-node`, PR https://github.com/melpa/melpa/pull/9132, ~~living in the same repo~~.  It offers tools for interfacing with org-roam -- really sort of puppeteering it by advising functions that are slow in favour of org-node things that are fast.

### Direct link to the package repository

https://github.com/meedstrom/org-node-fakeroam

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

