### PR TITLE
add consult-gh-nerd-icons recipe

### DIFF
--- a/recipes/consult-gh-nerd-icons
+++ b/recipes/consult-gh-nerd-icons
@@ -1,0 +1,4 @@
+(consult-gh-nerd-icons
+ :fetcher github
+ :repo "armindarvish/consult-gh"
+ :files ("consult-gh-nerd-icons.el"))


### PR DESCRIPTION
### Brief summary of what the package does

nerd-icons integration for consult-gh.

### Direct link to the package repository

https://github.com/armindarvish/consult-gh

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
