### PR TITLE
py-vterm-interaction: include python scripts

### DIFF
--- a/recipes/py-vterm-interaction
+++ b/recipes/py-vterm-interaction
@@ -1,4 +1,4 @@
 (py-vterm-interaction
  :repo "vale981/py-vterm-interaction.el"
  :fetcher github
- :files '("*.el" ("scripts/" "scripts/*.py")))
+ :files ("py-vterm-interaction*.el" ("scripts/" "scripts/*.py")))

--- a/recipes/py-vterm-interaction
+++ b/recipes/py-vterm-interaction
@@ -1,1 +1,4 @@
-(py-vterm-interaction :repo "vale981/py-vterm-interaction.el" :fetcher github)
+(py-vterm-interaction
+ :repo "vale981/py-vterm-interaction.el"
+ :fetcher github
+ :files '("*.el" ("scripts/" "scripts/*.py")))


### PR DESCRIPTION
I totally forgot to include some necessary script files in the first version as this one dated back before their addition. Here is a revised version.