### PR TITLE
add markdown-mermaid package

### DIFF
--- a/recipes/markdown-mermaid
+++ b/recipes/markdown-mermaid
@@ -1,0 +1,3 @@
+(markdown-mermaid
+ :fetcher github
+ :repo "pasunboneleve/markdown-mermaid")


### PR DESCRIPTION
### Brief summary of what the package does

`markdown-mermaid`  extracts mermaid code blocks from markdown buffers, compiles them using the mermaid-cli (mmdc), and displays the resulting image in a new buffer.

In other words, it makes it possible to visualise these GitHub diagrams directly in Emacs, which was a missing feature not covered by other packages.

### Direct link to the package repository

https://github.com/pasunboneleve/markdown-mermaid

### Your association with the package

I'm the original author and sole maintainer.

### Relevant communications with the upstream package maintainer

I am the author.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
