### PR TITLE
Add recipe for `org-srs`

### DIFF
--- a/recipes/org-srs
+++ b/recipes/org-srs
@@ -1,0 +1,1 @@
+(org-srs :fetcher github :repo "bohonghuang/org-srs")


### PR DESCRIPTION
### Brief summary of what the package does

Org-srs is a powerful and flexible spaced repetition system inside Org-mode, utilizing the advanced FSRS algorithm.

### Direct link to the package repository

https://github.com/bohonghuang/org-srs

### Your association with the package

I'm the maintainer :)

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
  **Caveat:** The following are the only remaining reports, which can be considered mis-reported by `package-lint` (possibly due to some inflexibility; fixing them would make naming awkward or break the modular organization of the project):
  ```
  145:0: error: "org-srs-algorithm-fsrs-optimize" doesn't start with package's prefix "org-srs-algorithm-fsrs-optimizer".
  36:0: error: "org-srs-child-frames" doesn't start with package's prefix "org-srs-child-frame".
  52:0: error: "org-srs-child-frames-1" doesn't start with package's prefix "org-srs-child-frame".
  59:0: error: "org-srs-child-frames" doesn't start with package's prefix "org-srs-child-frame".
  66:0: error: "\(setf\ org-srs-child-frames\)" doesn't start with package's prefix "org-srs-child-frame".
  88:0: error: "\(setf\ org-srs-item-cloze-overlay-text\)" doesn't start with package's prefix "org-srs-item-cloze".
  279:0: error: "org-srs-item-uncloze-default" doesn't start with package's prefix "org-srs-item-cloze".
  286:0: error: "org-srs-item-uncloze-function" doesn't start with package's prefix "org-srs-item-cloze".
  289:0: error: "org-srs-item-uncloze" doesn't start with package's prefix "org-srs-item-cloze".
  299:0: error: "org-srs-item-uncloze-interactively" doesn't start with package's prefix "org-srs-item-cloze".
  323:0: error: "org-srs-item-uncloze-dwim" doesn't start with package's prefix "org-srs-item-cloze".
  156:0: error: "\(setf\ org-srs-item-due-timestamp\)" doesn't start with package's prefix "org-srs-item".
  45:0: error: "org-srs" doesn't start with package's prefix "org-srs-property".
  60:0: error: "\(setf\ org-srs-property-plist\)" doesn't start with package's prefix "org-srs-property".
  77:0: error: "\(setf\ org-srs-review-cache\)" doesn't start with package's prefix "org-srs-review-cache".
  128:0: error: "\(setf\ org-srs-review-cache-query\)" doesn't start with package's prefix "org-srs-review-cache".
  59:0: error: "org-srs-reviewing-predicates" doesn't start with package's prefix "org-srs-review".
  62:0: error: "org-srs-reviewing-p" doesn't start with package's prefix "org-srs-review".
  54:0: error: "org-srs-review-ratings" doesn't start with package's prefix "org-srs-review-rate".
  57:0: error: "org-srs-review-before-rate-hook" doesn't start with package's prefix "org-srs-review-rate".
  60:0: error: "org-srs-review-after-rate-hook" doesn't start with package's prefix "org-srs-review-rate".
  85:0: error: "org-srs-review-define-rating-commands" doesn't start with package's prefix "org-srs-review-rate".
  79:0: error: "\(setf\ org-srs-schedule-offset-due-timestamp\)" doesn't start with package's prefix "org-srs-schedule-offset".
  44:0: error: "org-srs-stats-intervals" doesn't start with package's prefix "org-srs-stats-interval".
  179:0: error: "\(setf\ org-srs-table-field\)" doesn't start with package's prefix "org-srs-table".
  124:0: error: "org-srs-timestamp" doesn't start with package's prefix "org-srs-time".
  128:0: error: "org-srs-timestamp-time" doesn't start with package's prefix "org-srs-time".
  143:0: error: "org-srs-timestamp-now" doesn't start with package's prefix "org-srs-time".
  149:0: error: Aliases should start with the package's prefix "org-srs-time".
  151:0: error: "org-srs-timestamp-difference" doesn't start with package's prefix "org-srs-time".
  158:0: error: "org-srs-timestamp+" doesn't start with package's prefix "org-srs-time".
  164:0: error: "org-srs-timestamp-min" doesn't start with package's prefix "org-srs-time".
  168:0: error: "org-srs-timestamp-max" doesn't start with package's prefix "org-srs-time".
  172:0: error: "org-srs-timestamp-date-regexp" doesn't start with package's prefix "org-srs-time".
  175:0: error: "org-srs-timestamp-time-regexp" doesn't start with package's prefix "org-srs-time".
  178:0: error: "org-srs-timestamp-regexp" doesn't start with package's prefix "org-srs-time".
  181:0: error: "org-srs-timestamp-date" doesn't start with package's prefix "org-srs-time".
  ```
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
  **Caveat:** Docstrings defined in `cl-defgeneric` using `:documentation` are not recognized by `checkdoc`.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
