### PR TITLE
Update recipe for brf.

### DIFF
--- a/recipes/brf
+++ b/recipes/brf
@@ -1,1 +1,3 @@
-(brf :fetcher git :url "https://bitbucket.org/MikeWoolley/brf-mode")
+(brf :fetcher git
+     :url "https://bitbucket.org/MikeWoolley/brf-mode"
+     :files ("*.el" "*.org" "*.info"))


### PR DESCRIPTION
Org file was missing from package.

### Brief summary of what the package does

Brf-mode provides features from the legendary programmer's editor Brief.

### Direct link to the package repository

https://bitbucket.org/MikeWoolley/brf-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
