### PR TITLE
Add recipe for votd

### DIFF
--- a/recipes/votd
+++ b/recipes/votd
@@ -1,0 +1,2 @@
+(votd :repo "kristjoc/votd" :fetcher github)
+


### PR DESCRIPTION
### Brief summary of what the package does

votd is a simple Emacs package that fetches the Bible verse of the
day from https://www.biblegateway.com/ and formats it to be used as
an emacs-dashboard footer or *scratch* buffer message in Emacs.

### Direct link to the package repository

https://github.com/kristjoc/votd

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
