### PR TITLE
Add symex-core (companion to #9530)

### DIFF
--- a/recipes/symex-core
+++ b/recipes/symex-core
@@ -1,0 +1,5 @@
+(symex-core
+ :fetcher github
+ :repo "drym-org/symex.el"
+ :branch "2.0-integration"
+ :files ("symex-core/symex*.el"))


### PR DESCRIPTION
As part of a 2.0 release, the Symex package has been reorganized so that it is composed from component packages. This allows users flexibility in "paying for what they eat" instead of inheriting all dependencies and features that they may not use.

This is the core package containing the DSL, structural editing motions, computations, and transformations. It could be used directly by users using any UI they like, or it would even be appropriate as a library dependency.

As this package is maintained together with the other companion packages in the same repo, the lint and build results, etc., are identical with #9530.
