### PR TITLE
Add recipe for markdown-indent-mode

### DIFF
--- a/recipes/markdown-indent-mode
+++ b/recipes/markdown-indent-mode
@@ -1,0 +1,1 @@
+(markdown-indent-mode :fetcher github :repo "whhone/markdown-indent-mode")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

An Emacs minor mode for dynamic virtual indentation in Markdown, similar to `org-indent-mode` in Org mode.

### Direct link to the package repository

https://github.com/whhone/markdown-indent-mode

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
