### PR TITLE
Remove org-wild-notifier recipe

### DIFF
--- a/recipes/org-wild-notifier
+++ b/recipes/org-wild-notifier
@@ -1,1 +1,0 @@
-(org-wild-notifier :fetcher github :repo "akhramov/org-wild-notifier.el")


### PR DESCRIPTION
org-wild-notifier is largerly unmaintained and now is archived. To reduce fragmentation in ecosystem, it makes sense to sunset org-wild-notifier in favor of more active
[org-alert](https://github.com/spegoraro/org-alert).

This change removes org-wild-notifier recipe.

