### PR TITLE
Add missing files from karthink/elfeed-tube repository

### DIFF
--- a/recipes/elfeed-tube
+++ b/recipes/elfeed-tube
@@ -1,2 +1,4 @@
-(elfeed-tube :repo "karthink/elfeed-tube" :fetcher github
-             :files ("elfeed-tube.el" "elfeed-tube-utils.el" "elfeed-tube-fill.el"))
+(elfeed-tube
+ :fetcher github
+ :repo "karthink/elfeed-tube"
+ :files (:defaults (:exclude "elfeed-tube-mpv.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Youtube integration for Elfeed, the feed reader for Emacs 

### Direct link to the package repository

https://github.com/karthink/elfeed-tube

### Your association with the package

An enthusiastic user

### Relevant communications with the upstream package maintainer

https://github.com/karthink/elfeed-tube/issues/46

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
