### PR TITLE
add kdl-mode for KDL document markup language

### DIFF
--- a/recipes/kdl-mode
+++ b/recipes/kdl-mode
@@ -1,0 +1,1 @@
+(kdl-mode :fetcher github :repo "taquangtrung/emacs-kdl-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a major editing mode for the KDL document markup language: https://kdl.dev/

### Direct link to the package repository

https://github.com/taquangtrung/emacs-kdl-mode

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
