### PR TITLE
Add recipe for denote-wordcloud

### DIFF
--- a/recipes/denote-wordcloud
+++ b/recipes/denote-wordcloud
@@ -1,0 +1,1 @@
+(denote-wordcloud :fetcher codeberg :repo "treflip/denote-wordcloud")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does
denote-wordcloud is a simple package that displays a cloud of clickable denote keywords in a separate buffer. When clicked, a keyword from the cloud performs a search for files that contain it using denote-dired.

### Direct link to the package repository
https://codeberg.org/treflip/denote-wordcloud

### Your association with the package
I'm the maintainer.


### Relevant communications with the upstream package maintainer
**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
