### PR TITLE
Add recipe for orgit-file

### DIFF
--- a/recipes/orgit-file
+++ b/recipes/orgit-file
@@ -1,0 +1,1 @@
+(orgit-file :fetcher github :repo "gggion/orgit-file")


### PR DESCRIPTION
### Brief summary of what the package does

This package defines the Org link type `orgit-file', which can be used to link to files in Git repositories at specific revisions. 

    orgit-file:REPO::REV::FILE-PATH::SEARCH
    orgit-file:REPO::REV::FILE-PATH 

It also provides an export format to convert org links to proper forge urls.
- `orgit-file:~/orgit-file/::ef662d3::orgit-file.el` → https://github.com/gggion/orgit-file/blob/ef662d3/orgit-file.el

### Direct link to the package repository

https://github.com/gggion/orgit-file

### Your association with the package

I'm the author and mantainer of orgit-file.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)