### PR TITLE
Add recipe for project-terminal

### DIFF
--- a/recipes/project-terminal
+++ b/recipes/project-terminal
@@ -1,0 +1,3 @@
+(project-terminal
+ :fetcher github
+ :repo "cowboyd/project-terminal.el")


### PR DESCRIPTION
### Brief summary of what the package does

Manages a side-window of terminals (currently eshell or vterm) on a per-project basis. For years, I've eyed with envy this simple but powerful capability of VSCode, so this is my attempt to re-create something similar.

### Direct link to the package repository

https://github.com/cowboyd/project-terminal.el

### Your association with the package

I am the author

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

