### PR TITLE
Add Emacs-related config to the renpy-mode package

### DIFF
--- a/recipes/renpy-mode
+++ b/recipes/renpy-mode
@@ -1,4 +1,5 @@
 (renpy-mode
  :fetcher github
  :repo "Reagankm/renpy-mode"
+ :files (:defaults "emacs.edit.py")
  :old-names (renpy))


### PR DESCRIPTION
### Brief summary of what the package does

The package is a major mode for the Ren'py programming language. This particular change is limited to including one more file to the package.

### Direct link to the package repository

https://github.com/Reagankm/renpy-mode

### Your association with the package

A contributor

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
