### PR TITLE
ENH: Add newer capnp mode

### DIFF
--- a/recipes/capnp2-mode
+++ b/recipes/capnp2-mode
@@ -1,0 +1,4 @@
+(capnp2-mode
+ :repo "HaoZeke/capnp2-mode"
+ :fetcher github
+ :files ("capnp2-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Slightly nicer font-locking for `capnp`.

### Direct link to the package repository

https://github.com/HaoZeke/capnp2-mode

### Your association with the package

Maintainer and author.

### Relevant communications with the upstream package maintainer

N/A.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
