### PR TITLE
Exclude org-projectile-helm.el from org-projectile

### DIFF
--- a/recipes/org-projectile
+++ b/recipes/org-projectile
@@ -1,4 +1,4 @@
 (org-projectile
  :repo "colonelpanic8/org-project-capture"
  :fetcher github
- :files ("org-projectile*.el"))
+ :files ("org-projectile.el"))


### PR DESCRIPTION
org-projectile-helm.el is already included in org-projectile-helm. Including it in org-projectile causes compilation errors about missing dependency helm.

cc @colonelpanic8 

ref: https://github.com/NixOS/nixpkgs/issues/335442

<!-- After submitting, please fix any problems the CI reports. -->
