### PR TITLE
Add recipe for dup-transform: utility for graphics programmers

### DIFF
--- a/recipes/dup-transform
+++ b/recipes/dup-transform
@@ -1,0 +1,4 @@
+(dup-transform
+ :fetcher github
+ :repo "garyo/dup-transform.el"
+)


### PR DESCRIPTION
### Brief summary of what the package does

Simple Emacs package for graphics programmers, to duplicate and transform rgb/xy lines.

Graphics programmers often need to write near-duplicate code to process rgb or rgba pixels, or xy/xyz coordinates.
This package aims to make that a little more friction-free by auto-detecting common patterns and duplicating the lines with the proper transformations.

### Direct link to the package repository

https://github.com/garyo/dup-transform.el

### Your association with the package

I'm the author and intend to maintain it.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
