### PR TITLE
Add recipe for magit-git-toolbelt

### DIFF
--- a/recipes/magit-git-toolbelt
+++ b/recipes/magit-git-toolbelt
@@ -1,0 +1,1 @@
+(magit-git-toolbelt :fetcher github :repo "jonathanchu/magit-git-toolbelt")


### PR DESCRIPTION
### Brief summary of what the package does

Adds recipe for `magit-git-toolbelt`, a wrapper interface in Magit to a useful set of git command-line tools from @nvie's https://github.com/nvie/git-toolbelt.

### Direct link to the package repository

https://github.com/jonathanchu/magit-git-toolbelt

### Your association with the package

I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
