### PR TITLE
Add recipe for org-pdf-slide-show

### DIFF
--- a/recipes/org-pdf-slide-shower
+++ b/recipes/org-pdf-slide-shower
@@ -1,2 +1,2 @@
-(org-pdf-slide-shower :fetcher github :repo "99702/org-pdf-slide-shower")
+(org-pdf-slide-shower :fetcher github :repo "99702/org-pdf-slide-show")
 

--- a/recipes/org-pdf-slide-shower
+++ b/recipes/org-pdf-slide-shower
@@ -1,0 +1,2 @@
+(org-pdf-slide-shower :fetcher github :repo "99702/org-pdf-slide-shower")
+


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

org-pdf-slide-show displays specific PDF pages as inline images in Org mode. You write a link like [[pdfslide:./slides.pdf::3]] and the package extracts that page as a PNG (via pdftoppm) and shows it inline. It caches extracted images so they're only generated once, and auto-inserts companion [[file:...]] links so the images render on GitHub without the package installed.



### Direct link to the package repository

https://github.com/99702/org-pdf-slide-show.git

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

None

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
