### PR TITLE
Change fetcher from GitHub to SourceHut for org-books

### DIFF
--- a/recipes/org-books
+++ b/recipes/org-books
@@ -1,1 +1,1 @@
-(org-books :fetcher github :repo "lepisma/org-books")
+(org-books :fetcher sourcehut :repo "lepisma/org-books")


### PR DESCRIPTION
This PR changes the fetcher for org-books to its new git repository at SourceHut.

I am the maintainer of the package and have recently migrated the package from GitHub to SourceHut.

Old repository: https://github.com/lepisma/org-books
New repository: https://git.sr.ht/~lepisma/org-books