### PR TITLE
Add a recipe for stillness-mode

### DIFF
--- a/recipes/stillness-mode
+++ b/recipes/stillness-mode
@@ -1,0 +1,1 @@
+(stillness-mode :fetcher github :repo "neeasade/stillness-mode.el")


### PR DESCRIPTION
### Brief summary of what the package does

`stillness-mode` is an aesthetic minor mode that prevents windows from jumping around when a fixed-size minibuffer comes up. This includes scrolling (by moving the point) and window resizing in various layouts. 

### Direct link to the package repository

https://github.com/neeasade/stillness-mode.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**N/A**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
  - note: tested with `package-install-file` from `emacs -Q`

<!-- After submitting, please fix any problems the CI reports. -->
