### PR TITLE
Add recipe for calle24

### DIFF
--- a/recipes/calle24
+++ b/recipes/calle24
@@ -2,12 +2,4 @@
  :fetcher github
  :repo "kickingvegas/calle24"
  :files
- ("*.el" "lisp/*.el"
-   "dir" "*.info" "*.texi" "*.texinfo"
-   "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
-   "docs/dir" "docs/*.info" "docs/*.texi" "docs/*.texinfo"
-   "images"
-   (:exclude
-    ".dir-locals.el" "lisp/.dir-locals.el"
-    "test.el" "tests.el" "*-test.el" "*-tests.el"
-    "lisp/test.el" "lisp/tests.el" "lisp/*-test.el" "lisp/*-tests.el")))
+ (:defaults "images"))

--- a/recipes/calle24
+++ b/recipes/calle24
@@ -1,0 +1,13 @@
+(calle24
+ :fetcher github
+ :repo "kickingvegas/calle24"
+ :files
+ ("*.el" "lisp/*.el"
+   "dir" "*.info" "*.texi" "*.texinfo"
+   "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
+   "docs/dir" "docs/*.info" "docs/*.texi" "docs/*.texinfo"
+   "images"
+   (:exclude
+    ".dir-locals.el" "lisp/.dir-locals.el"
+    "test.el" "tests.el" "*-test.el" "*-tests.el"
+    "lisp/test.el" "lisp/tests.el" "lisp/*-test.el" "lisp/*-tests.el")))


### PR DESCRIPTION
### Brief summary of what the package does

This package substitutes by proxy the default Emacs tool bar images with their SF Symbols equivalent.

### Direct link to the package repository

https://github.com/kickingvegas/calle24


### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

*None Needed*


### Checklist


- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

