### PR TITLE
Add recipe for org-auto-export-pandoc

### DIFF
--- a/recipes/org-auto-export-pandoc
+++ b/recipes/org-auto-export-pandoc
@@ -1,0 +1,1 @@
+(org-auto-export-pandoc :repo "Y0ngg4n/org-auto-export-pandoc" :fetcher github)

--- a/recipes/org-auto-export-pandoc
+++ b/recipes/org-auto-export-pandoc
@@ -1,1 +1,1 @@
-(org-auto-export-pandoc :repo "Y0ngg4n/org-auto-export-pandoc" :fetcher github)
+(org-auto-export-pandoc :fetcher github :repo "Y0ngg4n/org-auto-export-pandoc")


### PR DESCRIPTION
### Brief summary of what the package does
This package adds the posibility to add the metadata tag `#+auto-export-pandoc: to-markdown` to org-mode files to automatically export the org-mode file via pandoc in the corresponding format. It just calls the corresponding function.
I am new to elisp, i hope i did nothing wrong. If this is not worth to be a package then please close it, but i experienced it as very useful.

### Direct link to the package repository

https://github.com/Y0ngg4n/org-auto-export-pandoc

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer
None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- []x My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
