### PR TITLE
Add recipe for hardtime

### DIFF
--- a/recipes/hardtime
+++ b/recipes/hardtime
@@ -1,0 +1,1 @@
+(hardtime :fetcher github :repo "ichernyshovvv/hardtime.el")


### PR DESCRIPTION
### Brief summary of what the package does

A package for preventing overuse of specified commands (basically, navigation commands)

When hardtime-mode is enabled, it allows you to use specified commands only M times in N seconds and if the limit (M) is reached, it moves the point back and calls hardtime-warn function. All mentioned variables are customizable. For example, hardtime-warn could be set to a function that tells you to use avy-goto-char-timer instead.

The common usage would be to prevent overuse of navigation commands (such as right-char, left-char, next-line, previous-line (bound to arrow keys and C-npbf)). This is the default behaviour.

The name of the package is taken from [vim-hardtime](https://github.com/takac/vim-hardtime/) plugin.

### Direct link to the package repository

https://github.com/ichernyshovvv/hardtime.el

### Your association with the package

Author

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
