### PR TITLE
add rasi-mode for Rofi configuration file

### DIFF
--- a/recipes/rasi-mode
+++ b/recipes/rasi-mode
@@ -1,0 +1,1 @@
+(rasi-mode :fetcher github :repo "taquangtrung/emacs-rasi-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a major editing mode for the [RASI configuration file](https://davatorium.github.io/rofi/CONFIG/) of the [Rofi window switcher application](https://github.com/davatorium/rofi).

### Direct link to the package repository

https://github.com/taquangtrung/emacs-rasi-mode/

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


