### PR TITLE
Add recipe for tokyo-night (a collection of color themes)

### DIFF
--- a/recipes/tokyo-night
+++ b/recipes/tokyo-night
@@ -1,0 +1,1 @@
+(tokyo-night :fetcher github :repo "bbatsov/tokyo-night-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

A faithful Emacs port of folke's Tokyo Night color theme with all four variants (night, storm, moon, day).

I finally got tired of Zenburn and Solarized, so it's time to work on different themes for a bit. :D

### Direct link to the package repository

https://github.com/bbatsov/emacs-tokyo-themes

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed** — I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)