### PR TITLE
chore: update org-ros files

### DIFF
--- a/recipes/org-ros
+++ b/recipes/org-ros
@@ -1,4 +1,4 @@
 (org-ros
-  :repo "LionyxML/ros"
   :fetcher github
-  :files ("*.el" "*.ps1"))
+  :repo "LionyxML/ros"
+  :files (:defaults "*.ps1"))

--- a/recipes/org-ros
+++ b/recipes/org-ros
@@ -1,3 +1,4 @@
 (org-ros
   :repo "LionyxML/ros"
-  :fetcher github)
+  :fetcher github
+  :files ("*.el" "*.ps1"))


### PR DESCRIPTION
`org-ros' now provides a Windows ps1 script to capture images. This needs to be provided with the MELPA bundles.
