### PR TITLE
Add a recipe for noether

### DIFF
--- a/recipes/noether
+++ b/recipes/noether
@@ -1,0 +1,3 @@
+(noether
+ :fetcher sourcehut :repo "lxsameer/noether"
+ :files ("*.el" (:exclude "test-noether.el")))


### PR DESCRIPTION
### Brief summary of what the package does

**Noether Mode** is a global minor mode which manages user-defined **Views** that can be called upon
using their corresponding function or keybinding. Each of them, may contain one or more *Units* that
can automatically update the parent view. Something like a framework to create posframes on demand.
As an example, my main use case for **Noether Mode** is a
replacement for mode line. I defined a View with a bunch of units like, buffer name, project name,
current time, line/column number of the cursor, and so on. And I used `C-c 1` as the keybinding,
and set the timeout of the view to 10 seconds. Subsequently, I just disabled the mode line since I
don't use it any more. Whenever I need the view, I just use `C-c 1` to call upon it. Noether shows
it to me for 10 seconds in a position that I set in the view definition.

One can create dashboards, view, or frames with auto-updating information.

![noether-screenshot](https://github.com/user-attachments/assets/3ff7c819-93c3-4f76-8b7a-b1b4487a494c)


### Direct link to the package repository

https://git.sr.ht/~lxsameer/noether

### Your association with the package

Author

### Relevant communications with the upstream package maintainer
None needed

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
