### PR TITLE
Explicitly download treesit-grammar files for gptel-cpp-complete

### DIFF
--- a/recipes/gptel-cpp-complete
+++ b/recipes/gptel-cpp-complete
@@ -1,4 +1,4 @@
 (gptel-cpp-complete
  :fetcher github
  :repo "beacoder/gptel-cpp-complete"
- :files (:defaults "treesit-grammars"))
+ :files (:defaults "treesit-grammars/*.so"))


### PR DESCRIPTION
The previsouly commit didn't include file type, which leads to grammar files not download.
so this commit explicitly specify it.