### PR TITLE
Add sparkweather recipe

### DIFF
--- a/recipes/sparkweather
+++ b/recipes/sparkweather
@@ -1,3 +1,2 @@
 (sparkweather :fetcher github
-              :repo "aglet/sparkweather"
-              :files ("sparkweather.el"))
+              :repo "aglet/sparkweather")


### PR DESCRIPTION
### Brief summary of what the package does

Provides a pop-up buffer with sparkline weather forecasts.

### Direct link to the package repository

https://github.com/aglet/sparkweather

### Your association with the package

Author & maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Building the package locally required me to `export COPYFILE_DISABLE=1`, but it did eventually work. There are a couple of warnings which I don't think matter because I'm piggybacking on a system package's variable, but let's see what the CI says!

```text
In sparkweather--fetch-day:
sparkweather.el:188:20: Warning: reference to free variable ‘calendar-latitude’
sparkweather.el:192:20: Warning: reference to free variable ‘calendar-longitude’
Done (Total of 1 file compiled, 2 skipped)
Package ‘sparkweather’ installed.
```

<!-- After submitting, please fix any problems the CI reports. -->
