### PR TITLE
Add recipe for M2

### DIFF
--- a/recipes/M2
+++ b/recipes/M2
@@ -1,0 +1,1 @@
+(M2 :fetcher github :repo "Macaulay2/M2-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

[Macaulay2](https://macaulay2.com) is a software platform widely used by researchers in algebraic geometry and commutative algebra.  For ~30 years, it has been distributed with an Emacs package containing two major modes: `M2-mode`, for editing Macaulay2 source code, and `M2-comint-mode`, for interacting with the Macaulay2 REPL.

### Direct link to the package repository

https://github.com/Macaulay2/M2-emacs

### Your association with the package

I am the release manager for Macaulay2 and one of the core developers of the Emacs package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
