### PR TITLE
Add a recipe for mcp-server-lib

### DIFF
--- a/recipes/mcp-server-lib
+++ b/recipes/mcp-server-lib
@@ -1,6 +1,4 @@
 (mcp-server-lib
  :fetcher github
  :repo "laurynas-biveinis/mcp-server-lib.el"
- :commit "676df9937d40f0a03344628b662c13699c9724dd"
- :files ("*.el" "emacs-mcp-stdio.sh"
-         (:exclude ".dir-locals.el" "*-test*.el")))
+ :files (:defaults "emacs-mcp-stdio.sh"))

--- a/recipes/mcp-server-lib
+++ b/recipes/mcp-server-lib
@@ -1,0 +1,6 @@
+(mcp-server-lib
+ :fetcher github
+ :repo "laurynas-biveinis/mcp-server-lib.el"
+ :commit "676df9937d40f0a03344628b662c13699c9724dd"
+ :files ("*.el" "emacs-mcp-stdio.sh"
+         (:exclude ".dir-locals.el" "*-test*.el")))


### PR DESCRIPTION
### Brief summary of what the package does

A library to write Model Context Protocol servers that run in Emacs.

### Direct link to the package repository

https://github.com/laurynas-biveinis/mcp-server-lib.el/

### Your association with the package

The maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

~~There is one not fixed but disabled package-lint warning: the package provides short commands `mcp-start` and `mcp-stop` that do not start with the package name suffix. I feel that the package usability is much better with this, but if this is unacceptable, I will rename to `mcp-server-lib-start` and `mcp-server-lib-stop`.~~

<!-- After submitting, please fix any problems the CI reports. -->
