### PR TITLE
Add recipe for nucleo-completion

### DIFF
--- a/recipes/nucleo-completion
+++ b/recipes/nucleo-completion
@@ -1,0 +1,4 @@
+(nucleo-completion
+ :repo "kn66/nucleo-completion.el"
+ :fetcher github
+ :files ("nucleo-completion.el" "bin"))

--- a/recipes/nucleo-completion
+++ b/recipes/nucleo-completion
@@ -1,4 +1,4 @@
 (nucleo-completion
- :repo "kn66/nucleo-completion.el"
  :fetcher github
+ :repo "kn66/nucleo-completion.el"
  :files ("nucleo-completion.el" "bin"))

--- a/recipes/nucleo-completion
+++ b/recipes/nucleo-completion
@@ -1,4 +1,4 @@
 (nucleo-completion
  :fetcher github
  :repo "kn66/nucleo-completion.el"
- :files ("nucleo-completion.el" "bin"))
+ :files ("nucleo-completion.el" "src" "Cargo.toml" "Cargo.lock"))


### PR DESCRIPTION
### Brief summary of what the package does

`nucleo-completion` provides an Emacs completion style backed by the Rust `nucleo-matcher` crate. It supports fuzzy
completion filtering, optional regexp expansion hooks, candidate highlighting, and an Emacs Lisp fallback when the
dynamic module is unavailable.

### Direct link to the package repository

https://github.com/kn66/nucleo-completion.el

### Your association with the package

I am the package maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-
list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging
issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/
melpa/blob/master/CONTRIBUTING.org)
