### PR TITLE
Add recipe for locs-and-refs

### DIFF
--- a/recipes/locs-and-refs
+++ b/recipes/locs-and-refs
@@ -1,3 +1,3 @@
 (locs-and-refs
  :fetcher github
- :repo "phf-1/locs-and-refs)
+ :repo "phf-1/locs-and-refs")

--- a/recipes/locs-and-refs
+++ b/recipes/locs-and-refs
@@ -1,0 +1,3 @@
+(locs-and-refs
+ :repo "phf-1/locs-and-refs"
+ :fetcher github)

--- a/recipes/locs-and-refs
+++ b/recipes/locs-and-refs
@@ -1,3 +1,3 @@
 (locs-and-refs
- :repo "phf-1/locs-and-refs"
- :fetcher github)
+ :fetcher github
+ :repo "phf-1/locs-and-refs)


### PR DESCRIPTION
### Brief summary of what the package does

Locations and References for Emacs

If there is a string like "[[ref:1234]]" in some buffer, then this minor mode
will turn it into a "Reference". A reference may be viewed as a button such that a
click will search for the matching "Location" in files' content, file names and
buffers. A matching location may be a string "[[id:1234]]" or a file named "1234".

More precisely:

- A location is defined as:
  - or `:ID: <ID>`
  - or `[[id:<ID>]]`
  - or `[[id:<ID>][<name>]]`

- A reference is defined as:
  - or `:REF: <ID>`
  - or `[[ref:<ID>]]`
  - or `[[ref:<ID>][<name>]]`



### Direct link to the package repository

https://github.com/phf-1/locs-and-refs

### Your association with the package

Author, maintainer.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


