### PR TITLE
Add recipe for org-gnosis-ui

### DIFF
--- a/recipes/org-gnosis-ui
+++ b/recipes/org-gnosis-ui
@@ -1,0 +1,2 @@
+(org-gnosis-ui :fetcher git
+               :url "https://git.thanosapollo.org/org-gnosis-ui")


### PR DESCRIPTION
### Brief summary of what the package does

This is a fork of org-roam-ui, that provides support for org-gnosis.  In the future this package is meant to provide a complete package agnostic UI interface to be used by other note taking systems as well.

### Direct link to the package repository

https://git.thanosapollo.org/org-gnosis-ui/

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed for org-gnosis-ui as I'm the "author" of said package.

In regards to org-roam-ui:
- https://github.com/org-roam/org-roam-ui/issues/323

As well as personal emails, from which unfortunately I've received no answer, thus the fork.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
