### PR TITLE
Add recipe for http-server

### DIFF
--- a/recipes/http-server
+++ b/recipes/http-server
@@ -1,0 +1,1 @@
+(http-server :fetcher git :url "https://codeberg.org/martenlienen/http-server.el.git")


### PR DESCRIPTION
### Brief summary of what the package does

http-server speaks HTTP for you. It is a building block for other packages that want to offer an HTTP server inside of Emacs to communicate with the user or external programs. http-server's minimal design makes no assumptions on what that package will do with the server. It gets out of your way and grants you full control and responsibility over any aspect of the server that is not directly tied to the HTTP protocol itself.

### Direct link to the package repository

https://codeberg.org/martenlienen/http-server.el

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)