### PR TITLE
Fix URL for hoa-mode 

### DIFF
--- a/recipes/hoa-mode
+++ b/recipes/hoa-mode
@@ -1,1 +1,1 @@
-(hoa-mode :fetcher git :url "https://gitlab.lrde.epita.fr/spot/emacs-modes.git")
+(hoa-mode :fetcher git :url "https://gitlab.lre.epita.fr/spot/emacs-modes.git")


### PR DESCRIPTION
Our lab was renamed from LRDE to LRE a few years ago.  The old address currently trigger a SSL issue.
