### PR TITLE
Add recipe for stripspace

### DIFF
--- a/recipes/stripspace
+++ b/recipes/stripspace
@@ -1,0 +1,1 @@
+(stripspace :fetcher github :repo "jamescherti/stripspace.el")


### PR DESCRIPTION
### Brief summary of what the package does

The **stripspace** Emacs package offers stripspace-local-mode, which ensures that trailing whitespace is removed before saving a buffer.

Additionally, The *stripspace* package offers an optional feature controlled by the stripspace-restore-column variable (disabled by default), which, when enabled, preserves the cursor's column position even after stripping spaces. This is useful when extra spaces are added and the file is saved. While *stripspace* removes trailing whitespace from both the saved file and the currently edited buffer, it ensures that the spaces before the cursor on the current line remain unchanged. This maintains a consistent editing experience and prevents the cursor from shifting due to the removal of spaces from the current line, in addition to other lines.

Features:
- Automatically removes trailing whitespace before saving buffers.
- An optional feature `stripspace-only-if-initially-clean` (disabled by default), which, when set to non-nil, instructs stripspace to only delete whitespace when the buffer is clean initially.
- The `stripspace-verbose` variable, when non-nil, shows in the minibuffer whether trailing whitespaces have been removed or, if not, provides the reason for their retention.
- The `(stripspace-clean)` function forces the deletion of trailing whitespace in the current buffer. When the `stripspace-only-if-initially-clean` variable is non-nil, this function also marks the buffer as clean, ensuring that `stripspace-local-mode` will remove trailing whitespace the next time the buffer is saved.
- An optional feature controlled by the `stripspace-restore-column` variable (disabled by default), which, when set to non-nil, preserves the cursor's column position even after stripping spaces. This is useful when extra spaces are added and the file is saved:
  - Saved file: Removes all trailing whitespace.
  - Currently edited file (buffer): Removes all trailing whitespace but **preserves the cursor's column position on the current line, including any spaces before the cursor**.
  This ensures a consistent editing experience and prevents unintended cursor movement when saving a buffer and removing trailing whitespace.

### Direct link to the package repository

https://github.com/jamescherti/stripspace.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
