### PR TITLE
Add markdown-modern recipe

### DIFF
--- a/recipes/markdown-modern
+++ b/recipes/markdown-modern
@@ -1,0 +1,3 @@
+(markdown-modern :fetcher github
+                 :repo "ahmetus/markdown-modern"
+                 :files ("markdown-modern.el"))


### PR DESCRIPTION
This adds the markdown-modern package.
   
   Package repository: https://github.com/ahmetus/markdown-modern
   Package description: Modern, beautiful Markdown editing for Emacs.
   
   Similar to org-modern but for Markdown. Provides:
   - Beautiful header bullets
   - Hierarchical indentation
   - Bold markup hiding
   - Checkbox prettification
   - Tree-sitter powered performance
   ─────────────────────────────────────────