### PR TITLE
Improve the pull request template in response to gh issue #9642

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ https://github.com/your/awesome_package
 - [] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
 - [] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
 - [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
-- [] My elisp byte-compiles cleanly
+- [] My elisp byte-compiles cleanly: `M-x elisp-byte-compile-buffer` or `M-x byte-compile-file` and address any errors.
 - [] I've used `M-x checkdoc` to check the package's documentation strings
 - [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
 


### PR DESCRIPTION
Github issue #9642 calls for a bit more clarity about the byte compiles step in the PR template. Here's one suggestion that might help?