### PR TITLE
Add recipe for buffer-background

### DIFF
--- a/recipes/buffer-background
+++ b/recipes/buffer-background
@@ -1,0 +1,1 @@
+(buffer-background :fetcher github :repo "theesfeld/buffer-background")


### PR DESCRIPTION
### Brief summary of what the package does

buffer-background is an Emacs package that allows you to display solid colors as backgrounds for your buffers. This focused implementation provides reliable color backgrounds with transparency and automatic assignment to specific buffers based on buffer name, major mode, file extension, or custom predicates. Each buffer can have its own unique background settings.

### Direct link to the package repository

https://github.com/theesfeld/buffer-background

### Your association with the package

I am the maintainer of this package

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
