### PR TITLE
Add recipe for kjv

### DIFF
--- a/recipes/kjv
+++ b/recipes/kjv
@@ -1,0 +1,5 @@
+(kjv
+ :fetcher github
+ :repo "port19x/bible-kjv-info"
+ ;; Use the tracked info file as with sicp package.
+ :files (:defaults (:exclude "kjv.texi" "preview.png")))


### PR DESCRIPTION
### Brief summary of what the package does

This package contains an info file of the Bible (King James Version)

### Direct link to the package repository

https://github.com/port19x/bible-kjv-info

### Your association with the package

I'm the original author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
