### PR TITLE
Add recipe for verdict

### DIFF
--- a/recipes/verdict
+++ b/recipes/verdict
@@ -1,0 +1,5 @@
+(verdict
+   :fetcher github
+   :repo "tjarvstrand/verdict.el"
+   :files ("packages/verdict/verdict.el")
+   :version-regexp "verdict-v\\([.0-9]*\\)")


### PR DESCRIPTION
### Brief summary of what the package does

verdict is a generic test runner with support for multiple backends.

### Direct link to the package repository

https://github.com/tjarvstrand/verdict.el

### Your association with the package
I'm the author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist
- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

