### PR TITLE
add recipe for myron-themes

### DIFF
--- a/recipes/myron-themes
+++ b/recipes/myron-themes
@@ -1,0 +1,1 @@
+(myron-themes :fetcher github :repo "neeasade/myron-themes" :files (:defaults "themes/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A set of light themes for emacs, built on color explorations over the past few years using [ct.el](https://github.com/neeasade/ct.el).

### Direct link to the package repository

https://github.com/neeasade/myron-themes

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

N/A

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
