### PR TITLE
Added recipes for my Emacs themes

### DIFF
--- a/recipes/amber-glow-theme
+++ b/recipes/amber-glow-theme
@@ -1,5 +1,5 @@
 (amber-glow-theme
- :repo "madara123pain/unique-emacs-theme-pack"
  :fetcher github
+ :repo "madara123pain/unique-emacs-theme-pack"
  :files ("Themes/amber-glow-theme.el"))
 

--- a/recipes/amber-glow-theme
+++ b/recipes/amber-glow-theme
@@ -1,0 +1,5 @@
+(amber-glow-theme
+ :repo "madara123pain/unique-emacs-theme-pack"
+ :fetcher github
+ :files ("Themes/amber-glow-theme.el"))
+

--- a/recipes/berry-theme
+++ b/recipes/berry-theme
@@ -1,5 +1,5 @@
 (berry-theme
- :repo "madara123pain/unique-emacs-theme-pack"
  :fetcher github
+ :repo "madara123pain/unique-emacs-theme-pack"
  :files ("Themes/berry-theme.el"))
 

--- a/recipes/berry-theme
+++ b/recipes/berry-theme
@@ -1,0 +1,5 @@
+(berry-theme
+ :repo "madara123pain/unique-emacs-theme-pack"
+ :fetcher github
+ :files ("Themes/berry-theme.el"))
+

--- a/recipes/ember-twilight-theme
+++ b/recipes/ember-twilight-theme
@@ -1,5 +1,5 @@
 (ember-twilight-theme
- :repo "madara123pain/unique-emacs-theme-pack"
  :fetcher github
+ :repo "madara123pain/unique-emacs-theme-pack" 
  :files ("Themes/ember-twilight-theme.el"))
 

--- a/recipes/ember-twilight-theme
+++ b/recipes/ember-twilight-theme
@@ -1,0 +1,5 @@
+(ember-twilight-theme
+ :repo "madara123pain/unique-emacs-theme-pack"
+ :fetcher github
+ :files ("Themes/ember-twilight-theme.el"))
+

--- a/recipes/marron-gold-theme
+++ b/recipes/marron-gold-theme
@@ -1,5 +1,5 @@
 (marron-gold-theme
- :repo "madara123pain/unique-emacs-theme-pack"
  :fetcher github
+ :repo "madara123pain/unique-emacs-theme-pack"  
  :files ("Themes/marron-gold-theme.el"))
 

--- a/recipes/marron-gold-theme
+++ b/recipes/marron-gold-theme
@@ -1,0 +1,5 @@
+(marron-gold-theme
+ :repo "madara123pain/unique-emacs-theme-pack"
+ :fetcher github
+ :files ("Themes/marron-gold-theme.el"))
+

--- a/recipes/roseline-theme
+++ b/recipes/roseline-theme
@@ -1,5 +1,5 @@
 (roseline-theme
- :repo "madara123pain/unique-emacs-theme-pack"
  :fetcher github
+ :repo "madara123pain/unique-emacs-theme-pack"  
  :files ("Themes/roseline-theme.el"))
 

--- a/recipes/roseline-theme
+++ b/recipes/roseline-theme
@@ -1,0 +1,5 @@
+(roseline-theme
+ :repo "madara123pain/unique-emacs-theme-pack"
+ :fetcher github
+ :files ("Themes/roseline-theme.el"))
+

--- a/recipes/solarized-gruvbox-theme
+++ b/recipes/solarized-gruvbox-theme
@@ -1,5 +1,5 @@
 (solarized-gruvbox-theme
- :repo "madara123pain/unique-emacs-theme-pack"
  :fetcher github
+ :repo "madara123pain/unique-emacs-theme-pack" 
  :files ("Themes/solarized-gruvbox-theme.el"))
 

--- a/recipes/solarized-gruvbox-theme
+++ b/recipes/solarized-gruvbox-theme
@@ -1,0 +1,5 @@
+(solarized-gruvbox-theme
+ :repo "madara123pain/unique-emacs-theme-pack"
+ :fetcher github
+ :files ("Themes/solarized-gruvbox-theme.el"))
+

--- a/recipes/spider-man-theme
+++ b/recipes/spider-man-theme
@@ -1,0 +1,5 @@
+(spider-man-theme
+ :repo "madara123pain/unique-emacs-theme-pack"
+ :fetcher github
+ :files ("Themes/spider-man-theme.el"))
+

--- a/recipes/spider-man-theme
+++ b/recipes/spider-man-theme
@@ -1,5 +1,5 @@
 (spider-man-theme
- :repo "madara123pain/unique-emacs-theme-pack"
  :fetcher github
+ :repo "madara123pain/unique-emacs-theme-pack" 
  :files ("Themes/spider-man-theme.el"))
 


### PR DESCRIPTION
### Brief summary of what the package does

This pull request adds recipes for my custom Emacs themes:

- **Amber Glow Theme**
- **Berry Theme**
- **Ember Twilight Theme**
- **Marron Gold Theme**
- **Roseline Theme**
- **Solarized Gruvbox Theme**
- **Spider-Man Theme**

These themes provide a unique color scheme and enhanced UI experience for Emacs users.

### Direct link to the package repository

[https://github.com/madara123pain/unique-emacs-theme-pack](https://github.com/madara123pain/unique-emacs-theme-pack)

### Your association with the package

I am the maintainer and creator of these themes.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[ ]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
