### PR TITLE
Add recipe for fretboard.el 

### DIFF
--- a/recipes/fretboard
+++ b/recipes/fretboard
@@ -1,0 +1,1 @@
+(fretboard :fetcher github :repo "skyefreeman/fretboard.el")


### PR DESCRIPTION
### Brief summary of what the package does

This is a music theory and guitar fretboard visualization tool for Emacs. `fretboard.el` enables end-users to visualize the guitar fretboard in pure text, toggling between keys and chords, and providing support for alternate tunings and chord voicing's.

### Direct link to the package repository

https://github.com/skyefreeman/fretboard.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
