### PR TITLE
Add recipe for linkin-org-pdf-link

### DIFF
--- a/recipes/linkin-org-pdf-link
+++ b/recipes/linkin-org-pdf-link
@@ -1,0 +1,1 @@
+(linkin-org-pdf-link :fetcher github :repo "Judafa/linkin-org-pdf-link")


### PR DESCRIPTION
### Brief summary of what the package does

This package is an extension of linkin-org that defines a link for pdfs, working with the emacs package pdf-tools.

### Direct link to the package repository

https://github.com/Judafa/linkin-org-pdf-link

### Your association with the package

I am the creator and maintainer.

### Relevant communications with the upstream package maintainer

The package did not install properly (as described in the Contributing.org document), as the other package on which this package relies, linkin-org, was not found. I guess this is because linkin-org is not part of Melpa yet.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
