### PR TITLE
Initial recipe for nice-org-html

### DIFF
--- a/recipes/nice-org-html
+++ b/recipes/nice-org-html
@@ -1,0 +1,5 @@
+(nice-org-html
+ :fetcher github
+ :repo "ewantown/nice-org-html"
+ :branch "release/1.0"
+ :files (:defaults "code/*.el" "code/*.css" "code/*.js"))


### PR DESCRIPTION
### Brief summary of what the package does

The package defines an org-to-html publishing pipeline that generates nicer HTML by default, and makes customized export and publishing much easier. The default generated HTML includes light/dark mode view-toggle, table-of-contents view-toggle, click-to-copy buttons on source blocks, and CSS derived from Emacs themes. Users can easily customize the output on a per-project basis, by specifying different themes for light and dark view-modes, the default mode, paths to site headers and footers, and additional CSS and JS to be injected. See the [HTML export of the README.org](https://etown.dev/nice-org-html/README) for illustration. 

### Direct link to the package repository

https://github.com/ewantown/nice-org-html

### Your association with the package

Author and willing maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
