### PR TITLE
Move `loopy-dash` to its own repo.

### DIFF
--- a/recipes/loopy-dash
+++ b/recipes/loopy-dash
@@ -1,3 +1,3 @@
 (loopy-dash :fetcher github
-            :repo "okamsn/loopy"
+            :repo "okamsn/loopy-dash"
             :files ("loopy-dash.el"))


### PR DESCRIPTION
This package is being moved to its own repo so that it can be included in Non-GNU ELPA with less friction.

### Brief summary of what the package does

This package adds support for destructuring via Dash to the looping/iterating package Loopy (https://github.com/okamsn/loopy).

This package is already on MELPA.

### Direct link to the package repository

https://github.com/okamsn/loopy-dash

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
