### PR TITLE
Add: show-inactive-region

### DIFF
--- a/recipes/show-inactive-region
+++ b/recipes/show-inactive-region
@@ -1,0 +1,3 @@
+(show-inactive-region
+ :fetcher codeberg
+ :repo "ideasman42/emacs-show-inactive-region")


### PR DESCRIPTION
### Brief summary of what the package does

This package shows the "inactive" region on any motion (fading out by default, although that is configurable).
It's useful for https://codeberg.org/ideasman42/emacs-meep
which operates on the inactive region, however it's generally useful as some of emacs built-in functions also use the point/mark even when it's not active (downcase-region for e.g.).

Note that I initially began this functionality as an extension to visible-mark-mode, but it's different enough to warrant a separate package in my opinion.

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-show-inactive-region

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
