### PR TITLE
Remove unmaintained packages bookmark-view and hasklig-mode

### DIFF
--- a/recipes/bookmark-view
+++ b/recipes/bookmark-view
@@ -1,3 +1,0 @@
-(bookmark-view
- :repo "minad/bookmark-view"
- :fetcher github)

--- a/recipes/hasklig-mode
+++ b/recipes/hasklig-mode
@@ -1,3 +1,0 @@
-(hasklig-mode
- :repo "minad/hasklig-mode"
- :fetcher github)


### PR DESCRIPTION
Remove two old packages of mine which are unmaintained and obsolete. They are not widely used.

- hasklig-mode.el has been superseded by ligatures.el
- bookmark-view.el has been superseded by tab-bookmark.el or activities.el