### PR TITLE
Split chatgpt-shell packages into separate repos

### DIFF
--- a/recipes/chatgpt-shell
+++ b/recipes/chatgpt-shell
@@ -1,4 +1,8 @@
 (chatgpt-shell
  :fetcher github
  :repo "xenodium/chatgpt-shell"
- :files ("chatgpt-shell.el"))
+ :files ("*.el" (:exclude "test_chatgpt-shell.el"
+                          "shell-maker.el"
+                          "ob-chatgpt-shell.el"
+                          "dall-e-shell.el"
+                          "ob-dall-e-shell.el")))

--- a/recipes/dall-e-shell
+++ b/recipes/dall-e-shell
@@ -1,4 +1,3 @@
 (dall-e-shell
  :fetcher github
- :repo "xenodium/chatgpt-shell"
- :files ("dall-e-shell.el"))
+ :repo "xenodium/dall-e-shell")

--- a/recipes/ob-chatgpt-shell
+++ b/recipes/ob-chatgpt-shell
@@ -1,4 +1,3 @@
 (ob-chatgpt-shell
  :fetcher github
- :repo "xenodium/chatgpt-shell"
- :files ("ob-chatgpt-shell.el"))
+ :repo "xenodium/ob-chatgpt-shell")

--- a/recipes/ob-dall-e-shell
+++ b/recipes/ob-dall-e-shell
@@ -1,4 +1,3 @@
 (ob-dall-e-shell
  :fetcher github
- :repo "xenodium/chatgpt-shell"
- :files ("ob-dall-e-shell.el"))
+ :repo "xenodium/ob-dall-e-shell")

--- a/recipes/shell-maker
+++ b/recipes/shell-maker
@@ -1,4 +1,3 @@
 (shell-maker
  :fetcher github
- :repo "xenodium/chatgpt-shell"
- :files ("shell-maker.el"))
+ :repo "xenodium/shell-maker")


### PR DESCRIPTION
### Brief summary of what the package does

This is a follow-up to existing MELPA packages:

**chatgpt-shell/shell-maker** https://github.com/melpa/melpa/pull/8479
**dall-e-shell** https://github.com/melpa/melpa/pull/8513
**ob-chatgpt-shell** https://github.com/melpa/melpa/pull/8514

The packages currently share the same GitHub repository (https://github.com/xenodium/chatgpt-shell). This PR migrates the packages to each have their own Github repository.

### Direct link to the package repository

The new location for the packages is at:

- https://github.com/xenodium/chatgpt-shell
- https://github.com/xenodium/shell-maker
- https://github.com/xenodium/ob-chatgpt-shell
- https://github.com/xenodium/dall-e-shell
- https://github.com/xenodium/ob-dall-e-shell

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)