### PR TITLE
Fix the bbdb recipe.

### DIFF
--- a/recipes/bbdb
+++ b/recipes/bbdb
@@ -1,4 +1,4 @@
 (bbdb
  :fetcher git
  :url "https://git.savannah.nongnu.org/git/bbdb.git"
- :files (:defaults (:rename "lisp/bbdb-site.el.in" "bbdb-site.el")))
+ :files ((:rename "lisp/bbdb-site.el.in" "bbdb-site.el")))


### PR DESCRIPTION
:rename does not go inside :defaults

Long form elided -- this is not a new recipe nor a new package, this is a bug fix for an existing package.
