### PR TITLE
Add recipe for tmux-csi-u

### DIFF
--- a/recipes/tmux-csi-u
+++ b/recipes/tmux-csi-u
@@ -1,0 +1,3 @@
+(tmux-csi-u
+  :fetcher github
+  :repo "lajarre/tmux-csi-u.el")


### PR DESCRIPTION

### Brief summary of what the package does

Emacs-side decoder for tmux CSI-u key sequences on the terminal Emacs path. Installs explicit `input-decode-map` entries from `tty-setup-hook` so shifted space, modified backspace / escape, M-RET / M-TAB, and the shifted punctuation family decode correctly while tmux stays on `extended-keys-format csi-u`.

### Direct link to the package repository

https://github.com/lajarre/tmux-csi-u.el

### Your association with the package

I'm the maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)