### PR TITLE
Exclude unrelated files in chronometrist-key-values

### DIFF
--- a/recipes/chronometrist-key-values
+++ b/recipes/chronometrist-key-values
@@ -3,7 +3,4 @@
  :repo "contrapunctus/chronometrist"
  :branch "dev"
  :files (:defaults
-         "elisp/*.el"
-         "elisp/*.org"
-         (:exclude "elisp/chronometrist.*"
-                   "elisp/chronometrist-goal*")))
+         "elisp/chronometrist-key-values.*"))


### PR DESCRIPTION
There are more files needing to be excluded now: https://codeberg.org/contrapunctus/chronometrist/src/branch/dev/elisp.

I think it is better to switch to an allow-list.

cc package author @contrapunctus-1

ref: https://github.com/NixOS/nixpkgs/issues/335442