### PR TITLE
Add recipe for agent-shell-org-transcript

### DIFF
--- a/recipes/agent-shell-org-transcript
+++ b/recipes/agent-shell-org-transcript
@@ -1,0 +1,3 @@
+(agent-shell-org-transcript
+ :fetcher github
+ :repo "lllShamanlll/agent-shell-org-transcript")


### PR DESCRIPTION
## Description

Add `agent-shell-org-transcript` — org-mode transcript support for [agent-shell](https://github.com/xenodium/agent-shell).

Saves conversation transcripts as `.org` files with markdown-to-org conversion, org-id, and FILETAGS for org-roam indexing.

## Checklist

- [x] I am the upstream author/maintainer
- [x] The package is on GitHub at https://github.com/lllShamanlll/agent-shell-org-transcript
- [x] The package has a valid open-source license (GPL-3.0-or-later)
- [x] Package-Requires lists all dependencies with minimum versions
- [x] The package byte-compiles cleanly