### PR TITLE
Add recipe `nerd-icons-xref`

### DIFF
--- a/recipes/nerd-icons-xref
+++ b/recipes/nerd-icons-xref
@@ -1,0 +1,3 @@
+(nerd-icons-xref
+ :fetcher github
+ :repo "hron/nerd-icons-xref")


### PR DESCRIPTION
### Brief summary of what the package does

The package adds nerd-icons to xref buffers:

![Screenshot From 2025-06-25 13-12-57](https://github.com/user-attachments/assets/60669d75-6677-4e2f-8c24-62381020082a)

### Direct link to the package repository

https://github.com/hron/nerd-icons-xref

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
