### PR TITLE
Add recipe for org-gnosis

### DIFF
--- a/recipes/org-gnosis
+++ b/recipes/org-gnosis
@@ -1,0 +1,2 @@
+(org-gnosis :fetcher git
+            :url "https://git.thanosapollo.org/org-gnosis")


### PR DESCRIPTION
### Brief summary of what the package does

`org-gnosis` is a zettelkasten-like knowledge management system, similar to org-roam of which it can serve as a drop-in replacement offering major improvements in performance with a minimal design.  Additionally, it offers a 'secondary' journals box which provides integration with org-agendas TODOs (the value of is set by org-gnosis-todo-files) for the day as checkboxes.

### Direct link to the package repository

https://git.thanosapollo.org/org-gnosis

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
