### PR TITLE
Exclude .bump-version.el in iregister

### DIFF
--- a/recipes/iregister
+++ b/recipes/iregister
@@ -1,1 +1,2 @@
-(iregister :fetcher github :repo "atykhonov/iregister.el")
+(iregister :fetcher github :repo "atykhonov/iregister.el"
+           :files (:defaults (:exclude ".bump-version.el")))


### PR DESCRIPTION
.bump-version.el is not useful for users.  It also causes a build [failure](https://hydra.nix-community.org/build/4124597/nixlog/1) in Emacs 30 in our CI.