### PR TITLE
add `transform-symbol-at-point`

### DIFF
--- a/recipes/transform-symbol-at-point
+++ b/recipes/transform-symbol-at-point
@@ -1,0 +1,1 @@
+(transform-symbol-at-point :fetcher github :repo "waymondo/transform-symbol-at-point")


### PR DESCRIPTION
### Brief summary of what the package does

this is a simple package i've been personally using for years that i figured i'd finally contribute. it allows you to take a symbol at point under the cursor and transform it with string transformations that are available via the `s.el` package, either with `transient` or `which-key`.

### Direct link to the package repository

https://github.com/waymondo/transform-symbol-at-point

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

none needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)