### PR TITLE
Adds recipe for asdf-vm

### DIFF
--- a/recipes/asdf-vm
+++ b/recipes/asdf-vm
@@ -1,0 +1,1 @@
+(asdf-vm :fetcher github :repo "zellio/emacs-asdf-vm")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a porcelain minor mode for the asdf-vm command line tool, integrating it into Emacs.

### Direct link to the package repository

https://github.com/zellio/emacs-asdf-vm

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

none needed 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
