### PR TITLE
codex-cli: New package (Codex CLI integration)

### DIFF
--- a/recipes/codex-cli
+++ b/recipes/codex-cli
@@ -1,4 +1,1 @@
-(codex-cli
- :fetcher github
- :repo "bennfocus/codex-cli.el"
- :files ("codex-cli/*.el" "README.md" "LICENSE"))
+(codex-cli :fetcher github :repo "bennfocus/codex-cli.el")

--- a/recipes/codex-cli
+++ b/recipes/codex-cli
@@ -1,0 +1,4 @@
+(codex-cli
+ :fetcher github
+ :repo "bennfocus/codex-cli.el"
+ :files ("codex-cli/*.el" "README.md" "LICENSE"))


### PR DESCRIPTION
### Brief summary of what the package does

`codex-cli.el` is a minimal Emacs integration for Codex CLI. It launches the Codex terminal UI in a project-scoped buffer and provides a few focused helpers to send prompts, regions, and files. It keeps the surface area small: no MCP server, no diagnostics bridges, no patch review UI—just a clean way to run Codex inside Emacs with predictable window management.

### Direct link to the package repository

https://github.com/bennfocus/codex-cli.el

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed. This package is original work maintained in its own repository.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (MIT)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)