### PR TITLE
Add recipe for EMCP

### DIFF
--- a/recipes/emcp
+++ b/recipes/emcp
@@ -1,0 +1,3 @@
+(emcp :fetcher codeberg
+      :repo "martenlienen/emcp"
+      :files (:defaults "emacs.svg"))


### PR DESCRIPTION
### Brief summary of what the package does

EMCP lets your LLM agent interact with Emacs. The agent can look up documentation and definitions, take screenshots, read buffers, execute code and more. Exactly which [prompts](https://codeberg.org/martenlienen/emcp#built-in-prompts), [resources](https://codeberg.org/martenlienen/emcp#built-in-resources) and [tools](https://codeberg.org/martenlienen/emcp#built-in-tools) are available to the agent depends on the active [profile](https://codeberg.org/martenlienen/emcp#profiles).

### Direct link to the package repository

https://codeberg.org/martenlienen/emcp

### Your association with the package

I am the author.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

Regarding package-lint, I have addressed all issues except:
1. The package summary contains "Emacs". However, here it is not redundant, because it does not mean "for the use in Emacs" but "Emacs is the subject of this MCP server", so removing it would make it less clear what this package is about.
2. There are functions with a `/` in the name like `emcp--server-request-prompts/list`, which package-lint thinks is a separator when `prompts/list` actually refers to an MCP request target and EMCP uses normal dash separators for functions. Therefore, I chose to ignore these issues as well.