### PR TITLE
Update recipe for indexed

### DIFF
--- a/recipes/indexed
+++ b/recipes/indexed
@@ -1,1 +1,0 @@
-(indexed :fetcher github :repo "meedstrom/indexed" :branch "indexed")

--- a/recipes/indexed
+++ b/recipes/indexed
@@ -1,1 +1,1 @@
-(indexed :fetcher github :repo "meedstrom/indexed")
+(indexed :fetcher github :repo "meedstrom/indexed" :branch "indexed")

--- a/recipes/org-mem
+++ b/recipes/org-mem
@@ -1,0 +1,2 @@
+(org-mem :fetcher github :repo "meedstrom/org-mem"
+         :old-names (indexed))


### PR DESCRIPTION
Hello. I plan to rename a package. I know I shouldn't do that, but it's important to me this time.

So, this is step 1 of a graceful transition, as far as I've thought about it.  Not done such a thing before.

These steps sound good?

1. Preserve old package forever, on a branch "indexed"  (see this commit)
2. Go on GitHub to rename my repo, so it gets new address at https://github.com/meedstrom/org-mem, and rename files in the default branch
3. Not sure what happens to old address https://github.com/meedstrom/indexed, but if it becomes a dead link, I'll just clone the repo so the "indexed" recipe keeps working, even for Elpaca users who haven't synced with MELPA in a while.
   - But I'd be surprised if GitHub can't set up an auto redirect.  And that's what step 1 is for.  The link may redirect, but not the branch.
5. Submit new recipe to MELPA called "org-mem", that fetches from default branch
6. Wait some months
7. Remove recipe "indexed"