### PR TITLE
Add recipe for vulpea-ui

### DIFF
--- a/recipes/vulpea-ui
+++ b/recipes/vulpea-ui
@@ -1,0 +1,1 @@
+(vulpea-ui :fetcher github :repo "d12frosted/vulpea-ui")


### PR DESCRIPTION
### Brief summary of what the package does

A widget-based sidebar for Emacs that displays contextual information (stats, outline, backlinks, links) for [vulpea](https://github.com/d12frosted/vulpea) notes.

### Direct link to the package repository

https://github.com/d12frosted/vulpea-ui

### Your association with the package

author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->

---

A question about functions obsolete in Emacs 31. Do I need to change something now?

```
$ make recipes/vulpea-ui

package-build/package-recipe.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-recipe.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-recipe.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-recipe.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-build.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
package-build/package-build.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
package-build/package-build.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
package-build/package-build.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-build.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-build.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-build.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-build.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
package-build/package-build.el: Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’ instead.
 • Building package vulpea-ui (from github:d12frosted/vulpea-ui)...
Cloning https://github.com/d12frosted/vulpea-ui to /Users/d12frosted/Developer/melpa/working/vulpea-ui/
Checking out d562d696b3e6650fb1411236c64138166a87ed1c
Copying files (->) and directories (=>)
  from /Users/d12frosted/Developer/melpa/working/vulpea-ui/
  to /var/folders/2r/r_3xz_mx3yj0881tbg9wkbw00000gn/T/vulpea-ui34Sify/vulpea-ui-20251228.2131
    vulpea-ui.el -> vulpea-ui.el
Created vulpea-ui-20251228.2131.tar containing:
  vulpea-ui-20251228.2131/
  vulpea-ui-20251228.2131/vulpea-ui-pkg.el
  vulpea-ui-20251228.2131/vulpea-ui.el
 ✓ Success:
  2025-12-28T21:32:06+0000  vulpea-ui-20251228.2131.entry
  2025-12-28T21:32:06+0000  vulpea-ui-20251228.2131.tar
Built vulpea-ui in 1.911s, finished at 2025-12-28T21:32:07+0000
```

Also, I could not run melpazoid locally, so not sure if it reports anything.