### PR TITLE
matlab-mode: update url to github, modify list of files

### DIFF
--- a/recipes/matlab-mode
+++ b/recipes/matlab-mode
@@ -1,9 +1,10 @@
 (matlab-mode
- :fetcher git
- :url "https://git.code.sf.net/p/matlab-emacs/src"
- :files ("*.el" "*.m" ("toolbox" "toolbox/*.m")
+ :fetcher github
+ :repo "mathworks/Emacs-MATLAB-Mode"
+ :files (:defaults "*.m" ("toolbox" "toolbox/*.m")
          ("toolbox/+emacs" "toolbox/+emacs/*.m")
          ("toolbox/+emacs/@Breakpoints" "toolbox/+emacs/@Breakpoints/*.m")
          ("toolbox/+emacs/@EmacsServer" "toolbox/+emacs/@EmacsServer/*.m")
          ("toolbox/+emacs/@Stack" "toolbox/+emacs/@Stack/*.m")
-         ("templates" "templates/*.srt")))
+         ("bin" "bin/*.sh")))
+         


### PR DESCRIPTION
### Brief summary of what the package does

Update the recipe, it points now to the new emacs-matlab repository in github

### Direct link to the package repository

https://github.com/mathworks/Emacs-MATLAB-Mode.git

### Your association with the package

I am one of the three maintainers

### Relevant communications with the upstream package maintainer

matlab-mode.el has been added

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
