### PR TITLE
Remove reference to file `loopy-dash.el` from recipe for `loopy`.

### DIFF
--- a/recipes/loopy
+++ b/recipes/loopy
@@ -1,3 +1,2 @@
 (loopy :fetcher github
-       :repo "okamsn/loopy"
-       :files (:defaults (:exclude "loopy-dash.el")))
+       :repo "okamsn/loopy")


### PR DESCRIPTION
That file was moved to a separate repo to make the packages `loopy` and `loopy-dash` easier to package in Non-GNU ELPA.  The recipe for `loopy-dash` was updated in Melpa PR #9309.

### Brief summary of what the package does

Loopy provides macros for destructuring and looping.  It uses parenthesized expressions instead of `cl-loop`'s keyword statements.

Loopy is already packaged in Melpa.

### Direct link to the package repository

https://github.com/okamsn/loopy

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

There are false positives with `checkdoc`.