### PR TITLE
add recipe for sly-system-browser

### DIFF
--- a/recipes/sly-system-browser
+++ b/recipes/sly-system-browser
@@ -1,0 +1,5 @@
+(sly-system-browser :fetcher github
+               :repo "Karscist/sly-system-browser"
+               :files (:defaults
+                       "*.lisp"
+                       "*.asd"))


### PR DESCRIPTION
### Brief summary of what the package does

A Smalltalk-like browser for Common Lisp systems, for Sly. Helps navigating packages, functions, classes, etc.

### Direct link to the package repository

https://github.com/Karscist/sly-system-browser

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


