### PR TITLE
Add recipe for just-ts-mode.el

### DIFF
--- a/recipes/just-ts-mode
+++ b/recipes/just-ts-mode
@@ -1,0 +1,1 @@
+(just-ts-mode :fetcher github :repo "leon-barrett/just-ts-mode.el")


### PR DESCRIPTION
### Brief summary of what the package does

`just-ts-mode` is a major mode for editing justfiles (as defined by the tool "just": https://github.com/casey/just), using a tree-sitter grammar. For me, at least, it is an upgrade over the existing `just-mode`, which had some issues parsing comments.

I suppose I could have just changed `just-mode` to use tree-sitter, but I believed it was better to leave the old package up for users who lack tree-sitter support.

### Direct link to the package repository

https://github.com/leon-barrett/just-ts-mode.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)