### PR TITLE
Add recipe for gnus-browse-url-in-article

### DIFF
--- a/recipes/gnus-browse-url-in-article
+++ b/recipes/gnus-browse-url-in-article
@@ -1,0 +1,1 @@
+(gnus-browse-url-in-article :fetcher github :repo "jmibanez/gnus-browse-url-in-article")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

Provides `gnus-browse-url-in-article`, an extensible command for browsing to the "best" URL in a Gnus article. Built-in handlers cover GitHub PR notifications and LinkedIn job alerts. Additional per-sender handlers can be registered via `gnus-browse-url-in-article-handlers`. 


### Direct link to the package repository

https://github.com/jmibanez/gnus-browse-url-in-article

### Your association with the package

Maintainer/Author

### Relevant communications with the upstream package maintainer

None

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
