### PR TITLE
Add recipe for hidepass

### DIFF
--- a/recipes/hidepass
+++ b/recipes/hidepass
@@ -1,0 +1,1 @@
+(hidepass :fetcher github :repo "Anoncheg1/emacs-hidepass")


### PR DESCRIPTION
### Brief summary of what the package does

Allow to hide multi-line or single line passwords in any mode. Musthave in public places.

Other same packages, like "hidepw" dont support multi-line passwords, like 2FA method recovery code, for example:
```
#+begin_src pass
29b46-2c63b
7f299-70e04
2c7d6-83876
a8eb1-44351
#+end_src
```
Will be showed like:
```
#+begin_src pass
***** 
***** 
***** 
***** 
#+end_src
```
### Direct link to the package repository

https://github.com/Anoncheg1/emacs-hidepass

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist
- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)