### PR TITLE
Add recipe for ttx-mode

### DIFF
--- a/recipes/ttx-mode
+++ b/recipes/ttx-mode
@@ -1,0 +1,1 @@
+(ttx-mode :fetcher github :repo "wmedrano/ttx-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`ttx-mode` allows inspecting ttf, otf, and woff2 font files as XML.

### Direct link to the package repository

https://github.com/wmedrano/ttx-mode

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
