### PR TITLE
Update recipes for calfw packages

### DIFF
--- a/recipes/calfw
+++ b/recipes/calfw
@@ -1,3 +1,3 @@
 (calfw :repo "kiwanami/emacs-calfw"
        :fetcher github
-       :files ("calfw.el"))
+       :files ("calfw.el" "calfw-compat.el"))

--- a/recipes/calfw-cal
+++ b/recipes/calfw-cal
@@ -1,3 +1,3 @@
 (calfw-cal :repo "kiwanami/emacs-calfw"
            :fetcher github
-           :files ("calfw-cal.el"))
+           :files ("calfw-cal.el" "calfw-compat.el"))

--- a/recipes/calfw-howm
+++ b/recipes/calfw-howm
@@ -1,3 +1,3 @@
 (calfw-howm :repo "kiwanami/emacs-calfw"
             :fetcher github
-            :files ("calfw-howm.el"))
+            :files ("calfw-howm.el" "calfw-compat.el"))

--- a/recipes/calfw-ical
+++ b/recipes/calfw-ical
@@ -1,3 +1,3 @@
 (calfw-ical :repo "kiwanami/emacs-calfw"
             :fetcher github
-            :files ("calfw-ical.el"))
+            :files ("calfw-ical.el" "calfw-compat.el"))

--- a/recipes/calfw-org
+++ b/recipes/calfw-org
@@ -1,3 +1,3 @@
 (calfw-org :repo "kiwanami/emacs-calfw"
            :fetcher github
-           :files ("calfw-org.el"))
+           :files ("calfw-org.el" "calfw-compat.el"))


### PR DESCRIPTION
### Brief summary of what the package does
This PR updates the recipe for the multiple `calfw` packages to add a new file `calfw-compat` which was added for backward compatibility. 

I've picked up the maintenance of the package and part of the work that was done was to follow standard naming schemes.  `calfw-compat` defines aliases for old names.

### Direct link to the package repository

https://github.com/kiwanami/emacs-calfw

### Your association with the package
Contributor

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
