### PR TITLE
docs: CONTRIBUTING.org Add MacOS build env var note

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -189,7 +189,13 @@ below.
 
 Let ~<NAME>~ denote the filename of the new recipe. Build the recipe
 via ~make recipes/<NAME>~, or with ~C-c C-c~ (~M-x package-build-current-recipe~)
-in the recipe file buffer.  When using (~package-build-current-recipe~), ensure
+in the recipe file buffer.
+
+Note: When using ~make recipes/<NAME>~ on MacOS, be sure to set the environment
+variable ~export COPYFILE_DISABLE=1~, otherwise Emacs will reject the tar
+ball produced from this step.
+
+Note: When using (~package-build-current-recipe~), ensure
 that the variables ~package-build-timeout-executable~ and ~package-build-tar-executable~
 reference compliant versions of the ~timeout~ and ~tar~ commands.  You can view the
 documentation and customize these variables with (~M-x customize-group package-build~).


### PR DESCRIPTION
When writing a package for melpa on MacOS, there was an issue with the tar ball produced during `make recipes/NAME` that Emacs was rejecting it in the `make sandbox INSTALL=NAME` step. It was saying that it "does not untar cleanly". After a lot of time spent debugging, it turned out to be some MacOS idiosyncrasy with `tar` also packaging Apple-specific metadata. By setting `COPYFILES_DISABLE=1`, `tar` does not do this.

This tip could save others a lot of time.