### PR TITLE
Add recipe for popon

### DIFF
--- a/recipes/popon
+++ b/recipes/popon
@@ -1,0 +1,1 @@
+(popon :fetcher codeberg :repo "akib/emacs-popon")


### PR DESCRIPTION
### Brief summary of what the package does

Popon allows you to pop text on a window, what we call a popon. Popons are window-local and sticky, they don't move while scrolling, and they even don't go away when switching buffer, but you can bind a popon to a specific buffer to only show on that buffer.

Use-cases include the package `corfu-terminal`, which uses Popon in lieu of child-frames for TTY Emacs.

### Direct link to the package repository

https://codeberg.org/akib/emacs-popon

### Your association with the package

User

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
