### PR TITLE
Add scratch-plus package

### DIFF
--- a/recipes/scratch-plus
+++ b/recipes/scratch-plus
@@ -1,0 +1,3 @@
+(scratch-plus
+ :fetcher sourcehut
+ :repo "swflint/scratch-plus")


### PR DESCRIPTION
### Brief summary of what the package does

The `scratch-plus` package combines features of several existing scratch-buffer related packages, into a single cohesive whole.  In particular, it supports the saving/restoration of scratch buffers, per-mode scratch buffers, and per-project/mode scratch buffers (which can be saved to a project-specific location).

### Direct link to the package repository

https://git.sr.ht/~swflint/scratch-plus

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)