### PR TITLE
added recipe for jam1015/evil-god-toggle

### DIFF
--- a/recipes/evil-god-toggle
+++ b/recipes/evil-god-toggle
@@ -1,0 +1,1 @@
+(evil-god-toggle :fetcher github :repo "jam1015/evil-god-toggle")


### PR DESCRIPTION
makes god-mode a state of evil

### Brief summary of what the package does

This package provides a simple global minor‐mode for Emacs that lets you switch seamlessly between Evil’s modal (Vim-style) editing and God mode’s single-key “command” input. It defines three toggleable states:

    god: enter persistent God mode

    god-once: enter God mode for exactly one command, then automatically revert to Evil

    god-off: explicitly disable God mode and return to Evil

Under the hood it manages hooks to preserve or restore visual selections, remembers your previous Evil state, and offers customization for whether God mode is applied buffer-locally or globally, and how visual regions should persist across toggles.

### Direct link to the package repository

https://github.com/jam1015/evil-god-toggle

### Your association with the package

I'm the author and maintainer.
### Relevant communications with the upstream package maintainer

**None needed**
### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
