### PR TITLE
Add recipe for cabal-mode

### DIFF
--- a/recipes/cabal-mode
+++ b/recipes/cabal-mode
@@ -1,0 +1,1 @@
+(cabal-mode :fetcher github :repo "webdevred/cabal-mode")


### PR DESCRIPTION
### Brief summary of what the package does

cabal mode extracted from haskell-mode. This is good since nowadays people do not use cabal as often, many people use stack nowadays. Also users using other haskell modes than haskell-mode are required to pull in haskell-mode to be able to use cabal-mode.

I am marking this as a draft, I am ready to discuss how to improve the package.

### Direct link to the package repository

https://github.com/webdevred/cabal-mode

### Your association with the package

I am the maintainer cabal-mode, trying to extract it from haskell-mode. I have discussed the plans in a issue with the haskell-mode maintainer @purcell

### Relevant communications with the upstream package maintainer

https://github.com/haskell/haskell-mode/issues/1879

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)


