### PR TITLE
Add recipe for d2-ts-mode

### DIFF
--- a/recipes/d2-ts-mode
+++ b/recipes/d2-ts-mode
@@ -1,0 +1,3 @@
+(d2-ts-mode :repo "chaploud/d2-ts-mode"
+            :fetcher github
+            :files ("*.el" (:exclude ".dir-locals.el")))

--- a/recipes/d2-ts-mode
+++ b/recipes/d2-ts-mode
@@ -1,3 +1,2 @@
-(d2-ts-mode :repo "chaploud/d2-ts-mode"
-            :fetcher github
-            :files ("*.el" (:exclude ".dir-locals.el")))
+(d2-ts-mode :fetcher github
+            :repo "chaploud/d2-ts-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A tree-sitter based major mode for editing [D2](https://d2lang.com) diagram files.
Provides syntax highlighting via tree-sitter font-lock (4 levels, 40+ builtins),
AST-based indentation, Imenu navigation, compile/watch/preview commands, and Org-Babel support.

Relation to existing packages:
[d2-mode](https://github.com/andorsk/d2-mode) is a regex-based major mode for D2 (Emacs 26.1+).
d2-ts-mode takes a different approach using tree-sitter for grammar-based highlighting,
AST-based indentation, and structured navigation. It requires Emacs 30.1+.

### Direct link to the package repository

https://github.com/chaploud/d2-ts-mode

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed (I am the upstream maintainer).

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)