### PR TITLE
Remove Superseded Casual Recipes

### DIFF
--- a/recipes/casual
+++ b/recipes/casual
@@ -1,1 +1,14 @@
-(casual :fetcher github :repo "kickingvegas/casual")
+(casual
+ :fetcher github
+ :repo "kickingvegas/casual"
+ :old-names (casual-agenda
+             casual-bookmarks
+             casual-calc
+             casual-dired
+             casual-editkit
+             casual-ibuffer
+             casual-info
+             casual-isearch
+             cc-isearch-menu
+             casual-lib
+             casual-re-builder))

--- a/recipes/casual-agenda
+++ b/recipes/casual-agenda
@@ -1,1 +1,0 @@
-(casual-agenda :fetcher github :repo "kickingvegas/casual-agenda")

--- a/recipes/casual-bookmarks
+++ b/recipes/casual-bookmarks
@@ -1,1 +1,0 @@
-(casual-bookmarks :fetcher github :repo "kickingvegas/casual-bookmarks")

--- a/recipes/casual-calc
+++ b/recipes/casual-calc
@@ -1,1 +1,0 @@
-(casual-calc :fetcher github :repo "kickingvegas/casual-calc")

--- a/recipes/casual-dired
+++ b/recipes/casual-dired
@@ -1,1 +1,0 @@
-(casual-dired :fetcher github :repo "kickingvegas/casual-dired")

--- a/recipes/casual-editkit
+++ b/recipes/casual-editkit
@@ -1,1 +1,0 @@
-(casual-editkit :fetcher github :repo "kickingvegas/casual-editkit")

--- a/recipes/casual-ibuffer
+++ b/recipes/casual-ibuffer
@@ -1,1 +1,0 @@
-(casual-ibuffer :fetcher github :repo "kickingvegas/casual-ibuffer")

--- a/recipes/casual-info
+++ b/recipes/casual-info
@@ -1,1 +1,0 @@
-(casual-info :fetcher github :repo "kickingvegas/casual-info")

--- a/recipes/casual-isearch
+++ b/recipes/casual-isearch
@@ -1,1 +1,0 @@
-(casual-isearch :fetcher github :repo "kickingvegas/casual-isearch" :old-names (cc-isearch-menu))

--- a/recipes/casual-lib
+++ b/recipes/casual-lib
@@ -1,1 +1,0 @@
-(casual-lib :fetcher github :repo "kickingvegas/casual-lib")

--- a/recipes/casual-re-builder
+++ b/recipes/casual-re-builder
@@ -1,1 +1,0 @@
-(casual-re-builder :fetcher github :repo "kickingvegas/casual-re-builder")


### PR DESCRIPTION
### Brief summary of what the package does

Remove Casual package recipes superseded by recent `casual` recipe introduced in #9218.

### Direct link to the package repository

https://github.com/kickingvegas/casual

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

Details on Casual package consolidation can be found at https://github.com/kickingvegas/casual-suite/discussions/50

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

