### PR TITLE
Replace kixtart-mode with maintained alternative

### DIFF
--- a/recipes/kixtart-mode
+++ b/recipes/kixtart-mode
@@ -1,1 +1,6 @@
-(kixtart-mode :fetcher github :repo "ryrun/kixtart-mode")
+(kixtart-mode
+ :fetcher sourcehut
+ :repo "mew/kixtart-mode"
+ :files ("doc/kixtart-mode.texi"
+         "kixtart-docstrings.el"
+         "kixtart-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

The original package and the replacement are both major modes for for the KiXtart scripting language.

The original package only provides some font-lock rules and so there are no customization settings which would be invalidated when switching to the replacement package. I have the original package author's permission to take over the package name and provide a replacement major mode.

### Direct link to the package repository

Original package: https://github.com/ryrun/kixtart-mode
Replacement package: https://git.sr.ht/~mew/kixtart-mode

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

https://github.com/ryrun/kixtart-mode/issues/2

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)