### PR TITLE
fix: Include ps1 script file in lsp-mode

### DIFF
--- a/recipes/lsp-mode
+++ b/recipes/lsp-mode
@@ -1,4 +1,4 @@
 (lsp-mode :repo "emacs-lsp/lsp-mode"
           :fetcher github
           :files (:defaults
-                  "clients/*.el"))
+                  "clients/*.*"))


### PR DESCRIPTION
For https://github.com/emacs-lsp/lsp-mode/issues/4557.