### PR TITLE
add recipe for password-store-menu

### DIFF
--- a/recipes/password-store-menu
+++ b/recipes/password-store-menu
@@ -1,0 +1,3 @@
+(password-store-menu
+ :fetcher github
+ :repo "rjekker/password-store-menu")


### PR DESCRIPTION
### Brief summary of what the package does

This emacs package improves on the user interface for password-store.el (see https://www.passwordstore.org/), adding a friendly transient pop-up.

### Direct link to the package repository

https://github.com/rjekker/password-store-menu

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
