### PR TITLE
Add recipe for compile-angel

### DIFF
--- a/recipes/compile-angel
+++ b/recipes/compile-angel
@@ -1,0 +1,1 @@
+(compile-angel :fetcher github :repo "jamescherti/compile-angel.el")


### PR DESCRIPTION
### Brief summary of what the package does

The **compile-angel** package automatically byte-compiles and native-compiles Emacs Lisp libraries. It offers two global minor modes:
- `(compile-angel-on-save-mode)`: Compiles when an .el file is modified and saved.
- `(compile-angel-on-load-mode)`: Compiles an .el file before it is loaded.

These modes speed up Emacs by ensuring all libraries are byte-compiled and native-compiled. Byte-compilation reduces the overhead of loading Emacs Lisp code at runtime, while native compilation optimizes performance by generating machine code specific to your system.

The author used to be an auto-compile user, but several of his .el files were not being compiled by auto-compile, and Emacs was slow due to the lack of native compilation. The author experimented for an extended period to understand why auto-compile wasn't compiling many of the .el files in the configuration. The result of that experiment became a package: compile-angel.

During the investigation, the author discovered that auto-compile was not utilizing autoload and eval-after-load to compile .el files. Even though autoload and eval-after-load don't directly load libraries, they provide a good indication of what will be loaded in the future. In the case of compile-angel, this triggers compilation if the file has not yet been compiled (The compile-angel package checks whether the .elc and/or .eln files are outdated before compiling them; it does not simply compile them without checking.).

Here are the main differences between auto-compile and compile-angel:
- **Compile-angel ensures more .el files are compiled**: The compile-angel package, in addition to compiling the elisp files that are loaded using `load` and `require`, **also handles files that auto-compile misses**, such as packages that are deferred (e.g., `:defer t` in `use-package`) and the `use-package` dependencies using, for example,`:after package-name`.
- Compile-angel can exclude files from compilation using regular expressions in `compile-angel-excluded-files-regexps`.
- Compile-angel provides options to allow enabling and disabling specific functions that should be advised (load, require, etc.).
- Compile-angel allows enabling debug mode, which allows knowing exactly what compile-angel does. Additionally, compiled files and features are stored in variables that help identify what was compiled.
- compile-angel-on-save-mode supports compiling indirect buffers (clones).
- compile-angel-on-load-mode compiles features that have already been loaded to make sure that they are compiled.

### Direct link to the package repository

https://github.com/jamescherti/compile-angel.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
