### PR TITLE
Adding tree-sitter cpp grammers files for gptel-cpp-complete

### DIFF
--- a/recipes/gptel-cpp-complete
+++ b/recipes/gptel-cpp-complete
@@ -1,1 +1,1 @@
-(gptel-cpp-complete :fetcher github :repo "beacoder/gptel-cpp-complete")
+(gptel-cpp-complete :fetcher github :repo "beacoder/gptel-cpp-complete" :files (:defaults "treesit-grammars"))


### PR DESCRIPTION
Adding tree-sitter cpp grammers files for gptel-cpp-complete

### Brief summary of what the package does
gptel-cpp-complete rely on tree-sitter to provide correct cpp context information
so this commit is to adding tree-sitter cpp grammers files for gptel-cpp-complete

### Direct link to the package repository

https://github.com/beacoder/gptel-cpp-complete

### Your association with the package

owner

### Relevant communications with the upstream package maintainer

[e.g., `package.el` compatibility changes that you have submitted. Write **None needed** if there is no problem.]

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
