### PR TITLE
Update to org-incoming recipe

### DIFF
--- a/recipes/org-incoming
+++ b/recipes/org-incoming
@@ -1,2 +1,3 @@
 (org-incoming :fetcher github
-              :repo "tinloaf/org-incoming")
+              :repo "tinloaf/org-incoming"
+              :files (:defaults "doc/*.png"))


### PR DESCRIPTION
recipes/org-incoming: adding PNG files for info file reference

### Brief summary of what the package does

Org-Incoming will ingest PDFs into an Org structure.

### Direct link to the package repository

https://github.com/tinloaf/org-incoming

### Your association with the package

I contributed the Info setup for this package.  This change on Melpa ensures PNGs for the Info file are available.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
