### PR TITLE
add `eros-inspector`

### DIFF
--- a/recipes/eros-inspector
+++ b/recipes/eros-inspector
@@ -1,0 +1,1 @@
+(eros-inspector :repo "port19x/eros-inspector" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Similar to how embark-consult is a package enhancing integration between embark and consult, this is a package enabling integration between the elisp development packages eros and inspector.

### Direct link to the package repository

https://github.com/port19x/eros-inspector

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)