### PR TITLE
added sixcolors-theme, a new theme for Emacs

### DIFF
--- a/recipes/sixcolors-theme
+++ b/recipes/sixcolors-theme
@@ -1,0 +1,1 @@
+(sixcolors-theme :repo "mastro35/sixcolors-theme" :fetcher github)

--- a/recipes/sixcolors-theme
+++ b/recipes/sixcolors-theme
@@ -1,1 +1,1 @@
-(sixcolors-theme :repo "mastro35/sixcolors-theme" :fetcher github)
+(sixcolors-theme :fetcher github :repo "mastro35/sixcolors-theme")


### PR DESCRIPTION
### Brief summary of what the package does

A new theme for Emacs based on the six colors
of the original Apple logo

### Direct link to the package repository

https://github.com/mastro35/sixcolors-theme

### Your association with the package

I am the author and the mantainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
