### PR TITLE
update upstream for following packages due to github rename

### DIFF
--- a/recipes/binky
+++ b/recipes/binky
@@ -1,4 +1,4 @@
 (binky
  :fetcher github
- :repo "liuyinz/binky.el"
+ :repo "eki3z/binky.el"
  :old-names (binky-mode))

--- a/recipes/coercion
+++ b/recipes/coercion
@@ -1,3 +1,3 @@
 (coercion
  :fetcher github
- :repo "liuyinz/coercion.el")
+ :repo "eki3z/coercion.el")

--- a/recipes/consult-todo
+++ b/recipes/consult-todo
@@ -1,3 +1,3 @@
 (consult-todo
  :fetcher github
- :repo "liuyinz/consult-todo")
+ :repo "eki3z/consult-todo")

--- a/recipes/conventional-changelog
+++ b/recipes/conventional-changelog
@@ -1,3 +1,3 @@
 (conventional-changelog
  :fetcher github
- :repo "liuyinz/emacs-conventional-changelog")
+ :repo "eki3z/emacs-conventional-changelog")

--- a/recipes/duplexer
+++ b/recipes/duplexer
@@ -1,3 +1,3 @@
 (duplexer
  :fetcher github
- :repo "liuyinz/duplexer.el")
+ :repo "eki3z/duplexer.el")

--- a/recipes/flymake-relint
+++ b/recipes/flymake-relint
@@ -1,1 +1,1 @@
-(flymake-relint :fetcher github :repo "liuyinz/flymake-relint")
+(flymake-relint :fetcher github :repo "eki3z/flymake-relint")

--- a/recipes/git-cliff
+++ b/recipes/git-cliff
@@ -1,3 +1,3 @@
 (git-cliff
  :fetcher github
- :repo "liuyinz/git-cliff.el")
+ :repo "eki3z/git-cliff.el")

--- a/recipes/mini-echo
+++ b/recipes/mini-echo
@@ -1,3 +1,3 @@
 (mini-echo
  :fetcher github
- :repo "liuyinz/mini-echo.el")
+ :repo "eki3z/mini-echo.el")

--- a/recipes/mise
+++ b/recipes/mise
@@ -1,3 +1,3 @@
 (mise
  :fetcher github
- :repo "liuyinz/mise.el")
+ :repo "eki3z/mise.el")


### PR DESCRIPTION


### Brief summary of what the package does

I change my github name, so repository updates needed, following repos are updated:

- binky
- coercion
- consult-todo
- conventional-changelog
- duplexer
- flymake-relint
- git-cliff
- mini-echo
- mise

### Direct link to the package repository

https://github.com/eki3z

### Your association with the package

author

### Relevant communications with the upstream package maintainer



### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
