### PR TITLE
Add recipe for trailing-newline-indicator

### DIFF
--- a/recipes/trailing-newline-indicator
+++ b/recipes/trailing-newline-indicator
@@ -1,0 +1,3 @@
+(trailing-newline-indicator
+ :fetcher github
+ :repo "saulotoledo/trailing-newline-indicator")


### PR DESCRIPTION
### Brief summary of what the package does

Displays a customizable visual indicator (⏎ by default) in the left margin for the trailing newline at the end of a file in Emacs. Optionally shows the next line number, making it clear where the file ends.

### Direct link to the package repository

https://github.com/saulotoledo/trailing-newline-indicator

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
