### PR TITLE
Add ordered-set.el

### DIFF
--- a/recipes/ordered-set
+++ b/recipes/ordered-set
@@ -1,0 +1,1 @@
+(ordered-set :fetcher github :repo "kisaragi-hiu/ordered-set.el")


### PR DESCRIPTION
### Brief summary of what the package does

This library is an implementation of JS-like sets. Like hash tables, member lookup is fast, but unlike hash tables, member insertion order is preserved.

### Direct link to the package repository

https://github.com/kisaragi-hiu/ordered-set.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
     There are false-positives: "Sets are sequences" triggers "probably Sets should be imperative Set", and "Return non-nil if SET contains an element equal to ELT." triggers "probably contains should be imperative contain".
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
