### PR TITLE
Add recipe for apple-container-tramp

### DIFF
--- a/recipes/apple-container-tramp
+++ b/recipes/apple-container-tramp
@@ -1,0 +1,3 @@
+(apple-container-tramp
+ :fetcher github
+ :repo "major1201/apple-container-tramp.el")


### PR DESCRIPTION
### Brief summary of what the package does

apple-container-tramp is a TRAMP integration for [Apple container](https://github.com/apple/container), it offers the TRAMP method `container` to access running containers.

### Direct link to the package repository

https://github.com/major1201/apple-container-tramp.el

### Your association with the package

I am the maintainer of the package.

### Relevant communications with the upstream package maintainer

**None needed** — I am the upstream maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
