### PR TITLE
Add recipe for mode-line-keyboard.

### DIFF
--- a/recipes/mode-line-keyboard
+++ b/recipes/mode-line-keyboard
@@ -1,0 +1,1 @@
+(mode-line-keyboard :repo "Lindydancer/mode-line-keyboard" :fetcher github)

--- a/recipes/mode-line-keyboard
+++ b/recipes/mode-line-keyboard
@@ -1,1 +1,1 @@
-(mode-line-keyboard :repo "Lindydancer/mode-line-keyboard" :fetcher github)
+(mode-line-keyboard :fetcher github :repo "Lindydancer/mode-line-keyboard")


### PR DESCRIPTION
### Brief summary of what the package does

Use the header-line and mode-line as a keyboard.

This is primarily useful for touch devices, for example when running Emacs in Termux on a tablet or phone.

### Direct link to the package repository

https://github.com/Lindydancer/mode-line-keyboard

### Your association with the package

I'm the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
