### PR TITLE
Add recipe for terminal-cursor-mode

### DIFF
--- a/recipes/terminal-cursor-mode
+++ b/recipes/terminal-cursor-mode
@@ -1,0 +1,3 @@
+(terminal-cursor-mode :fetcher github
+                      :repo "7696122/terminal-cursor-mode"
+                      :files ("*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A minor mode that changes terminal cursor
appearance based on Emacs cursor-type,
blink-cursor-mode, and cursor face color.
Works only in terminal mode (emacs -nw) and
supports different cursor shapes (box,
bar, hbar) with blinking control.

### Direct link to the package repository

https://github.com/7696122/terminal-cursor-
mode

### Your association with the package

I am the maintainer and author of this
package.

### Relevant communications with the
upstream package maintainer

None needed - This is an original package
with no upstream dependencies.

### Checklist

<!-- Please confirm by replacing [] with
[x]: -->

• [x] The package is released under a [GPL-
Compatible Free Software License](https://
www.gnu.org/licenses/license-list.en.html#
GPLCompatibleLicenses)
• [x] I've read [CONTRIBUTING.org](https://
github.com/melpa/melpa/blob/master/
CONTRIBUTING.org)
• [x] I've used the latest version of [
package-lint](https://github.com/purcell/
package-lint) to check for packaging
issues, and addressed its feedback
• [x] My elisp byte-compiles cleanly
• [x] I've used M-x checkdoc to check the
package's documentation strings
• [x] I've built and installed the package
using the instructions in [CONTRIBUTING.org
](https://github.com/melpa/melpa/blob/
master/CONTRIBUTING.org)