### PR TITLE
Add recipe for blamer

### DIFF
--- a/recipes/blamer
+++ b/recipes/blamer
@@ -1,1 +1,1 @@
-(blamer :repo "Artawower/blamer.el" :fetcher github)
+(blamer :fetcher github :repo "fvi-att/blamer-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

blamer.el displays `git blame` information inline between the line-numbers gutter and the source text. Consecutive lines sharing the same commit are grouped into a chunk; only the first line of each chunk shows the blame prefix (date, author, summary, or hash — configurable via `blamer-inline-columns`), the rest receive a blank spacer of the same width so the source stays aligned. Each chunk gets a deterministic background color derived from its commit hash. When point enters a blamed line, a child-frame popup (echo-area fallback on TTY) shows full commit details: author, timestamp, hash, and summary.

### Direct link to the package repository

https://github.com/fvi-att/blamer-emacs

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)