### PR TITLE
added zine mode

### DIFF
--- a/recipes/zine-mode
+++ b/recipes/zine-mode
@@ -1,0 +1,1 @@
+(zine-mode :fetcher github :repo "dcolazin/zine-mode")


### PR DESCRIPTION
### Brief summary of what the package does

zine-mode is a simple treesitter mode for zine (supermd and superhtml) files

### Direct link to the package repository

https://github.com/dcolazin/zine-mode/

### Your association with the package

Current maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
