### PR TITLE
Take ownership of ZNC.el

### DIFF
--- a/recipes/znc
+++ b/recipes/znc
@@ -1,1 +1,1 @@
-(znc :fetcher github :repo "sshirokov/ZNC.el")
+(znc :fetcher github :repo "enzuru/ZNC.el")


### PR DESCRIPTION
I have zero idea if this is kosher, but a very important PR has remained not responded to for nearly 3 years on ZNC.el: The package looks abandoned by the original author:

[Upgrading from deprecated cl to supported cl-lib](https://github.com/sshirokov/ZNC.el/pull/41)

I've decided to just maintain the improvements personally, along with update the README to reflect modern Emacs usage:

https://github.com/enzuru/ZNC.el/pull/1/files

I am willing to take ownership of this project given that the author is no longer maintaining the package.