### PR TITLE
Add  recipe for amaranth-dark-theme

### DIFF
--- a/recipes/amaranth-dark-theme
+++ b/recipes/amaranth-dark-theme
@@ -1,1 +1,1 @@
-(amaranth-dark-theme :repo "a9sk/amaranth-dark-theme" :fetcher github)
+(amaranth-dark-theme :fetcher github :repo "a9sk/amaranth-dark-theme")


### PR DESCRIPTION
### Brief summary of what the package does

Simple dark theme for Emacs.

### Direct link to the package repository

https://github.com/a9sk/amaranth-dark-theme

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)