### PR TITLE
Update compile-multi-embark

### DIFF
--- a/recipes/compile-multi-embark
+++ b/recipes/compile-multi-embark
@@ -1,3 +1,3 @@
 (compile-multi-embark
  :fetcher github :repo "mohkale/compile-multi"
- :files ("extensions/compile-multi-embark/compile-multi-embark*.el"))
+ :files ("extensions/compile-multi-embark/compile-multi-embark.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds embark support to compile-multi so actions like kill-new yank the underlying command instead of just what's presented in the minibuffer.
See https://github.com/melpa/melpa/pull/9183#issuecomment-2366908743.

### Direct link to the package repository

https://github.com/mohkale/compile-multi

### Your association with the package

Contributor

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
