### PR TITLE
Add recipe for lisp-docstring-toggle

### DIFF
--- a/recipes/lisp-docstring-toggle
+++ b/recipes/lisp-docstring-toggle
@@ -1,0 +1,1 @@
+(lisp-docstring-toggle :fetcher github :repo "gggion/lisp-docstring-toggle")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides commands to toggle the visibility of Lisp docstrings in code buffers.  It works with any major lisp mode that uses `font-lock-doc-face` for docstring highlighting.

before
``` elisp
(defun example-function-1 (arg)
  "This is a comprehensive docstring explaining
  the function's purpose, arguments, and return value."
  (+ arg 1))
```

after
``` elisp
(defun example-function-1 (arg)
  "[…]"
  (+ arg 1))
```

### Direct link to the package repository

https://github.com/gggion/lisp-docstring-toggle

### Your association with the package

Im the author and mantainer of lisp-docstring-toggle.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

