### PR TITLE
Add recipe for indigo

### DIFF
--- a/recipes/indigo
+++ b/recipes/indigo
@@ -1,0 +1,9 @@
+(indigo :repo "gicrisf/emacs-indigo"
+        :fetcher github
+        :files (:defaults
+                "Makefile"
+                "install.sh"
+                "install-indigo.sh"
+                "install-dependencies.sh"
+                ("src" "src/*.c")
+                ("src" "src/*.h")))

--- a/recipes/indigo
+++ b/recipes/indigo
@@ -1,5 +1,5 @@
-(indigo :repo "gicrisf/emacs-indigo"
-        :fetcher github
+(indigo :fetcher github
+        :repo "gicrisf/emacs-indigo"
         :files (:defaults
                 "Makefile"
                 "install.sh"


### PR DESCRIPTION
## Brief summary of what the package does

emacs-indigo provides Emacs Lisp bindings for the Indigo cheminformatics toolkit, enabling molecular structure manipulation, chemical file I/O, and cheminformatics operations from within Emacs.

The package supports:
- Loading molecules from SMILES strings and MOL/SDF files
- Querying molecular properties (atoms, bonds, coordinates, charges)
- Substructure search with SMARTS patterns
- Reaction handling (RXN files, reactants/products)
- Molecular rendering to SVG/PNG
- Lazy stream abstraction for iterating over molecular components

It uses a C dynamic module that wraps the Indigo library. The module is built automatically on first use via `M-x indigo-install`, which downloads pre-built Indigo binaries for the user's platform.

## Direct link to the package repository

https://github.com/gicrisf/emacs-indigo

## Your association with the package

I am the author and maintainer of this package.

## Relevant communications with the upstream package maintainer

None needed (I am the upstream maintainer).

## Notes

**Package structure**: This package uses a multi-file architecture with `indigo.el` as the main entry point and several submodules (`indigo-mol.el`, `indigo-io.el`, etc.).

I ran `package-lint` on every submodule and consistently get the same false-positive warnings due to package-lint treating each file as a standalone package:
- Missing `Package-Version` header
- Missing `URL` header
- Missing Emacs version in `Package-Requires`
- Prefix warnings (e.g., expecting `indigo-io-` instead of `indigo-`)

All public functions correctly use the `indigo-` package prefix. The main file `indigo.el` passes package-lint cleanly with all required headers present.

I also ran `checkdoc` on all files: all documentation strings are properly formatted and pass cleanly with no issues.

**Binary download and compilation**: The package uses a hybrid approach on first use via `M-x indigo-install`:
1. Downloads pre-built static binaries for the Indigo cheminformatics library (the upstream C/C++ toolkit)
2. Compiles an Emacs dynamic module (C wrapper code in this repository) that links against those binaries

The user explicitly selects their platform from a list (currently `linux-x86_64` only) before any download occurs. The compilation step uses the standard Emacs dynamic module API and requires only a C compiler (gcc/clang). This follows the same pattern as my other package `eldc` (#9702).

## Checklist

- [x] The package is released under a GPL-Compatible Free Software License
- [x] I've read CONTRIBUTING.org
- [x] I've used the latest version of package-lint to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used M-x checkdoc to check the package's documentation strings
- [x] I've built and installed the package using the instructions in CONTRIBUTING.org