### PR TITLE
Add recipe for typespec-ts-another-mode

### DIFF
--- a/recipes/typespec-ts-another-mode
+++ b/recipes/typespec-ts-another-mode
@@ -1,0 +1,1 @@
+(typespec-ts-another-mode :fetcher github :repo "ncaq/typespec-ts-another-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for TypeSpec using tree-sitter.

### Direct link to the package repository

<https://github.com/ncaq/typespec-ts-another-mode>

### Your association with the package

maintainer/author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

### Supplement

This package is similar to typespec-ts-mode, or rather,
it was first created under the name typespec-ts-mode and later renamed to typespec-ts-another-mode.
So it is doubtful that it meets the items for innovative packages.
However, typespec-ts-mode is a later development, simply because it was not registered with melpa.
I have no ill feelings toward typespec-ts-mode at all,
but I should mention that I did not ignore the guide that says “improve existing packages rather than creating new ones”.
When I was developing typespec-ts-another-mode,
there was no major mode for typespec,
and I developed and improved existing software by submitting PRs to the underlying tree-sitter-typespec,
fixing bugs, implementing features, etc.
I developed the software by improving the existing software.