### PR TITLE
Package rpm-spec-mode has a new home

### DIFF
--- a/recipes/rpm-spec-mode
+++ b/recipes/rpm-spec-mode
@@ -1,1 +1,1 @@
-(rpm-spec-mode :fetcher github :repo "stigbjorlykke/rpm-spec-mode")
+(rpm-spec-mode :fetcher github :repo "Thaodan/rpm-spec-mode")


### PR DESCRIPTION
This pull request sets https://github.com/Thaodan/rpm-spec-mode/ as the new source for the rpm-spec-mode package.

See the discussion at https://github.com/stigbjorlykke/rpm-spec-mode/issues/12 for background.