### PR TITLE
Add recipe for eldoc-mouse

### DIFF
--- a/recipes/eldoc-mouse
+++ b/recipes/eldoc-mouse
@@ -1,1 +1,1 @@
-(eldoc-mouse :repo "huangfeiyu/eldoc-mouse" :fetcher github)
+(eldoc-mouse :fetcher github :repo "huangfeiyu/eldoc-mouse")


### PR DESCRIPTION
### Show document for mouse hover.

eldoc-mouse is for showing document for mouse hover in eglot managed buffer, it utilize eldoc and posframe to show document on a popup for mouse hover.

### Direct link to the package repository

https://github.com/huangfeiyu/eldoc-mouse

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
