### PR TITLE
Add symex-ide (companion to #9530)

### DIFF
--- a/recipes/symex-ide
+++ b/recipes/symex-ide
@@ -1,0 +1,5 @@
+(symex-ide
+ :fetcher github
+ :repo "drym-org/symex.el"
+ :branch "2.0-integration"
+ :files ("symex-ide/symex*.el"))


### PR DESCRIPTION
As part of a 2.0 release, the Symex package has been reorganized so that it is composed from component packages. This allows users flexibility in "paying for what they eat" instead of inheriting all dependencies and features that they may not use.

This package contains IDE-like features such as convenient integration with major modes  (e.g. quick evaluation of expressions, doc lookups for various specific dialects of Lisp). Now that Symex supports treesitter, this could be broadened to support similar features for non-Lisp languages. Prior to this 2.0 release, this functionality was baked in, but it is now an optional add-on --- however, it will likely be used by the majority of symex users.

As this package is maintained together with the other companion packages in the same repo, the lint and build results, etc., are identical with #9530.
