### PR TITLE
Add repeat-fu

### DIFF
--- a/recipes/repeat-fu
+++ b/recipes/repeat-fu
@@ -1,0 +1,3 @@
+(repeat-fu
+ :fetcher codeberg
+ :repo "ideasman42/emacs-repeat-fu")


### PR DESCRIPTION
### Brief summary of what the package does

A package to repeat the last action that supports configurable groupings.

Or this could be presented as: `evil-repeat` for other modal editing systems (presets are included for Meow, Emacs for example).
Support for other modal editing systems is relatively easy to support.

This allows (among other things) all actions in "insert" mode to be grouped, it addresses the limitation noted here:
https://github.com/meow-edit/meow/discussions/414

NOTE: This started out as an improvement to [dot-mode](https://melpa.org/#/dot-mode), however the functionality changes enough that I don't think it's practical to attempt to make this an improvement to `dot-mode`.

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-repeat-fu

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
