### PR TITLE
Add recipe for p-search

### DIFF
--- a/recipes/p-search
+++ b/recipes/p-search
@@ -1,0 +1,5 @@
+(p-search
+ :fetcher github
+ :repo "zkry/p-search"
+ :files ("extensions/*.el"
+         "*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

p-search is a local search engine for Emacs, which can aggregate data from multiple sources providing a structured framework for search tasks.

A presentation describing the package can be seen at the last Emacsconf: https://emacsconf.org/2024/talks/p-search/

### Direct link to the package repository

https://github.com/zkry/p-search

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
