### PR TITLE
Add recipe for fairyfloss-theme

### DIFF
--- a/recipes/fairyfloss-theme
+++ b/recipes/fairyfloss-theme
@@ -1,0 +1,4 @@
+(fairyfloss-theme
+ :fetcher github
+ :repo "icunhacorrea/fairyfloss-emacs"
+ :files ("fairyfloss-theme.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A colorful port of the FairyFloss theme for vanilla Emacs.  
It faithfully recreates the original FairyFloss aesthetic from Sublime Text, but adapted for standard Emacs without requiring Doom Emacs or additional frameworks.

### Direct link to the package repository

https://github.com/icunhacorrea/fairyfloss-emacs

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.  
This theme is an independent port made specifically for Emacs.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package locally using the instructions in CONTRIBUTING.org

<!-- After submitting, please fix any problems the CI reports. -->