### PR TITLE
repo config-general-mode moved to codeberg

### DIFF
--- a/recipes/config-general-mode
+++ b/recipes/config-general-mode
@@ -1,2 +1,1 @@
-(config-general-mode :repo "TLINDEN/config-general-mode" :fetcher github)
-
+(config-general-mode :repo "scip/config-general-mode" :fetcher codeberg)


### PR DESCRIPTION
Nothing in the package has changed, it just moved to codeberg.