### PR TITLE
Add recipe org-grimoire

### DIFF
--- a/recipes/org-grimoire
+++ b/recipes/org-grimoire
@@ -1,0 +1,3 @@
+(org-grimoire :fetcher github
+              :repo "spiperac/org-grimoire"
+              :files ("org-grimoire.el" "themes"))


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

org-grimoire is a static site generator for Emacs. It uses Org files as
content, HTML templates for layout, and is configured and built directly
from your Emacs init file. It supports themes, pagination, tag pages,
RSS/Atom feeds, and sitemap generation.


### Direct link to the package repository

https://github.com/spiperac/org-grimoire

### Your association with the package

I'm the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
