### PR TITLE
Add recipe for with-command-redo

### DIFF
--- a/recipes/with-command-redo
+++ b/recipes/with-command-redo
@@ -1,0 +1,3 @@
+(with-command-redo
+ :fetcher codeberg
+ :repo "ideasman42/emacs-with-command-redo")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

This is middleware, to support running a command multiple times without adding to your undo history every time.

Typical use case is - correct spelling of a word, run twice to pick the next work - but only store the correction that was actually used in undo history.

For other use-cases see: [recomplete](https://codeberg.org/ideasman42/emacs-recomplete), this package was extracted from recomplete.
_If accepted, recomplete will be updated to use this package._

I wanted to use this functionality elsewhere, so I created this package to avoid duplicating lower level undo state management between packages.

### Direct link to the package repository

https://codeberg.org/ideasman42/emacs-with-command-redo

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
