### PR TITLE
Exclude screenshot dir of alectryon

### DIFF
--- a/recipes/alectryon
+++ b/recipes/alectryon
@@ -1,4 +1,4 @@
 (alectryon
  :fetcher github
  :repo "cpitclaudel/alectryon"
- :files ("etc/elisp/*"))
+ :files ("etc/elisp/alectryon*.el"))


### PR DESCRIPTION
Probably screenshot dir is not useful for users.  In addition, screenshot/capture.el needs an extra dependency proof-general which is not listed in the main file alectryon.el.

cc package author @cpitclaudel

ref: https://github.com/NixOS/nixpkgs/issues/335442