### PR TITLE
Add recipe for project-cmake

### DIFF
--- a/recipes/project-cmake
+++ b/recipes/project-cmake
@@ -1,0 +1,3 @@
+(project-cmake
+ :fetcher github
+ :repo "lucius-martius/project-cmake")


### PR DESCRIPTION
### Brief summary of what the package does

This package adds a cmake backend for Emacs’ project.el framework.

Since there already exist multiple packages that (claim to) do something similar I'll quickly reference how this package compares to them.

- There is **[cmake-project.el](https://github.com/alamaison/emacs-cmake-project)** here in MELPA, which is pretty outdated with the latest update >7 years ago. Instead of hooking into project.el as a backend it sits on top and provides its functionality via a minor mode independently of project.el. I also never got this to work right, which got me started on building my own thing.

- There is [another package](https://github.com/juanjosegarciaripoll/project-cmake) also called project-cmake, which shares no code with my package, and also doesn't hook into project.el but provides commands on top of project.el's default backend and a wrapper for eglot. Unlike my package, which parses CMakeCache.txt, this works by calling the CMake JSON API, which is the way recommended by CMake, but also more complicated and lacks some information that's in CMakeCache.txt. It also ships its own project-local-variables framework, which I find to be scope-creep. It hasn't been updated in 3 years and as far as I can see never made a PR to get into MELPA, so I get to keep the name! First come, first served. :)

**This package** attempts to support CMake-based projects seamlessly by implementing a new project.el backend that scans for the CMakeLists.txt (or CMakeCache.txt inside build directories). A small advice is needed for `project-compile`, since CMake usually builds in an external directory, which `project-compile` currently doesn't support. Various ways of configuring the build directory are provided via custom variables.

Furthermore, on top of the project.el backend, convenience commands with nice completion are added to configure projects (`project-cmake-set-option`) and run tests (`project-cmake-test`). I really think something like `project-test` and `project-configure` should be a thing in vanilla emacs, but until there's something like that, these exist.

Unlike the other projects this doesn't add any opinionated defaults or complex wrappers for `eglot` or similar. I've added config snippets to the Readme.org file how these things are easily done on the side of the user configuration.

### Direct link to the package repository

https://github.com/lucius-martius/project-cmake

### Your association with the package

I'm the maintainer/developer and use it daily at work, so I'm very motivated to keep this up-to-date and working smoothly.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

PS: I'll tag the version 0.1 after the review and requested changes, when everything is ready and done.