### PR TITLE
repo autoscratch moved to codeberg

### DIFF
--- a/recipes/autoscratch
+++ b/recipes/autoscratch
@@ -1,1 +1,1 @@
-(autoscratch :repo "TLINDEN/autoscratch" :fetcher github)
+(autoscratch :repo "scip/autoscratch" :fetcher codeberg)


### PR DESCRIPTION
Nothing in the package has changed, it just moved to codeberg.