### PR TITLE
Exclude .dir-locals.el from helm recipe

### DIFF
--- a/recipes/helm
+++ b/recipes/helm
@@ -3,7 +3,8 @@
  :repo "emacs-helm/helm"
  :files ("*.el"
          "emacs-helm.sh"
-         (:exclude "helm-lib.el"
+         (:exclude ".dir-locals.el"
+                   "helm-lib.el"
                    "helm-source.el"
                    "helm-multi-match.el"
                    "helm-core.el")))


### PR DESCRIPTION
Currently, the .dir-locals.el file is not excluded, which causes this compilation error[1] when doing AOT native compilation for Emacs lisp packages in NixOS.

Error: wrong-type-argument ("/nix/store/<hash>-emacs-helm-20240818.1231/share/emacs/site-lisp/elpa/helm-20240818.1231/.dir-locals.el" proper-list-p (mode . bug-reference-prog))
  mapbacktrace(#f(compiled-function (evald func args flags) #<bytecode -0xf42c55d2510e41>))
  debug-early-backtrace()
  debug-early(error (wrong-type-argument "/nix/store/<hash>-emacs-helm-20240818.1231/share/emacs/site-lisp/elpa/helm-20240818.1231/.dir-locals.el" proper-list-p (mode . bug-reference-prog)))
  signal(wrong-type-argument ("/nix/store/<hash>-emacs-helm-20240818.1231/share/emacs/site-lisp/elpa/helm-20240818.1231/.dir-locals.el" proper-list-p (mode . bug-reference-prog)))
  comp--native-compile("/nix/store/<hash>-emacs-helm-20240818.1231/share/emacs/site-lisp/elpa/helm-20240818.1231/.dir-locals.el")
  batch-native-compile()
  command-line-1(("--eval" "(setq large-file-warning-threshold nil)" "--eval" "(setq byte-compile-error-on-warn nil)" "-f" "batch-native-compile" "/nix/store/<hash>-emacs-helm-20240818.1231/share/emacs/site-lisp/elpa/helm-20240818.1231/.dir-locals.el"))
  command-line()
  normal-top-level()
Wrong type argument: "/nix/store/<hash>-emacs-helm-20240818.1231/share/emacs/site-lisp/elpa/helm-20240818.1231/.dir-locals.el", proper-list-p, (#<symbol mode at 445> . #<symbol bug-reference-prog at 452>)

We can workaround this by skipping native compilation for .dir-locals.el.  However, I do not think .dir-locals.el has to be included.  In addition, MELPA ignores[2] that file by default.

[1]: https://hydra.nixos.org/build/271308075/nixlog/1
[2]: https://github.com/melpa/melpa/blob/0c608bf895a3b5230b781662510e1326af17ea13/README.md?plain=1#L169-L170

cc @thierryvolpiatto 

ref: https://github.com/NixOS/nixpkgs/issues/335442