### PR TITLE
Add recipe for portage-modes

### DIFF
--- a/recipes/portage-modes
+++ b/recipes/portage-modes
@@ -1,0 +1,3 @@
+(portage-modes
+ :fetcher github
+ :repo "OpenSauce04/portage-modes")


### PR DESCRIPTION
### Brief summary of what the package does

Adds several major modes which provide syntax highlighting when viewing or editing config files for Portage, the Gentoo Linux package manager

### Direct link to the package repository

https://github.com/OpenSauce04/portage-modes

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
  - Warns about a lack of a `lexical-binding` directive but is otherwise fine
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

This is my first time writing anything in Elisp (or any other Lisp), so if I have done anything incorrectly or have taken a particularly strange approach to anything in the code of the package, assume it was simply due to my lack of knowledge and tell me what I can do to improve it.
