### PR TITLE
add recipe for nethack-el

### DIFF
--- a/recipes/nethack
+++ b/recipes/nethack
@@ -1,0 +1,5 @@
+(nethack
+ :fetcher github
+ :repo "Feyorsh/nethack-el"
+ :files ("nethack*.el"
+         "enh-*.patch"))


### PR DESCRIPTION
### Brief summary of what the package does

Emacs interface for playing the roguelike NetHack

### Direct link to the package repository

https://github.com/Feyorsh/nethack-el

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

### Notes
I am aware that there are a few checkdoc/package-lint notes:
- I don't think "lisp" should be capitalized in the context of "lisp patch" (as opposed to "Lisp to programming language"), but I'd be willing to change it
- I don't think every function/variable needs a docstring, and I don't think arguments need to necessarily appear in the docstring if their usage is self evident

The project does not currently have a LICENSE file, mainly because I am unsure how to specify that some files are under one license and other files are under a different license (both are GPL-compatible). Currently each file specifies its own license, but I'd appreciate suggestions here.

The `:branch "dev"` line will be removed before this PR is merged once I have incorporated any desired changes from maintainers into the project's main branch.
