### PR TITLE
Obsolete helm packages to remove (reopen)

### DIFF
--- a/recipes/helm-ack
+++ b/recipes/helm-ack
@@ -1,1 +1,0 @@
-(helm-ack :repo "emacsorphanage/helm-ack" :fetcher github)

--- a/recipes/helm-ag
+++ b/recipes/helm-ag
@@ -1,3 +1,0 @@
-(helm-ag
- :repo "emacsorphanage/helm-ag"
- :fetcher github)

--- a/recipes/helm-c-moccur
+++ b/recipes/helm-c-moccur
@@ -1,1 +1,0 @@
-(helm-c-moccur :fetcher github :repo "myuhe/helm-c-moccur.el")

--- a/recipes/helm-directory
+++ b/recipes/helm-directory
@@ -1,3 +1,0 @@
-(helm-directory
- :repo "masasam/emacs-helm-directory"
- :fetcher github)

--- a/recipes/helm-file-preview
+++ b/recipes/helm-file-preview
@@ -1,1 +1,0 @@
-(helm-file-preview :repo "jcs-legacy/helm-file-preview" :fetcher github)

--- a/recipes/helm-filesets
+++ b/recipes/helm-filesets
@@ -1,2 +1,0 @@
-(helm-filesets :repo "gcla/helm-filesets"
-	       :fetcher github)

--- a/recipes/helm-frame
+++ b/recipes/helm-frame
@@ -1,1 +1,0 @@
-(helm-frame :fetcher github :repo "chee/helm-frame")

--- a/recipes/helm-git
+++ b/recipes/helm-git
@@ -1,1 +1,0 @@
-(helm-git :repo "maio/helm-git" :fetcher github)

--- a/recipes/helm-git-grep
+++ b/recipes/helm-git-grep
@@ -1,1 +1,0 @@
-(helm-git-grep :fetcher github :repo "yasuyk/helm-git-grep")

--- a/recipes/helm-google
+++ b/recipes/helm-google
@@ -1,1 +1,0 @@
-(helm-google :fetcher git :url "https://framagit.org/steckerhalter/helm-google.git")

--- a/recipes/helm-helm-commands
+++ b/recipes/helm-helm-commands
@@ -1,1 +1,0 @@
-(helm-helm-commands :fetcher github :repo "vapniks/helm-helm-commands")

--- a/recipes/helm-icons
+++ b/recipes/helm-icons
@@ -1,1 +1,0 @@
-(helm-icons :repo "yyoncho/helm-icons" :fetcher github)

--- a/recipes/helm-migemo
+++ b/recipes/helm-migemo
@@ -1,3 +1,0 @@
-(helm-migemo :repo "emacs-jp/helm-migemo"
-             :fetcher github)
-

--- a/recipes/helm-posframe
+++ b/recipes/helm-posframe
@@ -1,1 +1,0 @@
-(helm-posframe :fetcher github :repo "tumashu/helm-posframe")

--- a/recipes/helm-pt
+++ b/recipes/helm-pt
@@ -1,2 +1,0 @@
-(helm-pt :fetcher github
-         :repo "punassuming/helm-pt")

--- a/recipes/helm-selector
+++ b/recipes/helm-selector
@@ -1,2 +1,0 @@
-(helm-selector :fetcher github
-               :repo "emacs-helm/helm-selector")

--- a/recipes/helm-shell-history
+++ b/recipes/helm-shell-history
@@ -1,1 +1,0 @@
-(helm-shell-history :repo "anoopemacs/helm-shell-history" :fetcher github)

--- a/recipes/helm-swoop
+++ b/recipes/helm-swoop
@@ -1,1 +1,0 @@
-(helm-swoop :fetcher github :repo "emacsorphanage/helm-swoop")

--- a/recipes/helm-themes
+++ b/recipes/helm-themes
@@ -1,3 +1,0 @@
-(helm-themes
- :repo "emacsorphanage/helm-themes"
- :fetcher github)

--- a/recipes/helm-unicode
+++ b/recipes/helm-unicode
@@ -1,2 +1,0 @@
-(helm-unicode :repo "bomgar/helm-unicode"
-              :fetcher github)


### PR DESCRIPTION
Here the helm packages that could be removed once we have an answer from their authors (see issue #9496):

- [x] [helm-pt](https://github.com/ralesi/helm-pt) @ralesi
- [x] [helm-ag](https://github.com/syohex/emacs-helm-ag) @jcs090218 
- [x] [helm-git](https://github.com/maio/helm-git) @maio
- [x] [helm-ack](https://github.com/syohex/emacs-helm-ack) @emacsorphanage
- [x] [helm-swoop](https://github.com/emacsorphanage/helm-swoop) @emacsorphanage
- [x] [helm-frame](https://github.com/chee/helm-frame) @chee
- [x] [helm-posframe](https://github.com/tumashu/helm-posframe) @tumashu
- [x] [helm-google](https://framagit.org/steckerhalter/helm-google) @steckerhalter
- [x] [helm-filesets](https://github.com/gcla/helm-filesets) @gcla
- [x] [helm-c-moccur](https://github.com/myuhe/helm-c-moccur.el) @myuhe
- [x] [helm-directory](https://github.com/masasam/emacs-helm-directory) @masasam
- [x] [helm-file-preview](https://github.com/jcs-elpa/helm-file-preview) @jcs090218 
- [x] [helm-shell-history](https://github.com/yuutayamada/helm-shell-history) @yuutayamada
- [x] [helm-helm-commands](https://github.com/vapniks/helm-helm-commands) @vapniks
- [x] [helm-icons](https://github.com/yyoncho/helm-icons) @yyoncho
- [x] [helm-migemo](https://github.com/emacs-jp/helm-migemo) @emacs-jp
- [x] [helm-themes](https://github.com/syohex/emacs-helm-themes) @jcs090218 
- [x] [helm-unicode](https://github.com/bomgar/helm-unicode) @bomgar
- [x] [helm-git-grep](https://github.com/yasuyk/helm-git-grep) @yasuyk
- [x] [helm-selector](https://github.com/emacs-helm/helm-selector) @ambrevar