### PR TITLE
Update symex packages to reflect modular decomposition

### DIFF
--- a/recipes/symex
+++ b/recipes/symex
@@ -2,4 +2,4 @@
  :fetcher github
  :repo "drym-org/symex.el"
  :branch "2.0-integration"
- :files ("symex/symex*.el" "symex/doc/*.texi"))
+ :files ("symex/symex*.el" "symex/doc/*.texi" "symex/doc/figures"))

--- a/recipes/symex
+++ b/recipes/symex
@@ -1,2 +1,5 @@
-(symex :repo "drym-org/symex.el"
-       :fetcher github)
+(symex
+ :fetcher github
+ :repo "drym-org/symex.el"
+ :branch "2.0-integration"
+ :files ("symex/symex*.el" "symex/doc/*.texi"))


### PR DESCRIPTION
### Brief summary

As part of the [upcoming 2.0 release](https://github.com/drym-org/symex.el/pull/71), the formerly monolithic Symex library is now decomposed into 4 modular packages.

The original `symex` package contained all of this functionality. It now contains specifically the modal UI and supporting features, which are layered on top of the underlying core DSL and structural editing library (`symex-core`), which itself has few dependencies. This `symex` package additionally depends on `lithium` (the modal UI provider), as well as on `repeat-ring` and other packages supporting command repetition and macros. Providing Symex as 4 separate packages (even though they are maintained together) allows users the flexibility to use just what they need, and has been requested by users for a long time.

This PR is a companion to #9505 (which is a dependency for the new version), and the last step before release.

### Direct link to the package repository

https://github.com/drym-org/symex.el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

---

### Older description excerpts for reference, below:

The new packages are each contained in a subfolder at the root path in the Symex repo. As the requirements on inclusion and exclusion of files, aside from this prefix path, should be the default, I've simply copied the default value for `:files` that was listed in the [recipe format](https://github.com/melpa/melpa/?tab=readme-ov-file#recipe-format) in the MELPA README, and prefixed each item by the appropriate subfolder for each of these packages.

Is there any way to add a prefix automatically, by any chance? If not, it could be useful to have a `:prefix` argument that could leverage the existing `:defaults` sentinel element, prepending the prefix to each of the default values, something like:

  `:files (:defaults (:prefix "symex-core/"))`

~I could create an issue for this, if we feel it's a good idea.~ I've created a PR (which links to this one, below).

Since merging the release branch before the new packages are listed on MELPA (or vice versa) would cause Symex to become uninstallable, this PR uses the 2.0 branch for each of these packages. Once the PR is merged, the upstream 2.0 PR could be merged on the Symex repo, and these recipes could then be updated to point to the main branch once more, so that it would remain installable at each stage. Does that sound like a reasonable way to do it, or is there another recommended way?