### PR TITLE
Add recipe for  go-template-helper-mode

### DIFF
--- a/recipes/go-template-helper-mode
+++ b/recipes/go-template-helper-mode
@@ -1,0 +1,1 @@
+(go-template-helper-mode :fetcher codeberg :repo "rch/go-template-helper-mode")


### PR DESCRIPTION
### Brief summary of what the package does

- Minor mode that overlays Go text/template ({{ ... }}) syntax highlighting on top of another major mode (commonly YAML), useful for templated config files and Helm chart templates.

### Direct link to the package repository

- https://codeberg.org/rch/go-template-helper-mode

### Your association with the package

- I am the author and maintainer of this package.

### Relevant communications with the upstream package maintainer

- Not applicable (I am the upstream maintainer).

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
