### PR TITLE
Fix agent-shell stable version filtering #9779

### DIFF
--- a/recipes/agent-shell
+++ b/recipes/agent-shell
@@ -1,1 +1,1 @@
-(agent-shell :fetcher github :repo "xenodium/agent-shell")
+(agent-shell :fetcher github :repo "xenodium/agent-shell" :version-regexp "v%v")


### PR DESCRIPTION
Fixes https://github.com/melpa/melpa/issues/9779 by introducing an explicit :version-regexp.

### Brief summary of what the package does

A native Emacs shell to interact with LLM agents powered by ACP ([Agent Client Protocol](https://agentclientprotocol.com/)).

### Direct link to the package repository

https://github.com/xenodium/agent-shell

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)