### PR TITLE
Amend casual recipe to include images

### DIFF
--- a/recipes/casual
+++ b/recipes/casual
@@ -11,4 +11,5 @@
              casual-isearch
              cc-isearch-menu
              casual-lib
-             casual-re-builder))
+             casual-re-builder)
+ :files (:defaults "docs/images"))


### PR DESCRIPTION
Amends recipe for `casual` to include the folder `docs/images`. This is to support images in the `casual.info` file.

### Brief summary of what the package does

Casual is a set of Transient user interfaces for different modes provided by Emacs.

### Direct link to the package repository

https://github.com/kickingvegas/casual

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

** None Needed **


### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


