### PR TITLE
The easysession package: Add the extensions/ directory

### DIFF
--- a/recipes/easysession
+++ b/recipes/easysession
@@ -1,1 +1,4 @@
-(easysession :fetcher github :repo "jamescherti/easysession.el")
+(easysession
+ :fetcher github
+ :repo "jamescherti/easysession.el"
+ :files (:defaults "extensions/*.el"))


### PR DESCRIPTION
This pull request ensures that MELPA includes both the main `easysession.el` and any supporting modules under `extensions/` in the package build, so users can access the extensions without having to adjust their `load-path` manually.
