### PR TITLE
update location of minsk-theme

### DIFF
--- a/recipes/minsk-theme
+++ b/recipes/minsk-theme
@@ -1,1 +1,1 @@
-(minsk-theme :fetcher github :repo "jlpaca/minsk-theme" :files ("theme/emacs/minsk-theme.el"))
+(minsk-theme :fetcher codeberg :repo "loj/minsk-theme" :files ("theme/emacs/minsk-theme.el"))


### PR DESCRIPTION
recipe originally added in https://github.com/melpa/melpa/pull/6556.

the repository is being migrated off github. this commit updates the recipe to use the new fetcher for codeberg, where the repository is now hosted ([link](https://codeberg.org/loj/minsk-theme)).