### PR TITLE
Add recipe for inform-mode

### DIFF
--- a/recipes/inform-mode
+++ b/recipes/inform-mode
@@ -1,0 +1,1 @@
+(inform-mode :fetcher github :repo "rrthomas/inform-mode")


### PR DESCRIPTION
### Brief summary of what the package does

inform-mode is an editing mode for Inform 6 files. (Inform 6 is a widely-used programming language for writing interactive fiction.)

### Direct link to the package repository

https://github.com/rrthomas/inform-mode

### Your association with the package

I’m the (new) maintainer (taking over from Rupert Lane).

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

One note: package-lint gives a warning:

    63:0: error: Customization groups should not end in "-mode" unless that name would conflict with their parent group.

I have not changed this, because inform-mode is a 30-year-old package, and it doesn’t seem worth breaking backwards compatibility at this point.