### PR TITLE
Add recipe for jsonp

### DIFF
--- a/recipes/jsonp
+++ b/recipes/jsonp
@@ -1,0 +1,1 @@
+(jsonp :fetcher github :repo "joshbax189/jsonp-el")


### PR DESCRIPTION
### Brief summary of what the package does

This is a library that implements JSON pointer resolution within Emacs Lisp representations of JSON objects.

The reason you might want such a library is to look up `$ref` properties in JSON schema or OpenAPI/Swagger specs. Since Emacs JSON parsing functions output a variety of formats, there are a surprising number of edge cases for what should be a simple algorithm.

There are usage examples in the repo's README.

### Direct link to the package repository

https://github.com/joshbax189/jsonp-el

### Your association with the package

Author/Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
