### PR TITLE
Add recipe for persist-text-scale

### DIFF
--- a/recipes/persist-text-scale
+++ b/recipes/persist-text-scale
@@ -1,0 +1,1 @@
+(persist-text-scale :fetcher github :repo "jamescherti/persist-text-scale.el")


### PR DESCRIPTION
### Brief summary of what the package does

The persist-text-scale is an Emacs package that persists and restores the text scale for files and special buffers. By default, it saves the text scale individually for each file and applies a shared text scale for categories of special buffers. This behavior ensures a consistent and personalized reading experience across sessions.

You can customize how buffer categories are determined by setting using a function. This function should return a category identifier based on the buffer context. Buffers within the same category will share the same text scale.

### Direct link to the package repository

https://github.com/jamescherti/persist-text-scale.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
