### PR TITLE
Add recipe for nael

### DIFF
--- a/recipes/nael
+++ b/recipes/nael
@@ -1,0 +1,4 @@
+(nael
+ :fetcher codeberg
+ :repo "mekeor/nael"
+ :files ("nael/*.el" "nael/nael.info" "nael/nael.texi"))


### PR DESCRIPTION
### Brief summary of what the package does

`nael` is a radically refactored fork of (abandoned) Lean4-Mode with focus on minimalism, modularity and integration into Emacs' core.
- It supports built-in Eglot optionally.
- It uses built-in Abbrev and Skeleton instead of Quail for Unicode input.
- It relies on commands like `compile` without much magic.

`nael-lsp` is an optional additional package that adds support for lsp-mode as LSP client.

`nael-markdown` is an optional additional little package that teaches markdown-mode about Nael.

### Direct link to the package repository

https://codeberg.org/mekeor/nael

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)