### PR TITLE
Add `too-wide-minibuffer-mode` recipe

### DIFF
--- a/recipes/too-wide-minibuffer-mode
+++ b/recipes/too-wide-minibuffer-mode
@@ -1,0 +1,3 @@
+(too-wide-minibuffer-mode
+ :fetcher github
+ :repo "hron/too-wide-minibuffer-mode")


### PR DESCRIPTION
### Brief summary of what the package does

too-wide-minibuffer-mode adjusts minibuffer size and position, so it is displayed under the selected window and occupied half of the frame. It is move convenient to focus if the frame is too wide.

![image](https://github.com/user-attachments/assets/6ffce7e1-dc5d-4d3f-80c8-7a416bfe3eb1)

### Direct link to the package repository

https://github.com/hron/too-wide-minibuffer-mode

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
