### PR TITLE
Add recipe for hl-printf

### DIFF
--- a/recipes/hl-printf
+++ b/recipes/hl-printf
@@ -1,0 +1,1 @@
+(hl-printf :fetcher github :repo "8dcc/hl-printf.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a minor mode for highlighting `printf` format specifiers, such as `%s`, `%lld` or `%-5.3f`. This package is meant for C-like modes, but it can be used on any major mode (that can detect strings with the `syntax-ppss` Emacs function).

The regexp used for the format specifiers (`hl-printf-regexp`) can be modified (or overwritten) to support other escape sequences, such as `\n` or `\x3F`. The font face is also customizable.

### Direct link to the package repository

https://github.com/8dcc/hl-printf.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed.**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
