### PR TITLE
Add recipe for alabaster-themes

### DIFF
--- a/recipes/alabaster-themes
+++ b/recipes/alabaster-themes
@@ -1,0 +1,3 @@
+(alabaster-themes
+ :fetcher github
+ :repo "vedang/alabaster-themes")


### PR DESCRIPTION
### Brief summary of what the package does

A collection of minimal light and dark themes for GNU Emacs based on the original Sublime Text Alabaster color scheme.

### Direct link to the package repository

https://github.com/vedang/alabaster-themes

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
