### PR TITLE
Add recipe for `denote-project-notes`

### DIFF
--- a/recipes/denote-project-notes
+++ b/recipes/denote-project-notes
@@ -1,0 +1,3 @@
+(denote-project-notes
+ :fetcher sourcehut
+ :repo "swflint/denote-project-notes")


### PR DESCRIPTION
-------

### Brief summary of what the package does

`denote-project-notes` provides a simple method of linking to Denote notes from a project (broadly considered).  This is useful to easily pull-up Denote notes from a `prog-mode` buffer or similar.

### Direct link to the package repository

https://git.sr.ht/~swflint/denote-project-notes

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->