### PR TITLE
Add el-job

### DIFF
--- a/recipes/el-job
+++ b/recipes/el-job
@@ -1,0 +1,1 @@
+(el-job :fetcher github :repo "meedstrom/el-job")


### PR DESCRIPTION
### Brief summary of what the package does

Imagine you have a function you’d like to run on a long list of inputs. You could run (mapcar #'FN INPUTS), but that hangs Emacs until done.

This library gives you the tools to split up the inputs and run the function in many subprocesses (one per CPU core), then merges their outputs and passes it back to the current Emacs. In the meantime, current Emacs does not hang at all.

The aim is to have a very thin performance overhead, compared to the popular [async](https://github.com/jwiegley/emacs-async/) which is more flexible.  Just spawn a dozen processes and get their outputs as they exit.  It also abstracts away boilerplate you'd have to write to split inputs and merge outputs, not to mention counting CPU cores and finding the path to the .elc/.eln.

### Direct link to the package repository

https://github.com/meedstrom/el-job/

Melpazoid clean! https://github.com/meedstrom/el-job/actions


### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist


- [X] The package is released under a [GPL-Compatible Free Software
  License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read
  [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of
  [package-lint](https://github.com/purcell/package-lint) to check for
  packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in
  [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
