### PR TITLE
Exclude chronometrist-spark* from chronometrist

### DIFF
--- a/recipes/chronometrist
+++ b/recipes/chronometrist
@@ -5,4 +5,5 @@
          "elisp/*.el"
          "elisp/*.org"
          (:exclude "elisp/chronometrist-key-values*"
+                   "elisp/chronometrist-spark*"
                    "elisp/chronometrist-goal*")))


### PR DESCRIPTION
There is chronometrist-spark for chronometrist-spark* files.

cc @contrapunctus-1 

ref: https://github.com/NixOS/nixpkgs/issues/335442

<!-- After submitting, please fix any problems the CI reports. -->
