### PR TITLE
Adding recipe for color-log-mode

### DIFF
--- a/recipes/color-log-mode
+++ b/recipes/color-log-mode
@@ -1,0 +1,3 @@
+(color-log-mode
+ :repo "yaitskov/color-log-mode"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

I found hard to work with colored log files in Emacs. 
There is a ansi-color package, but it is not end user stuff.
So Emacs opens a log buffer with unexpanded SGR symbols.

### Direct link to the package repository

https://github.com/yaitskov/color-log-mode

### Your association with the package

I am maintainer, contributor and user.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
