### PR TITLE
Update recipe for `yasnippet`

### DIFF
--- a/recipes/yasnippet
+++ b/recipes/yasnippet
@@ -1,3 +1,4 @@
-(yasnippet :repo "joaotavora/yasnippet"
-           :fetcher github
-           :files ("yasnippet.el" "snippets"))
+(yasnippet
+ :fetcher github
+ :repo "joaotavora/yasnippet"
+ :files (:defaults ("doc" "doc/*.org")))


### PR DESCRIPTION
### Summary
This PR updates the `yasnippet` recipe. The rationale is:

1. `yasnippet` no longer includes a `snippets` directory (see the repo, linked below)
2. `:defaults` for `:files` were introduced after the recipe, and cover all sensible inclusions and exclusions (i.e. they can address the motivations behind https://github.com/melpa/melpa/pull/374)
3.  `yasnippet` doesn't have Info files, but does have Org files, which are handy. (there is an open PR addressing an issue in `doc/yas-doc-helper.el`, which is why this PR only pulls in the Org files)

I've installed the package with `package-build-current-recipe`, and confirmed that it yields the following structure (produced with `tree`)

```
.
├── doc
│   ├── faq.org
│   ├── index.org
│   ├── snippet-development.org
│   ├── snippet-expansion.org
│   ├── snippet-menu.org
│   ├── snippet-organization.org
│   └── snippet-reference.org
├── yasnippet-autoloads.el
├── yasnippet-debug.el
├── yasnippet-debug.elc
├── yasnippet.el
├── yasnippet.elc
└── yasnippet-pkg.el
```

`yasnippet-debug` is used to test snippets from the shell (i.e. unlike test files, it is a useful artifact for users, as far as I can tell)

### Direct link to the package repository

https://github.com/joaotavora/yasnippet

### Your association with the package

Just a user (-:

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist
I've marked as **N/A** all items that I felt applied to a new recipe submission, as opposed to a fix.

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) **N/A**
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback **N/A**
- [X] My elisp byte-compiles cleanly **N/A**
- [X] I've used `M-x checkdoc` to check the package's documentation strings **N/A**
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)