### PR TITLE
Point shift-numbers to an updated repository with fixes/improvements

### DIFF
--- a/recipes/shift-number
+++ b/recipes/shift-number
@@ -1,3 +1,3 @@
 (shift-number
- :repo "ideasman42/emacs-shift-number"
- :fetcher codeberg)
+ :fetcher codeberg
+ :repo "ideasman42/emacs-shift-number")

--- a/recipes/shift-number
+++ b/recipes/shift-number
@@ -1,1 +1,3 @@
-(shift-number :repo "alezost/shift-number.el" :fetcher github)
+(shift-number
+ :repo "ideasman42/emacs-shift-number"
+ :fetcher codeberg)


### PR DESCRIPTION
### Brief summary of what the package does

Existing package on melpa to adjust numbers (see: https://melpa.org/#/shift-number )

The PR points to my repository with the following changes:

- Negative number support (optional).
- Fix to prevent the point "leaving" the number (& attempting to move the point beyond `(point-max)` in rare cases).
- Enable lexical bindings.

_These were submitted as PR's, so far it looks as if this package is no longer actively maintained._

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-shift-number

### Your association with the package

Proposing to become new maintainer.

### Relevant communications with the upstream package maintainer

Opened an issue checking if this is still maintained.

https://github.com/alezost/shift-number.el/issues/5

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
