### PR TITLE
Add recipe for pass-coffin

### DIFF
--- a/recipes/pass-coffin
+++ b/recipes/pass-coffin
@@ -1,4 +1,1 @@
-(pass-coffin
- :repo "rch/emacs-pass-coffin"
- :fetcher codeberg
- :files ("pass-coffin.el"))
+(pass-coffin :fetcher codeberg :repo "rch/emacs-pass-coffin")


### PR DESCRIPTION
### Brief summary of what the package does

- Emacs commands that invoke the external `pass-coffin` ("pass coffin") extension for `pass` (password-store): `pass open`, `pass open -t`, `pass close`, `pass timer`, and `pass timer stop`, displaying output in the echo area (ANSI stripped).

### Direct link to the package repository

- https://codeberg.org/rch/emacs-pass-coffin

### Your association with the package

- I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

- Not applicable (I am the upstream maintainer).

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
