### PR TITLE
Point ws-butler recipe to new maintainer's branch

### DIFF
--- a/recipes/ws-butler
+++ b/recipes/ws-butler
@@ -1,1 +1,3 @@
-(ws-butler :fetcher github :repo "lewang/ws-butler")
+(ws-butler :fetcher git
+	   :url "https://git.savannah.gnu.org/git/emacs/nongnu.git"
+	   :branch "elpa/ws-butler")


### PR DESCRIPTION
Hello,

I've taken over maintenance of the version of ws-butler distributed by NonGNU ELPA. I've released version 1.0 there.  This PR updates MELPA to fetch my new version.

As [discussed on emacs-devel](https://lists.gnu.org/archive/html/emacs-devel/2024-10/msg00391.html), the package was in need of some work, and I [requested to take over maintenance](https://github.com/lewang/ws-butler/issues/52) from the original author, who is largely inactive.  He never responded to repeated enquiries, so I opted to take it over without his blessing.  The package is now maintained out of the elpa/ws-butler branch of nongnu-elpa.git on Savannah.

I've made a number of improvements and I think they should be shared with MELPA users, too.

Thanks.