### PR TITLE
Add recipe for eglot-python-preset

### DIFF
--- a/recipes/eglot-python-preset
+++ b/recipes/eglot-python-preset
@@ -1,0 +1,1 @@
+(eglot-python-preset :fetcher github :repo "mwolson/eglot-python-preset")


### PR DESCRIPTION
### Brief summary of what the package does

`eglot-python-preset` configures Python LSP support for Emacs using Eglot, including support for [PEP-723](https://peps.python.org/pep-0723/) inline script metadata and automatic project detection. It works with either [ty](https://github.com/astral-sh/ty) or [basedpyright](https://github.com/DetachHead/basedpyright) as the language server, and integrates with [uv](https://github.com/astral-sh/uv) for Python environment management.

This package was developed in response to [a Reddit discussion](https://www.reddit.com/r/emacs/comments/1py6v5z/using_emacs_for_python_development_with_uv_and/) about the challenges of using Eglot with PEP-723 scripts and uv-managed environments.

### Direct link to the package repository

https://github.com/mwolson/eglot-python-preset

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)