### PR TITLE
add recipe for hdf5-viewer

### DIFF
--- a/recipes/hdf5-viewer
+++ b/recipes/hdf5-viewer
@@ -1,0 +1,4 @@
+(hdf5-viewer
+ :fetcher github
+ :repo "hdf5-viewer/hdf5-viewer"
+ :files (:defaults "h5parse.py"))


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a dired-like interface for navigating HDF5 files.  It provides advice to `find-fille` that suppresses loading of the HDF5 file which can be very large.  The python package `h5py` is used by the included `h5parse.py` code.

### Direct link to the package repository

https://github.com/hdf5-viewer/hdf5-viewer

### Your association with the package

Maintainer, coauthor, and user.

### Relevant communications with the upstream package maintainer

I have been working closely with the original author of the code (@paublo96).

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
