### PR TITLE
Add recipe for oai

### DIFF
--- a/recipes/oai
+++ b/recipes/oai
@@ -1,0 +1,1 @@
+(oai :fetcher github :repo "Anoncheg1/emacs-oai")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs package, provide blocks `#+begin_ai` in Org mode for communication with LLMs APIs. Text oriented fork of org-ai, much of rework.

Features:
- Tags: expansion of links in ai-block
- Highlighting of code in markdown blocks
- Auto filling
- provide prompt engineering tools

### Direct link to the package repository

https://github.com/Anoncheg1/emacs-oai

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
