### PR TITLE
Add recipe for auto-save-visited-local-mode

### DIFF
--- a/recipes/auto-save-visited-local-mode
+++ b/recipes/auto-save-visited-local-mode
@@ -1,4 +1,3 @@
 (auto-save-visited-local-mode
   :fetcher github
-  :repo "pierrelegall/auto-save-visited-local-mode"
-  :files ("auto-save-visited-local-mode.el"))
+  :repo "pierrelegall/auto-save-visited-local-mode")


### PR DESCRIPTION
### Notes

I added `:files ("auto-save-visited-local-mode.el")` to the recipe. Is it really something useful?

### Brief summary of what the package does

A buffer-local alternative to Emacs's built-in `auto-save-visited-mode`.

`auto-save-visited-local-mode` provides automatic saving of file-visiting buffers on a per-buffer basis, unlike the global `auto-save-visited-mode`. This allows you to enable auto-saving for specific buffers without affecting your entire Emacs session.

### Direct link to the package repository

https://github.com/pierrelegall/auto-save-visited-local-mode

### Your association with the package

I am the maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
