### PR TITLE
Use the codeberg fetcher for http-server

### DIFF
--- a/recipes/http-server
+++ b/recipes/http-server
@@ -1,1 +1,1 @@
-(http-server :fetcher git :url "https://codeberg.org/martenlienen/http-server.el.git")
+(http-server :fetcher codeberg :repo "martenlienen/http-server.el")


### PR DESCRIPTION
The :url recipe does not link to the git repo on the MELPA website. I hope that the native codeberg fetcher will set up repo links correctly in search results and the project page.