### PR TITLE
Add receipt for pif package

### DIFF
--- a/recipes/pif
+++ b/recipes/pif
@@ -1,0 +1,3 @@
+(pif
+ :fetcher github
+ :repo "oliverepper/pif")


### PR DESCRIPTION
### Brief summary of what the package does

pif.el prevents the initial “Flash of Light” during Emacs startup.

In addition to reducing the “Flash of Light”, it ensures that the initial frame appears in the correct size and position – just as it was when Emacs was closed. Furthermore, it hides GUI elements such as the modeline, fringes, and the cursor during startup for a distraction-free initialization.

### Direct link to the package repository

https://github.com/oliverepper/pif

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

