### PR TITLE
Add recipe for eager-state

### DIFF
--- a/recipes/eager-state
+++ b/recipes/eager-state
@@ -1,0 +1,1 @@
+(eager-state :fetcher github :repo "meedstrom/eager-state")


### PR DESCRIPTION
### Brief summary of what the package does

It is similar to https://codeberg.org/bram85/emacs-persist-state, but implementation differs:

- You get the ability to call functions if and only if they are also in `kill-emacs-hook` at runtime.  

  That leaves it to whatever package originally put the function there, to determine whether it is appropriate to call.  

  - Persist-state instead uses wrappers that do their own checks, e.g. check if `recentf-mode` is bound and true before calling `recentf-save-list`.  That increases the amount of labor the user has to do to add more.

- That any other package can use it as a library if they wish, as they can simply add to `eager-state-sync-hook` without having to unhygienically enable a mode on the user's behalf

### Direct link to the package repository

https://github.com/meedstrom/eager-state

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
