### PR TITLE
Add recipe for folgezett

### DIFF
--- a/recipes/folgezett
+++ b/recipes/folgezett
@@ -1,0 +1,2 @@
+(folgezett :fetcher github
+           :repo "landerwells/folgezett.el")


### PR DESCRIPTION
### Brief summary of what the package does

`folgezett` adds Luhmann-style folgezettel IDs to `org-roam`. When you capture a new note you are prompted to choose a parent, and the package generates a branching ID (e.g. `1.1`, `1.1a`, `1.1a2`) stored in a `FOLGEZETTEL_ID` property. It also provides commands to jump to a note's parent, list its children, reparent a note (optionally with its whole subtree), and view the full tree in a dedicated buffer.

### Direct link to the package repository

https://github.com/landerwells/folgezett.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)