### PR TITLE
Add recipe for kill-dollar-mode.

### DIFF
--- a/recipes/kill-dollar-mode
+++ b/recipes/kill-dollar-mode
@@ -1,0 +1,3 @@
+(kill-dollar-mode
+ :fetcher github
+ :repo "sandinmyjoints/kill-dollar-mode")


### PR DESCRIPTION
### Brief summary of what the package does

When killing text from shell-script-like code blocks in documentation, removes leading `$` for convenience.

### Direct link to the package repository

https://github.com/sandinmyjoints/kill-dollar-mode

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
