### PR TITLE
Add motion-selection-mode

### DIFF
--- a/recipes/motion-selection-mode
+++ b/recipes/motion-selection-mode
@@ -1,0 +1,3 @@
+(motion-selection-mode
+ :fetcher github
+ [:repo "alexispurslane/motion-selection-mode"])

--- a/recipes/motion-selection-mode
+++ b/recipes/motion-selection-mode
@@ -1,3 +1,3 @@
 (motion-selection-mode
  :fetcher github
- [:repo "alexispurslane/motion-selection-mode"])
+ :repo "alexispurslane/motion-selection-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Makes Emacs motion commands select the last text objects the user moved over (or extend a manually initiated selection by that text object), and automatically deselect after a certain period of not attempting to run a command on the selection. Essentially giving Emacs, through a combination of motion commands and region commands, a Kakoune-like object-adjective-verb text editing grammar.

### Direct link to the package repository

https://github.com/alexispurslane/motion-selection-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

***None needed***

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
