### PR TITLE
Add recipe for struct-completion

### DIFF
--- a/recipes/struct-completion
+++ b/recipes/struct-completion
@@ -1,0 +1,1 @@
+(struct-completion :fetcher github :repo "gggion/struct-completion.el")


### PR DESCRIPTION
### Brief summary of what the package does

struct-completion defines the minor mode `struct-completion-mode`, which completes keyword slot arguments (`:slot-name`) inside `cl-defstruct` constructor calls by introspecting slot metadata at runtime via `cl--class-slots` and constructor arglists via `help-split-fundoc`. It annotates candidates with their `:type` specifiers, marks inherited slots from `:include` chains with `↑`, and shows per-slot documentation, default values, and provenance via `:company-doc-buffer`. It adds a dedicated capf to `completion-at-point-functions` when enabled and removes it when disabled.

### Direct link to the package repository

https://github.com/gggion/struct-completion.el

### Your association with the package

I'm the author and mantainer of let-completion.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)