### PR TITLE
New erlang (treesitter) mode

### DIFF
--- a/recipes/erlang-ts
+++ b/recipes/erlang-ts
@@ -1,4 +1,3 @@
 (erlang-ts
  :fetcher github
- :repo "erlang/emacs-erlang-ts"
-)
+ :repo "erlang/emacs-erlang-ts")

--- a/recipes/erlang-ts
+++ b/recipes/erlang-ts
@@ -1,0 +1,4 @@
+(erlang-ts
+ :fetcher github
+ :repo "erlang/emacs-erlang-ts"
+)


### PR DESCRIPTION
### Brief summary of what the package does

New erlang (treesitter) mode

Currently only fixes font-locking and relies on the "old" erlang mode for everything else.

### Direct link to the package repository

https://github.com/erlang/emacs-erlang-ts

### Your association with the package

maintainer, author 

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] ** I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

** package-lint reports errors for function names but they are intentionally there for overriding the 
the erlang mode functions.

