### PR TITLE
Add fuzzy-clock recipe

### DIFF
--- a/recipes/fuzzy-clock
+++ b/recipes/fuzzy-clock
@@ -1,0 +1,1 @@
+(fuzzy-clock :fetcher github :repo "trevoke/fuzzy-clock.el")


### PR DESCRIPTION
### Brief summary of what the package does

Display a fuzzy (human-style granularity) clock in the mode-line. Has many levels of granularity for more hilarity.

### Direct link to the package repository

https://github.com/trevoke/fuzzy-clock.el

### Your association with the package

I'm the author

### Relevant communications with the upstream package maintainer

N/A

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
