### PR TITLE
Add recipe for speak-buffer

### DIFF
--- a/recipes/speak-buffer
+++ b/recipes/speak-buffer
@@ -1,0 +1,1 @@
+(speak-buffer :fetcher github :repo "lorniu/speak-buffer.el")


### PR DESCRIPTION
### Brief summary of what the package does

Speak buffer content paragraph by paragraph in Emacs using a TTS engine.

It's useful for listening to novels or articles,  making Emacs act like a reading app.

### Direct link to the package repository

https://github.com/lorniu/speak-buffer.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
