### PR TITLE
Update auth-source-xoauth2 to use codeberg.

### DIFF
--- a/recipes/auth-source-xoauth2
+++ b/recipes/auth-source-xoauth2
@@ -1,3 +1,3 @@
 (auth-source-xoauth2
- :fetcher github
+ :fetcher codeberg
  :repo "ccrusius/auth-source-xoauth2")


### PR DESCRIPTION
I am going to remove/archive the github repository after this change is comitted and some time has passed.

This is an existing packages and there are no code changes.