### PR TITLE
Add receipe for ical-form

### DIFF
--- a/recipes/ical-form
+++ b/recipes/ical-form
@@ -1,0 +1,3 @@
+(ical-form :fetcher github
+           :repo "haji-ali/maccalfw"
+           :files ("ical-form.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A package to display and edit ical events in a widget form. This is an independent package which can be used on its own and will required by the main package in the repo (`maccalfw`) and which I will submit soon.

### Direct link to the package repository

https://github.com/haji-ali/maccalfw

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
