### PR TITLE
Update flexoki-themes to use codeberg

### DIFF
--- a/recipes/flexoki-themes
+++ b/recipes/flexoki-themes
@@ -1,2 +1,2 @@
-(flexoki-themes :fetcher github
+(flexoki-themes :fetcher codeberg
                 :repo "crmsnbleyd/flexoki-emacs-theme")


### PR DESCRIPTION
### Brief summary of what the package does

Pair of Emacs themes

### Direct link to the package repository

https://codeberg.org/crmsnbleyd/flexoki-emacs-theme

### Your association with the package

Maintainer

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
