### PR TITLE
adds wiktionary-bro recipe

### DIFF
--- a/recipes/wiktionary-bro
+++ b/recipes/wiktionary-bro
@@ -1,0 +1,1 @@
+(wiktionary-bro :fetcher github :repo "agzam/wiktionary-bro.el")


### PR DESCRIPTION
adds new recipe for wiktionary-bro

### Brief summary of what the package does

wiktionary-bro is a package for looking up Wiktionary entries.

### Direct link to the package repository

https://github.com/agzam/wiktionary-bro.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist


- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

