### PR TITLE
Add org-roam-latte recipe

### DIFF
--- a/recipes/org-roam-latte
+++ b/recipes/org-roam-latte
@@ -1,0 +1,1 @@
+(org-roam-latte :fetcher github :repo "yad-tahir/org-roam-latte")


### PR DESCRIPTION
### Brief summary of what the package does

Org-roam Latte is a minor mode that automatically highlights unlinked org-roam references in your buffer. It scans buffer text and identifies words or phrases that match existing org-roam nodes (titles and aliases). It brings the "Unlinked Mentions" feature found in tools like Obsidian or Roam Research directly into Emacs, helping you discover connections you might have missed.

### Direct link to the package repository

https://github.com/yad-tahir/org-roam-latte

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
