### PR TITLE
recipes/digistar-mode: add :files for icon images

### DIFF
--- a/recipes/digistar-mode
+++ b/recipes/digistar-mode
@@ -1,1 +1,2 @@
-(digistar-mode :fetcher github :repo "retroj/digistar-mode")
+(digistar-mode :fetcher github :repo "retroj/digistar-mode"
+               :files (:defaults "images"))


### PR DESCRIPTION
### Brief summary of what the package does

I added a status-bar button to my package, digistar-mode, a mode for editing a scripting language called Digistar Script, used in planetariums. This change to the package definition is to include the icon files for this tool-bar button.

### Direct link to the package repository

https://github.com/retroj/digistar-mode/

### Your association with the package

I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
