### PR TITLE
Add recipe for org-expose-emphasis-markers.

### DIFF
--- a/recipes/org-expose-emphasis-markers
+++ b/recipes/org-expose-emphasis-markers
@@ -1,0 +1,2 @@
+(org-expose-emphasis-markers :fetcher github
+                             :repo "lorniu/org-expose-emphasis-markers")


### PR DESCRIPTION
### Brief summary of what the package does

Automatically show hidden emphasis markers at point in org mode.

This is useful for editing org file when org-hide-emphasis-markers is on.

In org mode, hide emphasis markers can make reading nice, but not good for editing. Here provide a mode to let hidden markers auto expose when the cursor on, and auto hide when cursor leave.

### Direct link to the package repository

https://github.com/lorniu/org-expose-emphasis-markers

### Your association with the package

the maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
