### PR TITLE
Add recipe for aws-athena-babel

### DIFF
--- a/recipes/aws-athena-babel
+++ b/recipes/aws-athena-babel
@@ -1,4 +1,1 @@
-(aws-athena-babel
- :fetcher github
- :repo "will-abb/aws-athena-babel"
- :files ("aws-athena-babel.el"))
+(aws-athena-babel :fetcher github :repo "will-abb/aws-athena-babel")

--- a/recipes/aws-athena-babel
+++ b/recipes/aws-athena-babel
@@ -1,0 +1,4 @@
+(aws-athena-babel
+ :fetcher github
+ :repo "will-abb/aws-athena-babel"
+ :files ("aws-athena-babel.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`aws-athena-babel` allows you to run AWS Athena SQL queries directly from Org Babel source blocks in Emacs. It submits queries via the AWS CLI, monitors their execution in a live buffer, and provides options to display results as CSV or JSON. It also supports cost tracking and result reuse using Athena workgroups.

### Direct link to the package repository

https://github.com/will-abb/aws-athena-babel

### Your association with the package

I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)