### PR TITLE
Rename package from `go-translate` to `gt`.

### DIFF
--- a/recipes/go-translate
+++ b/recipes/go-translate
@@ -1,2 +1,0 @@
-(go-translate :fetcher github
-              :repo "lorniu/go-translate")

--- a/recipes/gt
+++ b/recipes/gt
@@ -1,2 +1,3 @@
 (gt :fetcher github
-    :repo "lorniu/gt.el")
+    :repo "lorniu/gt.el"
+    :old-names (go-translate))

--- a/recipes/gt
+++ b/recipes/gt
@@ -1,0 +1,2 @@
+(gt :fetcher github
+    :repo "lorniu/gt.el")


### PR DESCRIPTION
### Brief summary of what the package does

As package evolved during development, name `go-translate` became increasingly inappropriate. 

As planning to add more functions about LLMs, I change the name to `gt`:
- Not only the meaning of ` General Translator` for the basic translate features,
- Also the meaning of `Go to Talk` for the integrated TTS features,
- But also  as the abbrev of `Gateway to Text-AI` or `Generative Text` for the LLM related features.

(#9535)

### Direct link to the package repository

https://github.com/lorniu/gt.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
