### PR TITLE
Add recipe for org-daily-reflection

### DIFF
--- a/recipes/org-daily-reflection
+++ b/recipes/org-daily-reflection
@@ -1,0 +1,1 @@
+(org-daily-reflection :fetcher github :repo "emacsomancer/org-daily-reflection")


### PR DESCRIPTION
### Brief summary of what the package does
Reflect on Org-related daily journal entries (currently set-up mainly for org-roam or similar daily note systems). Shows a range of split windows, each with a daily journal entry in them, at specified intervals. Org Daily Reflection can be used like a paper three- or five-year diary, to see what was happening on this day last year, and the year prior, &c. But dailies can be compared at other specified intervals (days, weeks, fortnights, months, years, [decades], [centuries]). (E.g., “show me 7 dailies at weekly intervals”; “show me 4 dailies at monthly intervals”, &c.)

A general interactive interface can be accessed via the command org-daily-reflect, which will ask the user for a time-span (e.g. “year”) and an integer range (“3”). When called non-interactively, it also be passed a span and range number (e.g., `(org-daily-reflection 'year 3)`, to get dailies comparing this day on the preceding three years.)

### Direct link to the package repository

https://github.com/emacsomancer/org-daily-reflection

### Your association with the package

creator/maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
