### PR TITLE
Add recipie for double-press

### DIFF
--- a/recipes/double-press
+++ b/recipes/double-press
@@ -1,0 +1,4 @@
+(double-press
+ :fetcher github
+ :repo "k-talo/double-press.el"
+ :files ("double-press.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Double-press key dispatcher for Emacs; bind single- and double-press actions to the same key.

### Direct link to the package repository

https://github.com/k-talo/double-press.el

### Your association with the package

I am the author and current maintainer of this package.

### Relevant communications with the upstream package maintainer

N/A — I’m the upstream author/maintainer; no separate communications.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
