### PR TITLE
Add recipe for cljvindent

### DIFF
--- a/recipes/cljvindent
+++ b/recipes/cljvindent
@@ -1,4 +1,4 @@
 (cljvindent
  :fetcher github
  :repo "narocath/cljvindent-emacs"
- :files (:defaults "clj-vindent-engine"))
+ :files (:defaults "src" "Cargo.toml"))

--- a/recipes/cljvindent
+++ b/recipes/cljvindent
@@ -1,0 +1,4 @@
+(cljvindent
+ :fetcher github
+ :repo "narocath/cljvindent-emacs"
+ :files (:defaults "clj-vindent-engine"))


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

`cljvindent` is a Clojure(script), and EDN indentation and alignment tool exposed in Emacs through a native module.
It was created to make indentation of large regions and whole file buffers with speed in mind.
The package provides commands for indenting the current form at point, parent forms, regions, and whole buffers.
The native module is built locally on first use automatically, or manually through an exposed command.

### Direct link to the package repository

https://github.com/narocath/cljvindent-emacs

### Your association with the package

Author

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
