### PR TITLE
add romkan recipe

### DIFF
--- a/recipes/romkan
+++ b/recipes/romkan
@@ -1,0 +1,1 @@
+(romkan :fetcher github :repo "gicrisf/romkan.el")


### PR DESCRIPTION
### Brief summary of what the package does

Romkan.el is a Japanese text conversion library for Emacs that converts between Romaji and Kana. It supports bidirectional conversion between Hiragana, Katakana, and both Hepburn and Kunrei-shiki romanization systems. The package is designed primarily as a library for other Emacs packages or custom functions that need Japanese text processing capabilities.

### Direct link to the package repository

https://github.com/gicrisf/romkan.el

### Your association with the package

I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
