### PR TITLE
Add numeri

### DIFF
--- a/recipes/numeri
+++ b/recipes/numeri
@@ -1,0 +1,3 @@
+(numeri
+ :fetcher github
+ :repo "kickingvegas/numeri")


### PR DESCRIPTION
### Brief summary of what the package does

Numeri is an Emacs Lisp package to support the conversion of [Hindu-Arabic numbers](https://en.wikipedia.org/wiki/Hindu–Arabic_numeral_system) to [Roman](https://en.wikipedia.org/wiki/Roman_numerals) and vice-versa. It is built off utility functions provided by the Org (`ox`) and reStructuredText (`rst`) packages. Only integer numbers are supported.

### Direct link to the package repository

https://github.com/kickingvegas/numeri

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


