### PR TITLE
feat: add org-invoice-table

### DIFF
--- a/recipes/org-invoice-table
+++ b/recipes/org-invoice-table
@@ -1,1 +1,1 @@
-(org-invoice-table :fetcher sourcehut :repo "trevdev/org-invoice-table")
+(org-invoice-table :fetcher codeberg :repo "trevdev/org-invoice-table")

--- a/recipes/org-invoice-table
+++ b/recipes/org-invoice-table
@@ -1,0 +1,1 @@
+(org-invoice-table :fetcher sourcehut :repo "trevdev/org-invoice-table")


### PR DESCRIPTION
### Brief summary of what the package does

This package contains a custom clocktable formatter for `org-mode` that helps the user build tables to invoice clients with.

### Direct link to the package repository

https://codeberg.org/trevdev/org-invoice-table

### Your association with the package

I am the author and maintainer

### Relevant communications with the upstream package maintainer

None required

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
