### PR TITLE
Add recipe for outline-stars

### DIFF
--- a/recipes/outline-stars
+++ b/recipes/outline-stars
@@ -1,0 +1,3 @@
+(outline-stars
+ :fetcher codeberg
+ :repo "phmcc/outline-stars")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

`outline-stars` brings `org`-like section folding to non-`org` buffers using star-based comment headings (`;;; *`, `### *`, `// *`, etc.) and the built-in outline-minor-mode. It handles comment prefix detection, per-level fontification, `imenu` integration, automatic numbering, and star-aware structure editing in a single, dependency-free file. It is designed to be a lightweight successor to the excellent `outshine` package.

### Direct link to the package repository

https://codeberg.org/phmcc/outline-stars

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed. Run against [melpazoid](https://github.com/riscy/melpazoid) for quick compliance checks prior to submission.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
