### PR TITLE
Add recipe for sidebuf

### DIFF
--- a/recipes/sidebuf
+++ b/recipes/sidebuf
@@ -1,0 +1,1 @@
+(sidebuf :fetcher github :repo "rain-64/sidebuf")


### PR DESCRIPTION
### Brief summary of what the package does

Sidebuf displays a persistent, sorted list of open buffers in a side window. It provides alphabetical or most-recent sort order, buffer pinning, visibility toggles for `*special*` and ` hidden` buffers, active-buffer tracking with a fringe indicator, smart window reuse, and modified/read-only indicators, all in a single file with zero external dependencies.

No existing MELPA package covers this niche. The closest (ibuffer-sidebar) is unmaintained since 2021 and lacks key features like pinning, sort toggling, and active-buffer tracking.

### Direct link to the package repository

https://github.com/rain-64/sidebuf

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed, I am the upstream author.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)