### PR TITLE
Update compile-multi-all-the-icons

### DIFF
--- a/recipes/compile-multi-all-the-icons
+++ b/recipes/compile-multi-all-the-icons
@@ -1,3 +1,3 @@
 (compile-multi-all-the-icons
  :fetcher github :repo "mohkale/compile-multi"
- :files ("extensions/compile-multi-all-the-icons/*.el"))
+ :files ("extensions/compile-multi-all-the-icons/compile-multi-all-the-icons.el"))

--- a/recipes/compile-multi-all-the-icons
+++ b/recipes/compile-multi-all-the-icons
@@ -1,3 +1,3 @@
 (compile-multi-all-the-icons
  :fetcher github :repo "mohkale/compile-multi"
- :files ("extensions/compile-multi-all-the-icons/compile-multi-all-the-icons.el"))
+ :files ("extensions/compile-multi-all-the-icons/compile-multi-all-the-icons*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Add [all-the-icons](https://github.com/domtronn/all-the-icons.el) support to the base `compile-multi` package. See [its section](https://github.com/mohkale/compile-multi?tab=readme-ov-file#compile-multi-all-the-icons) on the source package's README.
See https://github.com/melpa/melpa/pull/9183#issuecomment-2366908743.

### Direct link to the package repository

https://github.com/mohkale/compile-multi

### Your association with the package

Contributor

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
