### PR TITLE
Add recipie for org-links

### DIFF
--- a/recipes/org-links
+++ b/recipes/org-links
@@ -1,0 +1,1 @@
+(org-links :fetcher github :repo "Anoncheg1/emacs-org-links")


### PR DESCRIPTION
### Brief summary of what the package does

And new formats of links:
- [[PATH::NUM::LINE]] - At opening we search for LINE first, if not found exactly one, we use NUM line number.
- [[PATH::NUM-NUM::LINE]]
- [[PATH::NUM-NUM]]
- [[PATH::NUM]] creating

For ex. [[file:./notes/warehouse.el::23::(defun alina (pic))]]

Also, provide configuration for using standard ol.el without requirement of this package. Copying links to clipboard kill ring.

### Direct link to the package repository

https://github.com/Anoncheg1/emacs-org-links

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)