### PR TITLE
Add recipe for citar-org-node

### DIFF
--- a/recipes/citar-org-node
+++ b/recipes/citar-org-node
@@ -1,0 +1,3 @@
+(citar-org-node
+ :fetcher github
+ :repo "krisbalintona/citar-org-node")


### PR DESCRIPTION
### Brief summary of what the package does

This package integrates [org-node](https://github.com/meedstrom/org-node), a note-taking package, with [citar](https://github.com/emacs-citar/citar), a popular bibliographic references management package..

### Direct link to the package repository

https://github.com/krisbalintona/citar-org-node#

### Your association with the package

I am the author of this package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
