### PR TITLE
Add recipe for quick-sdcv

### DIFF
--- a/recipes/quick-sdcv
+++ b/recipes/quick-sdcv
@@ -1,0 +1,1 @@
+(quick-sdcv :fetcher github :repo "jamescherti/quick-sdcv.el")


### PR DESCRIPTION
### Brief summary of what the package does

The quick-sdcv package serves as an Emacs interface for the sdcv command-line interface, which is the console version of the StarDict dictionary application.

This package enables Emacs to function as an offline dictionary.

This integration allows users to access and utilize dictionary functionalities directly within the Emacs environment, leveraging the capabilities of sdcv to look up words and translations from various dictionary files formatted for StarDict.

### Direct link to the package repository

https://github.com/jamescherti/quick-sdcv.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
