### PR TITLE
Add recipe for turtles

### DIFF
--- a/recipes/turtles
+++ b/recipes/turtles
@@ -1,0 +1,2 @@
+(turtles :fetcher github
+         :repo "szermatt/turtles")


### PR DESCRIPTION
### Brief summary of what the package does

This package help write ERT-based tests to that check how Emacs renders buffers and windows. The ERT tests can be run interactively or in batch mode.

It's especially suited to test:

- the effect of display, before-string, after-string text properties
- the effect of overlays
- text visibility
- status line
- complex minibuffer interactions

See https://turtles.readthedocs.io/en/latest/tutorial.html for examples and an overview.

### Direct link to the package repository

https://github.com/szermatt/turtles

### Your association with the package

Original author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

The linter package reported 2 issues that I ignored, since the types mentioned are protected by checks on emacs version. I don't know how to make them nicer or acceptable to the linter:

File ‘turtles-instance.el’: no warnings
turtles-io.el:33:0: error: "print-unreadable-function" doesn't start with package's prefix "turtles".

```elisp
;; Keep the compiler happy under Emacs 26-28.
(eval-when-compile
  (when (< emacs-major-version 29)
    (defvar print-unreadable-function nil)))
```

Found 1 warning in file ‘turtles-io.el’
turtles.el:571:27: error: You should depend on (emacs "29.1") if you need `ert-test-file-name'.

```elisp
      (when (eval-when-compile (>= emacs-major-version 29))
        (unless file-name
          (setq file-name (ert-test-file-name test))))
```

- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

