### PR TITLE
Add recipe for circleci-yaml-mode

### DIFF
--- a/recipes/circleci-yaml-mode
+++ b/recipes/circleci-yaml-mode
@@ -1,0 +1,4 @@
+(circleci-yaml-mode
+ :fetcher github
+ :repo "CircleCI-Public/circleci-yaml-language-server"
+ :files ("editors/emacs/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`circleci-yaml-mode` is an Emacs major mode for editing CircleCI YAML configuration files. It derives from `yaml-mode` and provides automatic language server integration via the [CircleCI YAML Language Server](https://github.com/CircleCI-Public/circleci-yaml-language-server).

- Auto-activates for files under `.circleci/` directories
- Downloads the LS binary and schema on first use
- Works with both eglot and lsp-mode
- Supports `setToken` for private orb resolution

### Direct link to the package repository

https://github.com/CircleCI-Public/circleci-yaml-language-server

The Emacs package lives in [`editors/emacs/`](https://github.com/CircleCI-Public/circleci-yaml-language-server/tree/main/editors/emacs) alongside the VS Code extension.

### Your association with the package

I am the author of the Emacs package and a representative of the upstream maintainer (CircleCI).

### Relevant communications with the upstream package maintainer

The Emacs package was added upstream via [CircleCI-Public/circleci-yaml-language-server#418](https://github.com/CircleCI-Public/circleci-yaml-language-server/pull/418), which has been merged.

### Checklist

- [ ] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
   - pending: https://github.com/CircleCI-Public/circleci-yaml-language-server/pull/421
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)