### PR TITLE
Add recipe for automoji

### DIFF
--- a/recipes/automoji
+++ b/recipes/automoji
@@ -1,0 +1,4 @@
+(automoji
+ :fetcher github
+ :repo "Dev380/automoji-el"
+ :files (:defaults "generated.data"))


### PR DESCRIPTION
### Brief summary of what the package does

Discord-like emoji completion-at-point. Kind of like cape-emoji but with discord's shortcodes (if available) and support for more emojis (cape uses emacs's input methods to generate its emoji completions to avoid extra dependencies while this uses a separate list of emoji).

### Direct link to the package repository

https://github.com/Dev380/automoji-el

### Your association with the package

Author + maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
