### PR TITLE
Rename renpy to renpy-mode and update the recipy

### DIFF
--- a/recipes/renpy
+++ b/recipes/renpy
@@ -1,1 +1,0 @@
-(renpy :fetcher github :repo "Reagankm/renpy-mode")

--- a/recipes/renpy-mode
+++ b/recipes/renpy-mode
@@ -1,0 +1,4 @@
+(renpy-mode
+ :fetcher github
+ :repo "Reagankm/renpy-mode"
+ :old-names (renpy))


### PR DESCRIPTION
### Brief summary of what the package does

Renaming the renpy package to more compliant renpy-mode. 

### Direct link to the package repository

https://github.com/Reagankm/renpy-mode

### Your association with the package

Contributor

### Relevant communications with the upstream package maintainer

**None needed** as @morganwillcock was notified of the update already.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
