### PR TITLE
Add recipe for meshmonitor-chat

### DIFF
--- a/recipes/meshmonitor-chat
+++ b/recipes/meshmonitor-chat
@@ -1,0 +1,1 @@
+(meshmonitor-chat :fetcher git :url "https://git.andros.dev/andros/meshmonitor-chat.el.git")


### PR DESCRIPTION
### Brief summary of what the package does

Chat client for MeshMonitor (Meshtastic) in Emacs, inspired by ERC and rcirc. It enables users to browse channels, view node lists, manage direct messages, and send messages via a REST API connection to a MeshMonitor server without requiring external Meshtastic clients.

### Direct link to the package repository

https://git.andros.dev/andros/meshmonitor-chat.el

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

No.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)