### PR TITLE
Add recipe for ob-llm

### DIFF
--- a/recipes/ob-llm
+++ b/recipes/ob-llm
@@ -1,0 +1,3 @@
+(ob-llm
+ :fetcher github
+ :repo "sunflowerseastar/ob-llm")


### PR DESCRIPTION
### Brief summary of what the package does

This wraps Simon Willison's CLI tool, `llm` ([GitHub](https://github.com/simonw/llm), [docs](https://llm.datasette.io/en/stable/)), and makes it available as the Org Babel llm "language":

```
#+begin_src llm :m 4o
what are neil postman's six questions
#+end_src
```

Regular Babel header arguments (like `:results silent`) are respected. Other header arguments (like `:m 4o`), are passed to `llm` as command line flags. Results are streamed into the Org buffer and then automatically converted to Org syntax when finished (unless (1) it's using `:schema` or `:schema-multi`, in which case the returned JSON is prettified, or (2) the user has turned off auto-conversions per the docs).

### Direct link to the package repository

https://github.com/sunflowerseastar/ob-llm

### Your association with the package

Author/maintainer.

### Relevant communications with the upstream package maintainer



### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
