### PR TITLE
Add recipe for rimel

### DIFF
--- a/recipes/rimel
+++ b/recipes/rimel
@@ -1,0 +1,1 @@
+(rimel :fetcher github :repo "jixiuf/rimel")


### PR DESCRIPTION
### Brief summary of what the package does

Rimel is a lightweight Chinese input method for Emacs based on Rime/liberime. It uses Emacs'
built-in input-method-function interface, providing candidate display in echo area or posframe,
inline preedit, pagination support, and context-based auto English switching.

### Direct link to the package repository

https://github.com/jixiuf/rimel

### Your association with the package

author

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist


- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

