### PR TITLE
feat: add easy-theme-preview recipe

### DIFF
--- a/recipes/easy-theme-preview
+++ b/recipes/easy-theme-preview
@@ -1,0 +1,3 @@
+(easy-theme-preview
+ :fetcher github
+ :repo "ayys/easy-theme-preview.el")


### PR DESCRIPTION
### Brief summary of what the package does

easy-theme-preview is a simple package to easily preview and set
themes from a tabulated list inside Emacs.

### Direct link to the package repository

https://github.com/ayys/easy-theme-preview.el

### Your association with the package

I am the author of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)