### PR TITLE
add kaomel recipe

### DIFF
--- a/recipes/kaomel
+++ b/recipes/kaomel
@@ -1,0 +1,1 @@
+(kaomel :repo "gicrisf/kaomel" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Kaomel is an Emacs package that provides an interactive kaomoji picker for Emacs. It allows users to browse and select from hundreds kaomojis with multilingual tags, inserting them directly into the current buffer or copying to clipboard. The package integrates with popular completion frameworks like Vertico and Helm, and includes comprehensive tag filtering and customization options.

### Direct link to the package repository

https://github.com/gicrisf/kaomel

### Your association with the package

I am the creator and maintainer of this package.

### Relevant communications with the upstream package maintainer

I am the upstream maintainer.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation
