### PR TITLE
Exclude .dir-locals.el from el-get recipe

### DIFF
--- a/recipes/el-get
+++ b/recipes/el-get
@@ -1,4 +1,4 @@
 (el-get
  :fetcher github
  :repo "dimitri/el-get"
- :files ("*.el" ("recipes" "recipes/el-get.rcp") "methods"))
+ :files ("*.el" ("recipes" "recipes/el-get.rcp") "methods" (:exclude ".dir-locals.el")))


### PR DESCRIPTION
Currently, the .dir-locals.el file is not excluded, which causes this compilation error[1] when doing AOT native compilation for Emacs lisp packages in NixOS.

Error: wrong-type-argument ("/nix/store/<hash>-emacs-el-get-20240408.837/share/emacs/site-lisp/elpa/el-get-20240408.837/.dir-locals.el" proper-list-p (whitespace-line-column . 80))
  mapbacktrace(#f(compiled-function (evald func args flags) #<bytecode -0xf42c55d2510e41>))
  debug-early-backtrace()
  debug-early(error (wrong-type-argument "/nix/store/<hash>-emacs-el-get-20240408.837/share/emacs/site-lisp/elpa/el-get-20240408.837/.dir-locals.el" proper-list-p (whitespace-line-column . 80)))
  signal(wrong-type-argument ("/nix/store/<hash>-emacs-el-get-20240408.837/share/emacs/site-lisp/elpa/el-get-20240408.837/.dir-locals.el" proper-list-p (whitespace-line-column . 80)))
  comp--native-compile("/nix/store/<hash>-emacs-el-get-20240408.837/share/emacs/site-lisp/elpa/el-get-20240408.837/.dir-locals.el")
  batch-native-compile()
  command-line-1(("--eval" "(setq large-file-warning-threshold nil)" "--eval" "(setq byte-compile-error-on-warn nil)" "-f" "batch-native-compile" "/nix/store/<hash>-emacs-el-get-20240408.837/share/emacs/site-lisp/elpa/el-get-20240408.837/.dir-locals.el"))
  command-line()
  normal-top-level()
Wrong type argument: "/nix/store/<hash>-emacs-el-get-20240408.837/share/emacs/site-lisp/elpa/el-get-20240408.837/.dir-locals.el", proper-list-p, (#<symbol whitespace-line-column at 313> . 80)

We can workaround this by skipping native compilation for .dir-locals.el.  However, I do not think .dir-locals.el has to be included.  In addition, MELPA ignores[2] that file by default.

[1]: https://hydra.nixos.org/build/271385904/nixlog/1
[2]: https://github.com/melpa/melpa/blob/0c608bf895a3b5230b781662510e1326af17ea13/README.md?plain=1#L169-L170

ref: https://github.com/NixOS/nixpkgs/issues/335442