### PR TITLE
Adds prompt-binder recipe

### DIFF
--- a/recipes/prompt-binder
+++ b/recipes/prompt-binder
@@ -1,0 +1,1 @@
+(prompt-binder :fetcher github :repo "tracym/prompt-binder")


### PR DESCRIPTION
### Brief summary of what the package does

A lightweight Emacs package that lets you quickly invoke Large Language Model (LLM) prompts with simple key combinations. Pass context from Emacs into your LLM Prompts. Stream responses directly into dedicated buffers with visual feedback.

### Direct link to the package repository

https://github.com/tracym/prompt-binder

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
