### PR TITLE
Add emacs-mcp

### DIFF
--- a/recipes/emacs-mcp
+++ b/recipes/emacs-mcp
@@ -1,0 +1,3 @@
+(emacs-mcp :fetcher github
+           :repo "BuddhiLW/emacs-mcp"
+           :files ("elisp/*.el" "elisp/addons/*.el"))


### PR DESCRIPTION
## Summary

Add recipe for `emacs-mcp` - Emacs integration for Claude MCP (Model Context Protocol).

## Description

emacs-mcp allows Claude AI to interact with a running Emacs instance. It provides:

- **Persistent memory** - Notes, snippets, conventions, decisions stored per-project
- **Context gathering** - Buffer, region, project, git information
- **Workflow system** - User-defined multi-step automations
- **Keybindings** - `C-c m` prefix for quick access

## Source repository

https://github.com/BuddhiLW/emacs-mcp

## Recipe

```elisp
(emacs-mcp :fetcher github
           :repo "BuddhiLW/emacs-mcp"
           :files ("elisp/*.el"))
```

## Checklist

- [x] Recipe file added
- [x] Package has proper headers (Author, Maintainer, URL, Keywords, Package-Requires)
- [x] `lexical-binding: t` enabled
- [x] MIT License
- [x] All files end with `(provide ...)` and `;;; filename.el ends here`