### PR TITLE
Update repo location for astro-ts-mode

### DIFF
--- a/recipes/astro-ts-mode
+++ b/recipes/astro-ts-mode
@@ -1,3 +1,3 @@
 (astro-ts-mode
- :fetcher github
- :repo "Sorixelle/astro-ts-mode")
+ :fetcher git
+ :url "https://git.isincredibly.gay/srxl/astro-ts-mode.git")


### PR DESCRIPTION
I'm moving the repo away from Github and onto my own Forgejo instance. I think I've updated the recipe correctly - let me know if anything's off.