### PR TITLE
Add ultra-scroll

### DIFF
--- a/recipes/ultra-scroll
+++ b/recipes/ultra-scroll
@@ -1,0 +1,3 @@
+(ultra-scroll
+ :repo "jdtsmith/ultra-scroll"
+ :fetcher github)

--- a/recipes/ultra-scroll
+++ b/recipes/ultra-scroll
@@ -1,3 +1,3 @@
 (ultra-scroll
- :repo "jdtsmith/ultra-scroll"
- :fetcher github)
+ :fetcher github
+ :repo "jdtsmith/ultra-scroll")


### PR DESCRIPTION
### Brief summary of what the package does

`ultra-scroll` is a smooth-scrolling package for all emacs builds, including emacs-mac.  It provides highly optimized, pixel-precise smooth scrolling which can readily keep up with the very high event rates of modern track-pads and high-precision wheel mice.  It differs from the builtin `pixel-scroll-precision-mode` as [described here](https://github.com/jdtsmith/ultra-scroll#pixel-scroll-precision-comparison-and-interoperability).  This package has been in wide use within the community for about two years.

### Direct link to the package repository

https://github.com/jdtsmith/ultra-scroll

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
