### PR TITLE
Add evil-tex-ts

### DIFF
--- a/recipes/evil-tex-ts
+++ b/recipes/evil-tex-ts
@@ -1,0 +1,1 @@
+(evil-tex-ts :fetcher github :repo "Prgebish/evil-tex-ts")


### PR DESCRIPTION
Tree-sitter based LaTeX text objects and evil-surround integration for Evil mode.

**Repository:** https://github.com/Prgebish/evil-tex-ts

## Summary

evil-tex-ts provides LaTeX-specific text objects for Emacs Evil mode using tree-sitter for accurate parsing (Emacs 29.1+). It is a modern reimplementation of [evil-tex](https://github.com/iyefrat/evil-tex) without AUCTeX dependency.

**Features:**
- Text objects: environments (`ie`/`ae`), commands (`ic`/`ac`), math (`im`/`am`), delimiters (`id`/`ad`), sections, sub/superscripts
- Toggles: environment asterisk, math mode cycling, delimiter sizing, command asterisk
- evil-surround integration with keymaps for environments, delimiters, and accents

**Dependencies:** `evil`, `treesit` (built-in since Emacs 29.1)

## Checklist

- [x] Package builds successfully (`make recipes/evil-tex-ts`)
- [x] `package-lint` passes (only `with-eval-after-load` warnings for optional integrations)
- [x] GPL-3.0 license
- [x] Documentation in README.org