### PR TITLE
Add recipe for tagref

### DIFF
--- a/recipes/tagref
+++ b/recipes/tagref
@@ -1,0 +1,3 @@
+(tagref
+ :fetcher github
+ :repo "vedang/tagref.el")


### PR DESCRIPTION
### Brief summary of what the package does

Emacs integration for [tagref](https://github.com/stepchowfun/tagref), a tool for managing cross-references in code.

### Direct link to the package repository

https://github.com/vedang/tagref.el

### Your association with the package

I am the maintainer of this package

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
