### PR TITLE
Add a recipe for https://codeberg.org/treflip/zathura.el

### DIFF
--- a/recipes/zathura
+++ b/recipes/zathura
@@ -1,0 +1,1 @@
+(zathura :fetcher codeberg :repo "treflip/zathura.el")


### PR DESCRIPTION
### Brief summary of what the package does
It's a set of simple commands that create hyperlinks (org-mode elisp links and Hyperbole buttons) to documents open in Zathura document viewer (zathura's dbus interface is used for this). Following such a link will open the linked document in a new instance of Zathura.

### Direct link to the package repository
https://codeberg.org/treflip/zathura.el

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
