### PR TITLE
oMd org2

### DIFF
--- a/recipes/persp-topics
+++ b/recipes/persp-topics
@@ -1,3 +1,0 @@
-(persp-topics
- :fetcher codeberg
- :repo "ZeniesQis/persp-topics.git")


### PR DESCRIPTION
### Brief summary of what the package does

A few ways to convert Markdown into Org.

Convert markdown files on load, from a buffer, a region or one file into
another. A small interface to Pandoc to avoid looking at Markdown.

I had a need in another project, and a frustration reading ugly Markdown
READMEs.

### Direct link to the package repository

https://codeberg.org/ZeniesQis/md-org.git

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
