### PR TITLE
Add recipe for mysql

### DIFF
--- a/recipes/mysql
+++ b/recipes/mysql
@@ -1,0 +1,3 @@
+(mysql
+ :repo "LuciusChen/mysql.el"
+ :fetcher github)

--- a/recipes/mysql
+++ b/recipes/mysql
@@ -1,3 +1,3 @@
 (mysql
- :repo "LuciusChen/mysql.el"
- :fetcher github)
+ :fetcher github
+ :repo "LuciusChen/mysql.el")


### PR DESCRIPTION
### Brief summary of what the package does

`mysql` is a pure Emacs Lisp MySQL/MariaDB wire protocol client. It speaks the classic MySQL protocol directly and supports TLS, common authentication methods, text queries, and binary prepared statements.

### Direct link to the package repository

https://github.com/LuciusChen/mysql.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)