### PR TITLE
Add recipe for current-window-only

### DIFF
--- a/recipes/current-window-only
+++ b/recipes/current-window-only
@@ -1,0 +1,3 @@
+(current-window-only
+ :fetcher github
+ :repo "FrostyX/current-window-only")


### PR DESCRIPTION
### Brief summary of what the package does

It provides a minor mode that can be enabled with `M-x current-window-only-mode`. Once enabled, it _forces_ Emacs to open new buffers only in the current window. No other windows, no splits.

In the project README, there is a [section with GIFs](https://github.com/FrostyX/current-window-only?tab=readme-ov-file#obligatory-gif-section) comparing default Emacs and Emacs with this mode enabled. There is also a [short youtube video](https://www.youtube.com/watch?v=Qut1oO6nqgA) doing the same.

This package is more than a simple wrapper around `display-buffer-alist`. Not all commands respect this variable (sometimes because they were around before it was invented), and so this package implements multiple tricks to achieve the desired behavior.

It falls to the same category as [shackle](https://depp.brause.cc/shackle/) and [popwin](https://github.com/emacsorphanage/popwin) but in comparison to them, this package is opinionated and doesn't provide any user configuration. It assumes that a user wants to open new buffers always in the current window, and does exactly that.

### Direct link to the package repository

https://github.com/FrostyX/current-window-only

### Your association with the package

Package author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

