### PR TITLE
Add recipe for consult-gh-emacs-pr-review (renamed to consult-gh-with-pr-review)

### DIFF
--- a/recipes/consult-gh-emacs-pr-review
+++ b/recipes/consult-gh-emacs-pr-review
@@ -1,4 +1,0 @@
-(consult-gh-emacs-pr-review
- :fetcher github
- :repo "armindarvish/consult-gh"
- :files ("consult-gh-emacs-pr-review.el"))

--- a/recipes/consult-gh-emacs-pr-review
+++ b/recipes/consult-gh-emacs-pr-review
@@ -1,0 +1,4 @@
+(consult-gh-emacs-pr-review
+ :fetcher github
+ :repo "armindarvish/consult-gh"
+ :files ("consult-gh-emacs-pr-review.el"))

--- a/recipes/consult-gh-with-pr-review
+++ b/recipes/consult-gh-with-pr-review
@@ -1,0 +1,4 @@
+(consult-gh-with-pr-review
+ :fetcher github
+ :repo "armindarvish/consult-gh"
+ :files ("consult-gh-with-pr-review.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Adds pr-review integration for consult-gh  
  


### Direct link to the package repository

<https://github.com/armindarvish/consult-gh>  
  


### Your association with the package

I am the maintainer.  
  


### Relevant communications with the upstream package maintainer

None needed  
  


### Checklist

-   The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
-   I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
-   I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
-   My elisp byte-compiles cleanly
-   I've used `M-x checkdoc` to check the package's documentation strings
-   I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)