### PR TITLE
Add recipe for ob-aider package

### DIFF
--- a/recipes/ob-aider
+++ b/recipes/ob-aider
@@ -1,0 +1,3 @@
+(ob-aider
+ :fetcher github
+ :repo "localredhead/ob-aider.el")


### PR DESCRIPTION
Brief summary of what the package does
An Org Babel library for sending prompts to an already running Aider.el comint buffer directly from Org mode source blocks.

Direct link to the package repository
https://github.com/localredhead/ob-aider.el

Your association with the package
Maintainer / Creator

Relevant communications with the upstream package maintainer
None.

Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used M-x checkdoc to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
