### PR TITLE
Adding recipe for directory-slideshow

### DIFF
--- a/recipes/directory-slideshow
+++ b/recipes/directory-slideshow
@@ -1,0 +1,1 @@
+(directory-slideshow :fetcher github :repo "Duncan-Britt/directory-slideshow")


### PR DESCRIPTION
### Brief summary of what the package does

The premise of this package is that if you have a folder, you have a slideshow. The files are the slides. You can create slideshows by putting files (or symlinks) in folders. But you can also present the contents of some arbitrary directory created for some other purpose.

The slides themselves are completely ordinary buffers with no additional settings associated with the slideshow.
Slide transitions and are performed from a separate control frame, inspired by Ediff. Further, the package imposes no restrictions on which file types may be used as slides. This makes slides  interactive—you can highlight, edit, navigate, execute code, find-file, split-window, etc., all without inhibitions. Moreover, you can present the files you already have with no additional setup, such as, for example, a photo album.

### Direct link to the package repository

https://github.com/Duncan-Britt/directory-slideshow

### Your association with the package

Sole author and maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
