### PR TITLE
Add recipe for consult-wt

### DIFF
--- a/recipes/consult-wt
+++ b/recipes/consult-wt
@@ -1,0 +1,3 @@
+(consult-wt
+ :repo "tomoya/consult-wt"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

This package is a [Worktrunk](https://github.com/max-sixty/worktrunk) interface using consult. Worktrunk is a CLI for git worktree management.
Currently, the consult-wt provides two commands.  The first one `consult-wt-find` command select a worktree from the wt list and then find repository files using [affe-find](https://github.com/minad/affe) (similar to consult-find).
The second one `consult-wt-grep` commands select a worktree from the wt list and then grep repository files using affe-grep (similar to consult-ripgrep or consult-grep).

Similar packages are: 
- https://github.com/tomoya/consult-ghq

### Direct link to the package repository

https://github.com/tomoya/consult-wt

### Your association with the package

I am the author

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
