### PR TITLE
Add recipe for buffer-terminator

### DIFF
--- a/recipes/buffer-terminator
+++ b/recipes/buffer-terminator
@@ -1,0 +1,1 @@
+(buffer-terminator :fetcher github :repo "jamescherti/buffer-terminator.el")


### PR DESCRIPTION
### Brief summary of what the package does

The buffer-terminator Emacs package automatically terminates inactive buffers to help maintain a clean and efficient workspace. It also helps improve Emacs performance by reducing the number of open buffers.

Only buffers that are saved and inactive for a certain amount of time are terminated.

It provides configurable options to determine which buffers to keep, a timeout for inactivity, and periodic cleanup intervals.

By default, buffer-terminator-mode terminates all file-visiting and dired buffers that have been inactive for longer than the duration specified by buffer-terminator-inactivity-timeout. Special buffers are ignored by default, but you can configure buffer-terminator to include them by adjusting the relevant option provided below.

### Direct link to the package repository

https://github.com/jamescherti/buffer-terminator.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
