### PR TITLE
Switch @dickmao's repos to gitawonk

### DIFF
--- a/recipes/nndiscourse
+++ b/recipes/nndiscourse
@@ -1,3 +1,3 @@
-(nndiscourse :repo "dickmao/nndiscourse"
-	     :fetcher github
+(nndiscourse :url "https://gitawonk.com/dickmao/nndiscourse.git"
+	     :fetcher git
 	     :files ("nndiscourse.el" ("nndiscourse" "nndiscourse/Gemfile" "nndiscourse/Gemfile.lock" "nndiscourse/nndiscourse.gemspec" "nndiscourse/nndiscourse.thor" "nndiscourse/lib")))

--- a/recipes/nnhackernews
+++ b/recipes/nnhackernews
@@ -1,2 +1,2 @@
-(nnhackernews :repo "dickmao/nnhackernews"
-              :fetcher github)
+(nnhackernews :url "https://gitawonk.com/dickmao/nnhackernews.git"
+              :fetcher git)

--- a/recipes/nnreddit
+++ b/recipes/nnreddit
@@ -1,4 +1,4 @@
 (nnreddit
-  :fetcher github
-  :repo "dickmao/nnreddit"
+  :fetcher git
+  :url "https://gitawonk.com/dickmao/nnreddit.git"
   :files (:defaults "setup.py" "requirements.txt" "nnreddit"))

--- a/recipes/nntwitter
+++ b/recipes/nntwitter
@@ -1,1 +1,1 @@
-(nntwitter :fetcher github :repo "dickmao/nntwitter")
+(nntwitter :fetcher git :url "https://gitawonk.com/dickmao/nntwitter.git")


### PR DESCRIPTION
All the history in the GitHub repos has been squashed and, e.g., https://github.com/dickmao/nntwitter?tab=readme-ov-file#we-moved-to-gitawonk indicates that his repos are moving.
https://github.com/dickmao/magit-patch-changelog appears to be the only unmoved repo.

I'm not related to these projects, I was just trying to find the source and realized that the recipes weren't pointing at the canonical sources. It would be good if @dickmao could confirm that these new sources are correct/better.