### PR TITLE
Add package `ol-bible`

### DIFF
--- a/recipes/ol-bible
+++ b/recipes/ol-bible
@@ -1,0 +1,3 @@
+(ol-bible
+ :fetcher sourcehut
+ :repo "swflint/ol-bible")


### PR DESCRIPTION
### Brief summary of what the package does

The `ol-bible` package provides for links to the Bible with special attention paid to viewing (using several options), generation of HTTP(s) URLs, and automatic formatting of references.

### Direct link to the package repository

https://git.sr.ht/~swflint/ol-bible

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

<!-- Message of single commit: -->

Add recipe for `ol-bible`