### PR TITLE
Add recipe for pdffontetc

### DIFF
--- a/recipes/pdffontetc
+++ b/recipes/pdffontetc
@@ -1,0 +1,1 @@
+(pdffontetc :fetcher github :repo "emacsomancer/pdffontetc")


### PR DESCRIPTION
### Brief summary of what the package does
Displays information about PDF fonts and other PDF metadata, 
formatted with org-mode.

### Direct link to the package repository

https://github.com/emacsomancer/pdffontetc

### Your association with the package

Author/maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
