### PR TITLE
Add recipe for nostr-publish

### DIFF
--- a/recipes/nostr-publish
+++ b/recipes/nostr-publish
@@ -1,0 +1,3 @@
+(nostr-publish
+ :fetcher github
+ :repo "941design/emacs-nostr-publish")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs minor mode for publishing Markdown files with YAML frontmatter to Nostr relays via NIP-23 (long-form content). Provides keybindings for publishing (`C-c C-p`) and previewing (`C-c C-b`).

The Emacs package is a thin wrapper around a Python CLI tool (`nostr-publish`) which handles event construction, validation, and relay communication. The Python CLI uses the external `nak` tool for NIP-46 remote signing.

### Direct link to the package repository

https://github.com/941design/emacs-nostr-publish

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed** - I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
