### PR TITLE
Specify `:fetcher` before `:repo` as suggested for magik-mode

### DIFF
--- a/recipes/magik-mode
+++ b/recipes/magik-mode
@@ -1,4 +1,4 @@
 (magik-mode
- :repo "roadrunner1776/magik"
  :fetcher github
+ :repo "roadrunner1776/magik"
  :files (:defaults "snippets"))


### PR DESCRIPTION
### Brief summary of what the package does

Provides a major mode for editing Smallworld (GIS) Magik files.

### Direct link to the package repository

[roadrunner1776/magik](https://github.com/roadrunner1776/magik)

### Your association with the package

A contributor

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [ ] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)