### PR TITLE
Remove recipe for finalize

### DIFF
--- a/recipes/finalize
+++ b/recipes/finalize
@@ -1,2 +1,0 @@
-(finalize :repo "skeeto/elisp-finalize"
-          :fetcher github)


### PR DESCRIPTION
This package was obsoleted by the release of Emacs 25.1 in 2016. According to `archive.json`, no MELPA packages depend on it.

* https://github.com/skeeto/elisp-finalize
* #1421

Simpler to remove and archive it than update package metadata: https://github.com/skeeto/elisp-finalize/pull/3