### PR TITLE
Add recipe for iwd-manager

### DIFF
--- a/recipes/iwd-manager
+++ b/recipes/iwd-manager
@@ -1,0 +1,2 @@
+(iwd-manager :fetcher github :repo "sarg/wifi-manager"
+             :files ("iwd-manager.el"))


### PR DESCRIPTION
### Brief summary of what the package does

A dbus-based client for IWD (iNet Wireless Daemon). Allows scanning for networks and connecting to open or PSK protected ones.

### Direct link to the package repository

https://github.com/sarg/wifi-manager

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
