### PR TITLE
Update documentation for the tar executable

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -189,7 +189,10 @@ below.
 
 Let ~<NAME>~ denote the filename of the new recipe. Build the recipe
 via ~make recipes/<NAME>~, or with ~C-c C-c~ (~M-x package-build-current-recipe~)
-in the recipe file buffer.
+in the recipe file buffer.  When using (~package-build-current-recipe~), ensure
+that the variables ~package-build-timeout-executable~ and ~package-build-tar-executable~
+reference compliant versions of the ~timeout~ and ~tar~ commands.  You can view the
+documentation and customize these variables with (~M-x customize-group package-build~).
 
 If the repository contains tags for releases, confirm that the correct
 version is detected by running ~MELPA_CHANNEL=stable make recipes/<NAME>~.  The

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -232,8 +232,8 @@ applied.  This setting requires
   "Path to a (preferably GNU) tar command.
 Certain package names (e.g., \"@\") may not work properly with a BSD tar.
 
-On MacOS it is possible to install gnu-tar using Homebrew or
-similar, which will provide the GNU tar program as
+On MacOS it is possible to install coreutils using Homebrew or
+similar, which will provide the GNU timeout program as
 \"gtar\"."
   :group 'package-build
   :type '(file :must-match t))

--- a/package-build/package-build.el
+++ b/package-build/package-build.el
@@ -232,8 +232,8 @@ applied.  This setting requires
   "Path to a (preferably GNU) tar command.
 Certain package names (e.g., \"@\") may not work properly with a BSD tar.
 
-On MacOS it is possible to install coreutils using Homebrew or
-similar, which will provide the GNU timeout program as
+On MacOS it is possible to install gnu-tar using Homebrew or
+similar, which will provide the GNU tar program as
 \"gtar\"."
   :group 'package-build
   :type '(file :must-match t))


### PR DESCRIPTION
This is not a package, but updates/fixes to the documentation to address #9460.  It adds a note about the `package-build-timeout-executable` and `package-build-tar-executable` variables to CONTRIBUTING.org.

This also fixes a couple errors in the documentation string for `package-build-timeout-executable`.