### PR TITLE
Add Fancy URLs Menu package.

### DIFF
--- a/recipes/fancy-urls-menu
+++ b/recipes/fancy-urls-menu
@@ -1,0 +1,3 @@
+(fancy-urls-menu
+ :fetcher codeberg
+ :repo "kakafarm/emacs-fancy-urls-menu")


### PR DESCRIPTION
### Brief summary of what the package does

Lists the URLs in current buffer in an interactive Tabulated-list buffer, where one may mark the entries for opening.

### Direct link to the package repository

https://codeberg.org/kakafarm/emacs-fancy-urls-menu/

### Your association with the package

Author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)