### PR TITLE
Add recipe for smali-mode

### DIFF
--- a/recipes/smali-mode
+++ b/recipes/smali-mode
@@ -1,0 +1,1 @@
+(smali-mode :fetcher github :repo "strazzere/Emacs-Smali")


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for smali files. Smali is a human readable format of Android dex byte code, see explanation: https://payatu.com/blog/an-introduction-to-smali/#Smali_Code

### Direct link to the package repository

https://github.com/strazzere/Emacs-Smali

### Your association with the package

user

### Relevant communications with the upstream package maintainer

None.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (only `204:3: warning: Closing parens should not be wrapped onto new lines.`)
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
