### PR TITLE
Add receipe for pretend-type

### DIFF
--- a/recipes/pretend-type
+++ b/recipes/pretend-type
@@ -1,0 +1,1 @@
+(pretend-type :fetcher github :repo "haji-ali/pretend-type")


### PR DESCRIPTION
### Brief summary of what the package does

The package mainly include `pretend-type-mode`, which is a playful Emacs minor mode that hides the content of a buffer and "reveals" it as you pretend to type. Your keystrokes do **not** insert any text; instead, the hidden text is gradually revealed. This is perfect for demos, presentations, or just for fun.

### Direct link to the package repository

https://github.com/haji-ali/pretend-type

### Your association with the package
Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
