### PR TITLE
Add beluga-mode

### DIFF
--- a/recipes/beluga-mode
+++ b/recipes/beluga-mode
@@ -1,0 +1,1 @@
+(beluga-mode :fetcher github :repo "Beluga-lang/Beluga" :files ("tools/beluga-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for [Beluga](https://github.com/Beluga-lang/Beluga) proof assistant

### Direct link to the package repository

https://github.com/Beluga-lang/Beluga

### Your association with the package

A formal maintainer and a user

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [ ] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
