### PR TITLE
Add emacs-bash-alias

### DIFF
--- a/recipes/emacs-bash-alias
+++ b/recipes/emacs-bash-alias
@@ -1,1 +1,1 @@
-(emacs-bash-alias :repo "amno1/emacs-bash-alias" :fetcher github)
+(emacs-bash-alias :repo "amno1/emacs-bash-alias" :fetcher github :files ("bash-alias.el"))


### PR DESCRIPTION
### Brief summary of what the package does

Shell-command and async-shell-command replacements that understand Bash aliases.

### Direct link to the package repository

https://github.com/amno1/emacs-bash-alias

### Your association with the package

I am the author, the maintainer, and an enthusiastic user.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
