### PR TITLE
Add cuckoo-search package

### DIFF
--- a/recipes/cuckoo-search
+++ b/recipes/cuckoo-search
@@ -1,3 +1,3 @@
-(cuckoo-search :repo "rtrppl/cuckoo-search"
-               :fetcher github
-               :files (:defaults "readme.org"))
+(cuckoo-search :fetcher github
+               :repo "rtrppl/cuckoo-search"
+               :files (:defaults))

--- a/recipes/cuckoo-search
+++ b/recipes/cuckoo-search
@@ -1,3 +1,1 @@
-(cuckoo-search :fetcher github
-               :repo "rtrppl/cuckoo-search"
-               :files (:defaults))
+(cuckoo-search :fetcher github :repo "rtrppl/cuckoo-search")

--- a/recipes/cuckoo-search
+++ b/recipes/cuckoo-search
@@ -1,0 +1,3 @@
+(cuckoo-search :repo "rtrppl/cuckoo-search"
+               :fetcher github
+               :files (:defaults "readme.org"))


### PR DESCRIPTION

### Brief summary of what the package does

The package adds content-based search and saved-searches for the Elfeed package. Content-based search draws on `ripgrep`; saved-searches  are stored in a JSON-formatted local file.

### Direct link to the package repository

https://github.com/rtrppl/cuckoo-search

### Your association with the package

I am the maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
