### PR TITLE
add eldc recipe

### DIFF
--- a/recipes/eldc
+++ b/recipes/eldc
@@ -1,0 +1,1 @@
+(eldc :fetcher github :repo "gicrisf/eldc")


### PR DESCRIPTION
Brief summary of what the package does

eldc (Emacs Lisp Dictionary Converter) converts Emacs Lisp data structures to JSON and YAML files. It's particularly useful for managing configuration files like package.json or GitHub Actions workflows by writing them in Emacs Lisp and exporting to standard formats. The package evaluates the last s-expression in the buffer, supporting both static data and dynamic generation with any Emacs Lisp code.

JSON conversion uses Emacs' built-in json-encode (no dependencies), while YAML conversion uses an optional Rust-based binary converter that auto-downloads on first use.

Direct link to the package repository

https://github.com/gicrisf/eldc

Your association with the package

I am the author and maintainer of this package.

Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)