### PR TITLE
Add recipe for blue

### DIFF
--- a/recipes/blue
+++ b/recipes/blue
@@ -1,0 +1,1 @@
+(blue :fetcher codeberg :repo "lapislazuli/blue.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides an Emacs native completion interface for the [BLUE](https://codeberg.org/lapislazuli/blue) build system. The completion interface relies on [completing read](https://www.gnu.org/software/emacs/manual/html_node/elisp/Minibuffer-Completion.html) and [completion at point](https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-in-Buffers.html). This means that it should work out of the box with native and modern completion packages such as [vertico](https://github.com/minad/vertico) and [corfu](https://github.com/minad/corfu).

### Direct link to the package repository

https://codeberg.org/lapislazuli/blue.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
