### PR TITLE
Add recipe for mozc-modeless

### DIFF
--- a/recipes/mozc-modeless
+++ b/recipes/mozc-modeless
@@ -1,0 +1,4 @@
+(mozc-modeless
+ :repo "kiyoka/mozc-modeless-emacs"
+ :fetcher github
+ :files ("mozc-modeless.el" "mozc-modeless-english-words.el"))

--- a/recipes/mozc-modeless
+++ b/recipes/mozc-modeless
@@ -1,4 +1,1 @@
-(mozc-modeless
- :repo "kiyoka/mozc-modeless-emacs"
- :fetcher github
- :files ("mozc-modeless.el" "mozc-modeless-english-words.el"))
+(mozc-modeless :fetcher github :repo "kiyoka/mozc-modeless-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

`mozc-modeless` provides a modeless Japanese input interface for Emacs using Mozc. Normally you type in alphanumeric mode. When you want to convert the preceding romaji to Japanese, press `C-j`. After conversion is confirmed, the mode automatically returns to alphanumeric input — no need to toggle an IME on/off.

Key features:
- Modeless input: no IME ON/OFF switching required
- Auto-return to alphanumeric mode after conversion
- Cancel with `C-g` to restore original romaji
- Ambient conversion: optional auto-conversion triggered by particles + space or punctuation
- English text detection to avoid false conversions

### Direct link to the package repository

https://github.com/kiyoka/mozc-modeless-emacs

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)