### PR TITLE
Update Paredit Git repository

### DIFF
--- a/recipes/paredit
+++ b/recipes/paredit
@@ -1,1 +1,1 @@
-(paredit :fetcher git :url "https://mumble.net/~campbell/git/paredit.git")
+(paredit :fetcher git :url "https://paredit.org/cgit/paredit.git")


### PR DESCRIPTION
### Brief summary of what the package does

Update Paredit URL to point to the Git repository

### Direct link to the package repository

https://paredit.org/

### Your association with the package

User

### Relevant communications with the upstream package maintainer

N/A

### Checklist

N/A