### PR TITLE
Add recipe for `fsrs`

### DIFF
--- a/recipes/fsrs
+++ b/recipes/fsrs
@@ -1,0 +1,1 @@
+(fsrs :fetcher github :repo "open-spaced-repetition/lisp-fsrs")


### PR DESCRIPTION
### Brief summary of what the package does

FSRS is an advanced spaced repetition algorithm that optimizes review scheduling by adapting to individual memory patterns. It outperforms SM-2 and can be used to implement some Anki-like spaced repetition systems inside Emacs.

### Direct link to the package repository

https://github.com/open-spaced-repetition/lisp-fsrs

### Your association with the package

Maintainer in the organization

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings  
  **Note**: The docstring provided via `:documentation` for `cl-defgeneric` (the only declaration method allowed in ANSI CL) is recognized by Emacs but deemed missing by `checkdoc`. I will report this issue to the Emacs maintainers later.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->