### PR TITLE
Add recipe for inhibit-mouse

### DIFF
--- a/recipes/inhibit-mouse
+++ b/recipes/inhibit-mouse
@@ -1,0 +1,1 @@
+(inhibit-mouse :fetcher github :repo "jamescherti/inhibit-mouse.el")


### PR DESCRIPTION
### Brief summary of what the package does

The **inhibit-mouse** package allows the disabling of mouse input in Emacs using `inhibit-mouse-mode`.

Instead of modifying the keymap of its own mode (as the *disable-mouse* package does), enabling `inhibit-mouse-mode` only modifies `input-decode-map` to disable mouse events, making it simpler and faster. Additionally, the *inhibit-mouse* package allows for the restoration of mouse input when `inhibit-mouse-mode` is disabled.

### Direct link to the package repository

https://github.com/jamescherti/inhibit-mouse.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
