### PR TITLE
remove unmatained vhdl-tools

### DIFF
--- a/recipes/vhdl-tools
+++ b/recipes/vhdl-tools
@@ -1,1 +1,0 @@
-(vhdl-tools :repo "emacs-elisp/vhdl-tools" :fetcher gitlab)


### PR DESCRIPTION
-------

### Brief summary of what the package does

This package is unmantained since a very long time. I’m not using it anymore.

### Direct link to the package repository

https://gitlab.com/csantosb/emacs-elisp/vhdl-tools

### Your association with the package

Owner and maintainer.