### PR TITLE
Add recipe for a6s

### DIFF
--- a/recipes/a6s
+++ b/recipes/a6s
@@ -1,0 +1,1 @@
+(a6s :fetcher github :repo "The-Autonoma/a6s-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

A6s is an Emacs client for the local A6s CLI daemon (`a6s code --daemon`). It connects over WebSocket to `ws://localhost:9876/ws` and exposes intelligent multi-agent orchestration directly inside Emacs: invoke RIGOR agents, explain / refactor / review / generate-tests for the active region, and manage long-running background tasks. The daemon is the only component that talks to a remote orchestrator — the package itself never holds API credentials.

### Direct link to the package repository

https://github.com/The-Autonoma/a6s-emacs

### Your association with the package

I am the maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed** — I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (Apache-2.0)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly (with `byte-compile-error-on-warn`)
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org) — `make recipes/a6s` succeeds locally and produces `a6s-20260425.357.tar`