### PR TITLE
Add recipe for dwin

### DIFF
--- a/recipes/dwin
+++ b/recipes/dwin
@@ -1,0 +1,4 @@
+(dwin :fetcher github :repo "lsth/dwin"
+      :files (:defaults
+              "etc/bin"
+              "etc/_local-share-applications"))


### PR DESCRIPTION
### Brief summary of what the package does
Emacs Desktop Window Manager (dwin) --- Manage desktop windows from your Emacs

Move seamlessly between Emacs windows and external windows managed by an external window manager / compositor like KDE's KWin,

- 🔀 switching to the Emacs or desktop window at left/right/above/below or
- 🏷️ switching to another application like firefox by name, as well as
-  ⧉ reposition and resize desktop windows with keys from within emacs instead of with the mouse.

Currently works for KDE's KWin under Wayland and X11. It should not be difficult to extend it to other window managers or compositors. 

### Direct link to the package repository

https://github.com/lsth/dwin

### Your association with the package

I am the author / maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
