### PR TITLE
Add recipe for dicom

### DIFF
--- a/recipes/dicom
+++ b/recipes/dicom
@@ -1,0 +1,3 @@
+(dicom
+ :fetcher github
+ :repo "minad/dicom")


### PR DESCRIPTION
### Brief summary of what the package does

DICOM stands for Digital Imaging and Communications in Medicine. DICOM files are typically used for medical imaging with different modalities like US, CR, CT, MRI or PET. This package adds the ability to view such files in Emacs. The images and metadata are displayed in regular Emacs buffers. The package registers itself in auto-mode-alist and magic-mode-alist for DICOMDIR directory files and DICOM images (file extension *.dcm or *.ima). Furthermore the command dicom-open opens DICOMDIR directory files or DICOM image files interactively.

### Direct link to the package repository

https://github.com/minad/dicom

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
