### PR TITLE
Add recipe for mlx-mode

### DIFF
--- a/recipes/mlx-mode
+++ b/recipes/mlx-mode
@@ -1,0 +1,1 @@
+(mlx-mode :fetcher github :repo "finalclass/emacs-mlx")

--- a/recipes/mlx-mode
+++ b/recipes/mlx-mode
@@ -1,1 +1,1 @@
-(mlx-mode :fetcher github :repo "finalclass/emacs-mlx")
+(mlx-mode :fetcher github :repo "ocaml-mlx/emacs-mlx")


### PR DESCRIPTION
## Summary
- Add recipe for `mlx-mode`, an Emacs major mode for editing MLX files (OCaml with JSX syntax)
- MLX is an OCaml syntax dialect that integrates JSX expressions directly into OCaml
- The mode extends `tuareg-mode` with JSX syntax highlighting, indentation, and LSP support

## Links
- Package repository: https://github.com/finalclass/emacs-mlx
- MLX language: https://github.com/ocaml-mlx/mlx
- Neovim equivalent: https://github.com/ocaml-mlx/ocaml_mlx.nvim