### PR TITLE
Add recipe for denote-mcp

### DIFF
--- a/recipes/denote-mcp
+++ b/recipes/denote-mcp
@@ -1,0 +1,3 @@
+(denote-mcp
+ :fetcher github
+ :repo "greggroth/denote-mcp")


### PR DESCRIPTION
### Brief summary of what the package does

denote-mcp is a Model Context Protocol (MCP) server for Denote, exposing Denote's note creation, search, linking, and journal operations as MCP tools and resources so that LLM coding agents can reliably work with a Denote notes corpus without having to re-discover Denote's filename rules, identifier scheme, journal subdirectories, or front-matter conventions.

### Direct link to the package repository

https://github.com/greggroth/denote-mcp

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (GPL-3.0-or-later)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)