### PR TITLE
Update contributor guides re: package maturity, AI assistance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ https://github.com/your/awesome_package
 
 - [] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
 - [] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
-- [] The package has been maintained in a public repository for 2 months or more
+- [] The package has been maintained in a public repository for 1 month or more
 - [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 - [] My elisp byte-compiles cleanly
 - [] I've used `M-x checkdoc` to check the package's documentation strings

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,5 +29,6 @@ https://github.com/your/awesome_package
 - [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 - [] My elisp byte-compiles cleanly
 - [] I've used `M-x checkdoc` to check the package's documentation strings
+- [] This project has been maintained in a public repository for 2 months or more
 
 <!-- After submitting, please fix any problems the CI reports. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,5 @@ https://github.com/your/awesome_package
 - [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 - [] My elisp byte-compiles cleanly
 - [] I've used `M-x checkdoc` to check the package's documentation strings
-- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
 
 <!-- After submitting, please fix any problems the CI reports. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,9 +26,10 @@ https://github.com/your/awesome_package
 
 - [] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
 - [] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
+- [] The package has been maintained in a public repository for 2 months or more
 - [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
 - [] My elisp byte-compiles cleanly
 - [] I've used `M-x checkdoc` to check the package's documentation strings
-- [] This project has been maintained in a public repository for 2 months or more
+- [] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
 
 <!-- After submitting, please fix any problems the CI reports. -->

--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -39,11 +39,12 @@ New recipe submissions should adhere to the following guidelines:
      dependency of the others, open the pull request for that one
      first.  Avoid circular dependencies.
 
-- Reasonably innovative package :: MELPA provides a curated set of
+- Reasonably innovative and mature :: MELPA provides a curated set of
      Emacs Lisp packages, not an exhaustive list of every single Emacs
      Lisp file ever created. By default, MELPA maintainers will reject
      packages that duplicate functionality provided by existing
-     packages. Please try to improve existing packages instead of
+     packages, or nascent packages that haven't had time to see real
+     maintenance.  Please try to improve existing packages instead of
      creating new ones when possible.
 
 - Official repository :: Packages should be built from the official

--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -46,10 +46,6 @@ New recipe submissions should adhere to the following guidelines:
      packages. Please try to improve existing packages instead of
      creating new ones when possible.
 
-- Software Configuration Management (SCM) :: Upstream source must be
-     stored in an authoritative Git or Mercurial [[https://en.wikipedia.org/wiki/Software_configuration_management][SCM
-     repository]]. [[https://www.emacswiki.org/][EmacsWiki]] recipes are no longer accepted.
-
 - Official repository :: Packages should be built from the official
      package repository.  Forks of the official repository will not be
      accepted except in extreme circumstances.
@@ -58,11 +54,6 @@ New recipe submissions should adhere to the following guidelines:
      git) repository. This makes it possible to have a different
      version number for each package as MELPA stable looks at the
      SCM's tags to assign version numbers to recipes.
-
-- Quality :: Because we care about the quality of packages that are
-             part of MELPA, MELPA maintainers review every recipe and
-             its associated package. Please read and follow the
-             guidelines below.
 
 - Contact package author :: If you are not the original author or
      maintainer of the package you are submitting, please notify the
@@ -114,13 +105,6 @@ will delay the process.
      package metadata. Use [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html][checkdoc]] to make sure that your package
      follows the conventions for documentation strings, within reason.
 
-- Avoid long functions :: The longer a function the harder it is for a
-     MELPA maintainer to understand what is happening and to give
-     feedback. It is also much harder to point to a specific portion
-     of the code we believe could be improved. Please spend time
-     decomposing your long functions into smaller, well-named and
-     documented, ones.
-
 - Avoid change logs and readmes :: Files like these would only end up
      in an obscure installation directory where a user would never know
      to look when searching for information. Possible exceptions to this
@@ -141,10 +125,7 @@ which delay review by several days or even weeks. Please double check
 this list before submitting your package:
 
 - Please run quality-checking tools specified above (really, do it!).
-- Please enable [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Lexical-Binding.html][lexical binding]] by adding ~-*- lexical-binding: t;
-  -*-~ at the end of the first line of each Emacs Lisp file. If you
-  want to know more about why you should always do that, read [[https://nullprogram.com/tags/emacs/][Chris
-  Wellons Emacs' blog posts]] ([[https://nullprogram.com/blog/2016/12/22/][this post]] for example).
+- Please enable [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Lexical-Binding.html][lexical binding]] (read [[https://nullprogram.com/blog/2016/12/22/][this post]] for details).
 - Please avoid defining a face that both ~:inherit~ another face and
   also override their attributes (e.g. by making them bold, underlined
   or inverse-video). The result could be really bad depending on user
@@ -154,11 +135,6 @@ this list before submitting your package:
   instead of just ' (i.e., the special form ~quote~) to tell the
   compiler this is [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Anonymous-Functions.html][a function reference]]. E.g., ~(seq-filter #'evenp
   list)~.
-- MELPA *only* looks at the main ~.el~ file (or ~-pkg.el~ file, if
-  provided, though we discourage that).  If you have different
-  optional parts of a large package, each of which has different
-  dependencies, then these should really be published as *separate
-  packages*.
 
 ** Preparing a pull request to MELPA
 
@@ -210,7 +186,7 @@ You can optionally run a sandboxed Emacs in which locally-built
 packages will be available for installation along with those already
 in MELPA:
 
-#+BEGIN_SRC shell
+#+BEGIN_SRC
 make sandbox INSTALL=<NAME>
 #+END_SRC
 

--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -47,6 +47,13 @@ New recipe submissions should adhere to the following guidelines:
      maintenance.  Please try to improve existing packages instead of
      creating new ones when possible.
 
+- Full responsibility for AI-generated code :: Using AI to assist in
+     writing code or opening pull requests is fine, but a human should
+     be the *first* and *most thorough* reviewer of any such output.
+     While not a strict requirement, you can help the community track
+     AI assistance by providing an [[https://docs.kernel.org/process/coding-assistants.html#attribution][Assisted-by tag]] near the top of your
+     package's main file.
+
 - Official repository :: Packages should be built from the official
      package repository.  Forks of the official repository will not be
      accepted except in extreme circumstances.

--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -48,11 +48,11 @@ New recipe submissions should adhere to the following guidelines:
      creating new ones when possible.
 
 - Full responsibility for AI-generated code :: Using AI to assist in
-     writing code or opening pull requests is fine, but a human should
-     be the *first* and *most thorough* reviewer of any such output.
-     While not a strict requirement, you can help the community track
-     AI assistance by providing an [[https://docs.kernel.org/process/coding-assistants.html#attribution][Assisted-by tag]] near the top of your
-     package's main file.
+     writing code or opening pull requests is fine, but the human
+     author should be the *first* and *most thorough* reviewer of any
+     such output. While not a strict requirement, you can help the
+     community track AI assistance by providing an [[https://docs.kernel.org/process/coding-assistants.html#attribution][Assisted-by tag]]
+     near the top of your package's main file.
 
 - Official repository :: Packages should be built from the official
      package repository.  Forks of the official repository will not be


### PR DESCRIPTION
Update our contributor guides (CONTRIBUTING.org, the checklist template).

- Big change: CONTRIBUTING.org and the checklist ask packages to reach a certain level of maturity (2 months of existence)
- CONTRIBUTING.org was getting a little long and needed a little pruning; I wanted to address this while I'm adding to it
- CONTRIBUTING.org now includes a recommendation to use "Assisted-by" tags as required by Linux kernel developers - not required yet, but encouraged

@tarsius thanks for your initial thoughts on this, which I've incorporated here.