### PR TITLE
Add electric-list-directory recipe

### DIFF
--- a/recipes/electric-list-directory
+++ b/recipes/electric-list-directory
@@ -1,0 +1,4 @@
+(electric-list-directory
+ :fetcher github
+ :repo "kshartman/electric-directory-list"
+ :files ("electric-list-directory.el"))

--- a/recipes/electric-list-directory
+++ b/recipes/electric-list-directory
@@ -1,4 +1,1 @@
-(electric-list-directory
- :fetcher github
- :repo "kshartman/electric-directory-list"
- :files ("electric-list-directory.el"))
+(electric-list-directory :fetcher github :repo "kshartman/electric-directory-list")


### PR DESCRIPTION
### Brief summary of what the package does
Lightweight “electric” popup directory browser intended as a replacement for `list-directory`.

Features:
- Popup buffer *Electric Directory* (reused each time)
- Header line shows current directory
- RET on file opens and exits; RET on directory drills into it
- `d` deletes file/dir (prompt) and refreshes in place
- `~` deletes backup/autosave files and refreshes
- Backspace goes up one directory level
- `q` quits and restores previous window layout
- Prefix arg runs plain `list-directory`

### Direct link to the package repository
https://github.com/kshartman/electric-directory-list

### Your association with the package
I am the maintainer.

### Relevant communications with the upstream package maintainer
None needed — I am the maintainer.

### Checklist
- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
