### PR TITLE
Add recipe for `denote-journal-capture`

### DIFF
--- a/recipes/denote-journal-capture
+++ b/recipes/denote-journal-capture
@@ -1,0 +1,4 @@
+(denote-journal-capture
+ :fetcher sourcehut
+ :repo "swflint/denote-extras"
+ :files ("denote-journal-capture.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package improves integration between org-capture and denote-journal-extras, by allowing users to capture to a specific journal note, and re-use the date in the template.

### Direct link to the package repository

https://git.sr.ht/~swflint/denote-extras

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->