### PR TITLE
Add recipe for tab-line-nerd-icons

### DIFF
--- a/recipes/tab-line-nerd-icons
+++ b/recipes/tab-line-nerd-icons
@@ -1,0 +1,3 @@
+(tab-line-nerd-icons
+ :fetcher github
+ :repo "lucius-martius/tab-line-nerd-icons")


### PR DESCRIPTION
### Brief summary of what the package does

The package defines a global minor mode that applies the icons from nerd-icons to tab-line tabs. This works by adding an advice to `tab-line-tab-name-format-default`. I've decided against defining a custom format function and setting it via `tab-line-tab-name-format-function` because then disabling the global minor mode would be less straight forward. If there is a better way to do this, as with all other aspects, I'm open to suggestions.

### Direct link to the package repository

https://github.com/lucius-martius/tab-line-nerd-icons/tree/master

### Your association with the package

I am the maintainer/author of the package.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
