### PR TITLE
Add recipe for real-mono-themes

### DIFF
--- a/recipes/real-mono-themes
+++ b/recipes/real-mono-themes
@@ -1,3 +1,3 @@
 (real-mono-themes
- :repo "NestorLiao/real-mono-themes"
- :fetcher github)
+ :fetcher github
+ :repo "NestorLiao/real-mono-themes")


### PR DESCRIPTION
### Brief summary of what the package does

A theme that let emacs be real clean monochrome.

### Direct link to the package repository

https://github.com/NestorLiao/real-mono-themes

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

none

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
