### PR TITLE
move `use-package-chords` back to it's original home

### DIFF
--- a/recipes/bind-chord
+++ b/recipes/bind-chord
@@ -1,3 +1,3 @@
-(bind-chord :repo "jwiegley/use-package"
+(bind-chord :repo "waymondo/use-package-chords"
             :fetcher github
             :files ("bind-chord.el"))

--- a/recipes/use-package-chords
+++ b/recipes/use-package-chords
@@ -1,3 +1,3 @@
-(use-package-chords :repo "jwiegley/use-package"
+(use-package-chords :repo "waymondo/use-package-chords"
                     :fetcher github
                     :files ("use-package-chords.el"))


### PR DESCRIPTION
`bind-key` and `use-package` live in emacs core these days. the `use-package-chords` extension though lives in John Wiegley's old repo that has drifted from the now "official" version.

the `use-package-chords` extension lived in that repo though, so the plan is to move it out so it can be maintained via MELPA in accordance of the official version.

to address this, i pulled the most recent versions of both `bind-chord` and `use-package-chords` from the `use-package` repo back into my original repo (before i moved them there). this PR just simply points the recipes back to the old home of these repos now.

let me know if there's another step i've missed in this process!

connect to https://github.com/melpa/melpa/issues/9238