### PR TITLE
Move upstream for binder

### DIFF
--- a/recipes/binder
+++ b/recipes/binder
@@ -1,1 +1,1 @@
-(binder :fetcher github :repo "rnkn/binder")
+(binder :fetcher codeberg :repo "divyaranjan/binder")


### PR DESCRIPTION
Binder has a new maintainer and thus new upstream at Codeberg. The current GitHub repo will be archived.

### Direct link to the package repository

https://codeberg.org/divyaranjan/binder

### Your association with the package

Author, previous maintainer

### Relevant communications with the upstream package maintainer

Transfer of maintainer over email

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
