### PR TITLE
Add recipe for varuga

### DIFF
--- a/recipes/varuga
+++ b/recipes/varuga
@@ -1,0 +1,3 @@
+(varuga
+ :fetcher git
+ :url "https://git.systemreboot.net/varuga/")


### PR DESCRIPTION
-------

### Brief summary of what the package does

Send ical calendar invites using your Emacs mail client. These invites are similar to those produced by Google Calendar, Outlook
Calendar, etc. and are compatible with them.

varuga populates a message mode buffer with an ical MIME part (using
MML, the MIME Meta Language). It also adds a plain text part listing
the time of the event in various configured timezones.

All dates and times you enter into varuga are in your local timezone. varuga automatically converts these into a set of configured timezones (specified in `varuga-clock-list`) for your correspondents' benefit.

### Direct link to the package repository

https://git.systemreboot.net/varuga/

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->