### PR TITLE
Update gpt.el to include providers directory

### DIFF
--- a/recipes/gpt
+++ b/recipes/gpt
@@ -1,3 +1,3 @@
 (gpt :fetcher github
      :repo "stuhlmueller/gpt.el"
-     :files (:defaults "gpt.py"))
+     :files (:defaults "gpt.py" "providers" "providers/*.py"))


### PR DESCRIPTION
# Update gpt recipe to include providers directory

Right now the `providers/` Python package directory is not being included when MELPA packages `gpt.el`. This causes the Python backend (`gpt.py`) to fail with import errors when trying to load the provider modules. This PR adds the directory.

### Brief summary of what the package does

gpt.el provides an interface to instruction-following language models like GPT-4, Claude 3.5 Sonnet, and Gemini Pro. It allows you to interact with these models directly from Emacs using natural language commands, featuring multi-provider support, streaming responses, flexible context modes, and interactive conversations.

### Direct link to the package repository

https://github.com/stuhlmueller/gpt.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed** - This is a fix for the existing recipe to include newly refactored Python provider modules.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (MIT License)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

### Additional Context

The package was recently refactored to move provider implementations into a `providers/` subdirectory. The current MELPA recipe only includes the root-level files, causing import errors when the Python backend tries to load the provider modules. This PR updates the recipe to explicitly include the `providers/` directory and its Python files.