### PR TITLE
Add aidev-mode recipe

### DIFF
--- a/recipes/aidev-mode
+++ b/recipes/aidev-mode
@@ -1,0 +1,4 @@
+(aidev-mode
+ :fetcher github
+ :repo "inaimathi/aidev-mode"
+ :files ("aidev-mode.el"))

--- a/recipes/aidev-mode
+++ b/recipes/aidev-mode
@@ -1,4 +1,3 @@
 (aidev-mode
  :fetcher github
- :repo "inaimathi/aidev-mode"
- :files ("aidev-mode.el"))
+ :repo "inaimathi/aidev-mode")

--- a/recipes/aidev-mode
+++ b/recipes/aidev-mode
@@ -1,3 +1,1 @@
-(aidev-mode
- :fetcher github
- :repo "inaimathi/aidev-mode")
+(aidev-mode :fetcher github :repo "inaimathi/aidev-mode")


### PR DESCRIPTION
### Brief summary of what the package does

Exposes a minimal interface for AI-assisted development in any major mode. Specifically,

```
aidev-insert-chat
aidev-refactor-region-with-chat
aidev-refactor-buffer-with-chat
aidev-new-buffer-from-chat
aidev-start-chat
```

supports `ollama`, Claude and ChatGPT as backends with specifiable models.

### Direct link to the package repository

https://github.com/inaimathi/aidev-mode

### Your association with the package

I'm the maintainer and enthusiastic user (although I have to admit, I mostly call `insert-chat` and `refactor-region-with-chat`).

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
