### PR TITLE
Move `apt-sources-list`

### DIFF
--- a/recipes/apt-sources-list
+++ b/recipes/apt-sources-list
@@ -1,2 +1,2 @@
-(apt-sources-list :fetcher git
-                  :url "https://git.korewanetadesu.com/apt-sources-list.git")
+(apt-sources-list :fetcher gitlab
+                  :repo "joewreschnig/apt-sources-list-mode")


### PR DESCRIPTION
Due to changing jobs and my hosting provider going out of business I need to transfer or drop ownership of these projects. Sorry for the trouble.

### Your association with the package

I am or was the maintainer of all of these packages. I am talking with former contributors to find someone to adopt gitlab-ci-mode, but if they do it will move to a different URL.

### Relevant communications with the upstream package maintainer

For verification please see:
- updated description at https://git.korewanetadesu.com/?p=pelican-mode.git;a=summary
- updated description at https://git.korewanetadesu.com/?p=apt-sources-list.git;a=summary
- comments https://gitlab.com/joewreschnig/gitlab-ci-mode/-/merge_requests/4#note_2225589040
