### PR TITLE
Add evil-insert-plus

### DIFF
--- a/recipes/evil-insert-plus
+++ b/recipes/evil-insert-plus
@@ -1,0 +1,1 @@
+(evil-insert-plus :fetcher github :repo "yad-tahir/evil-insert-plus")


### PR DESCRIPTION
### Brief summary of what the package does

`evil-insert-plus` transforms the standard `evil-mode` insertion and appending _commands_ into first-class **operators**. This allow users to perform insertions and appends using the full power of Evil motions and text objects (e.g., `I i p` to insert at the start of a paragraph). 

### Direct link to the package repository

https://github.com/yad-tahir/evil-insert-plus

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)