### PR TITLE
Add recipe for agda-lib-mode

### DIFF
--- a/recipes/agda-lib-mode
+++ b/recipes/agda-lib-mode
@@ -1,0 +1,1 @@
+(agda-lib-mode :fetcher codeberg :repo "heraplem/agda-lib-mode")


### PR DESCRIPTION
### Brief summary of what the package does

This is an extremely simple package that adds basic support for editing `.agda-lib` library description files.

### Direct link to the package repository

https://codeberg.org/heraplem/agda-lib-mode

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
