### PR TITLE
Add recipe for evil-keypad

### DIFF
--- a/recipes/evil-keypad
+++ b/recipes/evil-keypad
@@ -1,0 +1,3 @@
+(evil-keypad
+ :fetcher github
+ :repo "achyudh/evil-keypad")


### PR DESCRIPTION
### Brief summary of what the package does

**Evil Keypad** is a transient key dispatch system for Evil users that provides modal input for their keybindings. Inspired by [Meow's Keypad](https://github.com/meow-edit/meow) and [God Mode](https://github.com/emacsorphanage/god-mode), it provides a fast and ergonomic way to enter Emacs commands like `C-x C-f`, `C-c C-x C-c`, or `C-u 4 C-x ^` without holding modifier keys. After pressing a trigger key (e.g., `,` or `SPC` in Evil normal state), you enter a short sequence of unmodified keys. Evil Keypad interprets this sequence into a standard Emacs keybinding and executes the resulting command, then automatically exits.

### Direct link to the package repository

https://github.com/achyudh/evil-keypad

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
