### PR TITLE
Update recipes: geiser projects moved to codeberg

### DIFF
--- a/recipes/geiser
+++ b/recipes/geiser
@@ -1,4 +1,4 @@
 (geiser
- :fetcher gitlab
- :repo "emacs-geiser/geiser"
+ :fetcher codeberg
+ :repo "geiser/geiser"
  :files ("elisp/*.el" "doc/dir" "doc/geiser.texi"))

--- a/recipes/geiser-chez
+++ b/recipes/geiser-chez
@@ -1,4 +1,4 @@
 (geiser-chez
- :fetcher gitlab
- :repo "emacs-geiser/chez"
+ :fetcher codeberg
+ :repo "geiser/chez"
  :files (:defaults ("src" "src/*")))

--- a/recipes/geiser-chibi
+++ b/recipes/geiser-chibi
@@ -1,4 +1,4 @@
 (geiser-chibi
- :fetcher gitlab
- :repo "emacs-geiser/chibi"
+ :fetcher codeberg
+ :repo "geiser/chibi"
  :files (:defaults ("src" "src/*")))

--- a/recipes/geiser-chicken
+++ b/recipes/geiser-chicken
@@ -1,4 +1,4 @@
 (geiser-chicken
- :fetcher gitlab
- :repo "emacs-geiser/chicken"
+ :fetcher codeberg
+ :repo "geiser/chicken"
  :files (:defaults "src"))

--- a/recipes/geiser-gambit
+++ b/recipes/geiser-gambit
@@ -1,4 +1,4 @@
 (geiser-gambit
- :fetcher gitlab
- :repo "emacs-geiser/gambit"
+ :fetcher codeberg
+ :repo "geiser/gambit"
  :files (:defaults ("src" "src/*")))

--- a/recipes/geiser-guile
+++ b/recipes/geiser-guile
@@ -1,4 +1,4 @@
 (geiser-guile
- :fetcher gitlab
- :repo "emacs-geiser/guile"
+ :fetcher codeberg
+ :repo "geiser/guile"
  :files (:defaults ("src" "src/*")))

--- a/recipes/geiser-mit
+++ b/recipes/geiser-mit
@@ -1,4 +1,4 @@
 (geiser-mit
- :fetcher gitlab
- :repo "emacs-geiser/mit"
+ :fetcher codeberg
+ :repo "geiser/mit"
  :files (:defaults ("src" "src/*")))

--- a/recipes/geiser-racket
+++ b/recipes/geiser-racket
@@ -1,4 +1,4 @@
 (geiser-racket
- :fetcher gitlab
- :repo "emacs-geiser/racket"
+ :fetcher codeberg
+ :repo "geiser/racket"
  :files (:defaults ("src" "src/*" "bin" "bin/*")))


### PR DESCRIPTION
This is for geiser projects that I maintain. There are still 3 other geiser-* packages in gitlab.