### PR TITLE
Add coc-damage-calculator recipe

### DIFF
--- a/recipes/coc-damage-calculator
+++ b/recipes/coc-damage-calculator
@@ -1,1 +1,0 @@
-(coc-damage-calculator :fetcher github :repo "S0mbr3/coc-damage-calculator")

--- a/recipes/coc-damage-calculator
+++ b/recipes/coc-damage-calculator
@@ -1,4 +1,1 @@
-(coc-damage-calculator
- :fetcher github
- :repo "S0mbr3/coc-damage-calculator"
- :files "coc-damage-calculator.el")
+(coc-damage-calculator :fetcher github :repo "S0mbr3/coc-damage-calculator")

--- a/recipes/coc-damage-calculator
+++ b/recipes/coc-damage-calculator
@@ -1,0 +1,4 @@
+(coc-damage-calculator
+ :fetcher github
+ :repo "S0mbr3/coc-damage-calculator"
+ :files "coc-damage-calculator.el")

--- a/recipes/coc-dc
+++ b/recipes/coc-dc
@@ -1,0 +1,1 @@
+(coc-dc :fetcher github :repo "S0mbr3/coc-damage-calculator")


### PR DESCRIPTION
### Brief summary of what the package does

coc-damage-calculator package is meant to help Clash of Clans players to quickly calculate damages to buildings from various equipements and spells.

It provides an hydra menu to select the options.

### Direct link to the package repository

https://github.com/S0mbr3/coc-damage-calculator

### Your association with the package

I am the author and maintener.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
