### PR TITLE
Add recipe for goto-line-with-numbers

### DIFF
--- a/recipes/goto-line-with-numbers
+++ b/recipes/goto-line-with-numbers
@@ -1,0 +1,2 @@
+(goto-line-with-numbers :fetcher gitlab
+                        :repo "wavexx/goto-line-with-numbers.el")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

This is a simple convenience function to turn on display-line-numbers while calling `goto-line` interactively. Based on some emacswiki suggestion I've found decades ago and marginally improved over time.

Packaged for sharing convenience.

### Direct link to the package repository

https://gitlab.com/wavexx/goto-line-with-numbers.el

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

n/a

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
