### PR TITLE
Clean up recipes

### DIFF
--- a/recipes/org-node
+++ b/recipes/org-node
@@ -1,4 +1,1 @@
-(org-node :repo "meedstrom/org-node"
-          :fetcher github
-          :branch "melpa"
-          :files (:defaults (:exclude "org-node-fakeroam.el")))
+(org-node :fetcher github :repo "meedstrom/org-node")

--- a/recipes/org-node-fakeroam
+++ b/recipes/org-node-fakeroam
@@ -1,3 +1,1 @@
-(org-node-fakeroam :repo "meedstrom/org-node-fakeroam"
-                   :fetcher github
-                   :branch "melpa")
+(org-node-fakeroam :fetcher github :repo "meedstrom/org-node-fakeroam")


### PR DESCRIPTION
This simplifies two of my recipes.

1. Remove an `:exclude` statement that no longer did anything.

2. Remove the `:branch "melpa"`. Seeing as I was convinced in #9133 to tag versions anyway, it has increased the amount of steps I need to take each time I push a new stable commit, so going forwards I will maintain only one public branch instead of two, thus bringing my workload back down.

I was also considering adding a `:version-regexp regexp-unmatchable`.  I can not make up my mind about that. Maybe later. Keeping this PR uncontroversial ;)