### PR TITLE
Add qso to recipes

### DIFF
--- a/recipes/qso
+++ b/recipes/qso
@@ -1,0 +1,1 @@
+(qso :fetcher github :repo "K6SM/Emacs-QSO-Logger")


### PR DESCRIPTION
### Brief summary of what the package does

This LISP code provides some basic functions for Emacs to rapidly capture and log amateur radio contacts (QSOs). qso.el provides a fuction that generates a customizable, dynamic form (qso-log-form) to log amateur radio QSOs using almost any combination of ADIF fields in the ADIF 3.1.4 specification. This allows the user to customize the form for use in contests or general logging. All customizations are accessible in the QSO group, whose parent is the Emacs "Applications" group.

### Direct link to the package repository

https://github.com/K6SM/Emacs-QSO-Logger

### Your association with the package

I'm the developer/maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
