### PR TITLE
Add recipe for once

### DIFF
--- a/recipes/once
+++ b/recipes/once
@@ -1,0 +1,1 @@
+(once :fetcher github :repo "meedstrom/once")


### PR DESCRIPTION
### Brief summary of what the package does

It provides six small callables:

- `once-hook`, `once-hook*`, `once-hook!`
- `once-load`, `once-load*`, `once-load!`

They are mostly for help with writing initfiles, but `once-hook` in particular is surprisingly handy in general-purpose Lisp code.

### Direct link to the package repository

https://github.com/meedstrom/once

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
