### PR TITLE
Update denote-agenda URL

### DIFF
--- a/recipes/denote-agenda
+++ b/recipes/denote-agenda
@@ -1,4 +1,3 @@
 (denote-agenda
  :fetcher sourcehut
- :repo "swflint/denote-extras"
- :files ("denote-agenda.el"))
+ :repo "swflint/denote-agenda")


### PR DESCRIPTION
Based on the discussion in #9357, I have split `denote-agenda` and `denote-journal-capture` into separate repositories.  I have renamed the repository for both as well.  A second PR will follow for `denote-journal-capture`.