### PR TITLE
Add symex-evil (companion to #9530)

### DIFF
--- a/recipes/symex-evil
+++ b/recipes/symex-evil
@@ -1,0 +1,5 @@
+(symex-evil
+ :fetcher github
+ :repo "drym-org/symex.el"
+ :branch "2.0-integration"
+ :files ("symex-evil/symex*.el"))


### PR DESCRIPTION
As part of a 2.0 release, the Symex package has been reorganized so that it is composed from component packages. This allows users flexibility in "paying for what they eat" instead of inheriting all dependencies and features that they may not use.

This package contains Evil integration --- this includes common Evil keybindings, as well as wrapping Evil commands like undo and redo so that they work outside of the presumed Normal state context (i.e., in Symex mode instead of Normal state). Prior to this 2.0 release, this functionality was baked in, but it is now an optional add-on.

As this package is maintained together with the other companion packages in the same repo, the lint and build results, etc., are identical with #9530.
