### PR TITLE
Remove casual-calc old-names

### DIFF
--- a/recipes/casual-calc
+++ b/recipes/casual-calc
@@ -1,1 +1,1 @@
-(casual-calc :fetcher github :repo "kickingvegas/casual-calc" :old-names (casual))
+(casual-calc :fetcher github :repo "kickingvegas/casual-calc")


### PR DESCRIPTION
### Brief summary of what the package does

Remove old name of "casual" from "casual-calc" to support consolidation of existing Casual packages into a future package to be named "casual".

Planning details on Casual package consolidation can be found at https://github.com/kickingvegas/casual-suite/discussions/50

### Direct link to the package repository

https://github.com/kickingvegas/casual-calc

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

If there are any questions or concerns about this, please express them to me at your earliest convenience.

### Checklist
- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

