### PR TITLE
Add recipe for python-unicode-escape

### DIFF
--- a/recipes/python-unicode-escape
+++ b/recipes/python-unicode-escape
@@ -1,0 +1,1 @@
+(python-unicode-escape :fetcher github :repo "jb3/python-unicode-escape")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

Adds autocompletion for Python's `\N{UNICODE NAME}` string escape syntax in Emacs.

### Direct link to the package repository

https://github.com/jb3/python-unicode-escape

### Your association with the package

I am the maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
