### PR TITLE
Add: new color themes for kanagawa-themes

### DIFF
--- a/recipes/kanagawa-theme
+++ b/recipes/kanagawa-theme
@@ -1,3 +1,0 @@
-(kanagawa-theme
- :fetcher github
- :repo "Fabiokleis/emacs-kanagawa-theme")

--- a/recipes/kanagawa-themes
+++ b/recipes/kanagawa-themes
@@ -1,0 +1,3 @@
+(kanagawa-themes
+ :fetcher github
+ :repo "Fabiokleis/kanagawa-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

Kanagawa now has three variants: wave (default), dragon, and lotus.

Kanagawa for Emacs supports officially Emacs 24+.

### Direct link to the package repository

https://github.com/Fabiokleis/kanagawa-emacs

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
