### PR TITLE
Add recipe for casual

### DIFF
--- a/recipes/casual
+++ b/recipes/casual
@@ -1,0 +1,1 @@
+(casual :fetcher github :repo "kickingvegas/casual")


### PR DESCRIPTION
### Brief summary of what the package does

Casual is a collection of opinionated Transient-based keyboard-driven user interfaces for various built-in Emacs modes.

The package `casual` itself consolidates a number of packages published on MELPA which will be obsoleted in the near future.

Details of this consolidation is found at the following link:

https://github.com/kickingvegas/casual-suite/discussions/50

### Direct link to the package repository

https://github.com/kickingvegas/casual

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

My only concern is any stateful behavior in MELPA as the package `casual` was originally published (PR #8951) and then later renamed to `casual-calc` (PR #9064).

A subsequent PR #9213 removed the `:old-names` key from the `casual-calc` recipe.

Please let me know if there are any issues and thanks!


### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
