### PR TITLE
Add recipe for dired-du-duc

### DIFF
--- a/recipes/dired-du-duc
+++ b/recipes/dired-du-duc
@@ -1,0 +1,1 @@
+(dired-du-duc :fetcher github :repo "meedstrom/dired-du-duc")


### PR DESCRIPTION
### Brief summary of what the package does

An extension for [dired-du](https://elpa.gnu.org/packages/dired-du.html).

It uses [duc](https://github.com/zevv/duc) instead of du when it can, because otherwise dired-du can make it slow to open a Dired buffer, having to calculate recursive directory sizes.

### Direct link to the package repository

https://github.com/meedstrom/dired-du-duc

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
