### PR TITLE
Add recipe for batppuccin (collection of color-themes)

### DIFF
--- a/recipes/batppuccin
+++ b/recipes/batppuccin
@@ -1,0 +1,1 @@
+(batppuccin :fetcher github :repo "bbatsov/batppuccin-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

An opinionated Emacs port of the [Catppuccin](https://github.com/catppuccin/catppuccin) color scheme. Four separate themes (Mocha, Macchiato, Frappe, Latte) that work with standard `load-theme`, following the official Catppuccin style guide with broad face coverage.

I wrote this because the existing `catppuccin-theme` has some architectural issues that don't sit well with how Emacs themes typically work (single theme with runtime flavor switching, `load-file-name` dependency that breaks in some `load-theme` code paths, missing faces for popular packages). More details in [this blog post](https://batsov.com/posts/2026/03/29/batppuccin-my-take-on-catppuccin-for-emacs/).

### Direct link to the package repository

https://github.com/bbatsov/batppuccin-emacs

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed -- this is a new, independent package.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)