### PR TITLE
Add ob-ts-node package

### DIFF
--- a/recipes/ob-ts-node
+++ b/recipes/ob-ts-node
@@ -1,1 +1,1 @@
-(ob-ts-node :repo "tmythicator/ob-ts-node" :fetcher github :files ("ob-ts-node.el"))
+(ob-ts-node :fetcher github :repo "tmythicator/ob-ts-node")


### PR DESCRIPTION
### Brief summary of what the package does

`ob-ts-node` provides Org-Babels support for evaluating TypeScript code blocks using [ts-node ](https://typestrong.org/ts-node/)
It allows you to execute #+begin_src typescript and #+begin_src ts blocks directly inside Org documents, with automatic tangling to .ts files.

### Direct link to the package repository

https://github.com/tmythicator/ob-ts-node

### Your association with the package

I am the original author and current maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist
- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
