### PR TITLE
Add recipe for geiser-hoot

### DIFF
--- a/recipes/geiser-hoot
+++ b/recipes/geiser-hoot
@@ -1,0 +1,4 @@
+(geiser-hoot
+ :fetcher codeberg
+ :repo "spritely/geiser-hoot"
+ :files (:defaults ("src" "src/*")))


### PR DESCRIPTION
### Brief summary of what the package does

This is an extension of [Geiser](https://geiser.nongnu.org) for the [Hoot](https://spritely.institute/hoot) Scheme to WebAssembly compiler. It allows connecting Emacs to a Scheme REPL running in a web browser.

### Direct link to the package repository

https://codeberg.org/spritely/geiser-hoot

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
