### PR TITLE
add org-aws-iam-role recipe

### DIFF
--- a/recipes/org-aws-iam-role
+++ b/recipes/org-aws-iam-role
@@ -1,0 +1,3 @@
+(org-aws-iam-role
+ :fetcher github
+ :repo "will-abb/org-aws-iam-role")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides an interactive interface for browsing and modifying AWS IAM Roles directly within an Org mode buffer. It uses a custom Org Babel language (`aws-iam`) to apply policy changes via the AWS CLI and includes a built-in IAM Policy Simulator to test a role's permissions.

### Direct link to the package repository

[https://github.com/will-abb/org-aws-iam-role](https://github.com/will-abb/org-aws-iam-role)

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)