### PR TITLE
Add recipe for incus-tramp

### DIFF
--- a/recipes/incus-tramp
+++ b/recipes/incus-tramp
@@ -1,0 +1,1 @@
+(incus-tramp :repo "lckarssen/incus-tramp" :fetcher gitlab)


### PR DESCRIPTION
### Brief summary of what the package does

With this package one can connect to [Incus](https://linuxcontainers.org/incus/) containers using TRAMP. This is basically a copy of [`lxd-tramp`](https://github.com/onixie/lxd-tramp) (packaged [here](https://github.com/melpa/melpa/blob/master/recipes/lxd-tramp)) with calls to `lxc`/`lxd`  replaced with calls to `incus`. 

### Direct link to the package repository

https://gitlab.com/lckarssen/incus-tramp

### Your association with the package

I am the maintainer. 

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
