### PR TITLE
Add uniq-region recipe

### DIFF
--- a/recipes/uniq-region
+++ b/recipes/uniq-region
@@ -1,0 +1,1 @@
+(uniq-region :fetcher codeberg :repo "yabobay/emacs-uniq-region")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides the function `uniq-region`, which removes duplicate lines from the region (except for whitespace, which i might make optional in the future).

### Direct link to the package repository

https://codeberg.org/yabobay/emacs-uniq-region

### Your association with the package

I made this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [*] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [*] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [*] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [*] My elisp byte-compiles cleanly
- [*] I've used `M-x checkdoc` to check the package's documentation strings
- [*] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
