### PR TITLE
Add  recipe for code-awareness

### DIFF
--- a/recipes/code-awareness
+++ b/recipes/code-awareness
@@ -1,3 +1,3 @@
 (code-awareness
  :fetcher github
- :repo "codeawareness/ca.emacs")
+ :repo "codeawareness/kawa.emacs")


### PR DESCRIPTION
### Brief summary of what the package does

This is an extension for Code Awareness, which is a low noise collaboration tool, meant to highlight work intersection areas between contributors. More information on [Code Awareness website](https://codeawareness.com).

### Direct link to the package repository

https://github.com/CodeAwareness/kawa.emacs

### Your association with the package

I am the author of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
