### PR TITLE
Add recipe for citar-vulpea

### DIFF
--- a/recipes/citar-vulpea
+++ b/recipes/citar-vulpea
@@ -1,0 +1,1 @@
+(citar-vulpea :fetcher github :repo "fabcontigiani/citar-vulpea")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

`citar-vulpea` integrates the [citar](https://github.com/emacs-citar/citar) bibliography manager with the [vulpea](https://github.com/d12frosted/vulpea) note database. It acts as a bridge that allows Citar to detect, display, and manage Vulpea research notes as first-class bibliographic items.

**Core Functionality:**
* **Backend Registration**: Registers Vulpea as a note source for Citar, enabling Citar to identify existing notes and surface visual indicators in its completion interface.
* **Metadata Synchronization**: Automatically manages the link between citation keys and notes via customizable Org properties and file tags.
* **Streamlined Note Creation**: Provides a unified workflow for generating new research notes with pre-populated bibliographic metadata.
* **Interactive Reference Management**: Includes context-aware commands to add, remove, or visit citation references directly within Org-mode notes.

### Direct link to the package repository

https://github.com/fabcontigiani/citar-vulpea

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
