### PR TITLE
Add recipe for bookmarks-menu

### DIFF
--- a/recipes/bookmarks-menu
+++ b/recipes/bookmarks-menu
@@ -1,0 +1,1 @@
+(bookmarks-menu :fetcher github :repo "ajrosen/bookmarks-menu")


### PR DESCRIPTION
### Brief summary of what the package does

Adds a _Bookmarks_ menu to the menu bar like web browsers.

### Direct link to the package repository

https://github.com/ajrosen/bookmarks-menu

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

`make recipes/bookmarks-menu` and `(package-build-archive)` succeed.

I get `tar--check-descriptor: Wrong type argument: arrayp, nil` when trying to install with `(package-install-file)`.  I get this error with every recipe.

<!-- After submitting, please fix any problems the CI reports. -->
