### PR TITLE
Add recipe for cotype

### DIFF
--- a/recipes/cotype
+++ b/recipes/cotype
@@ -1,0 +1,1 @@
+(cotype :fetcher github :repo "yurug/cotype" :files ("editors/emacs/cotype.el"))


### PR DESCRIPTION
### Brief summary of what the package does                      

  `cotype-mode` is a buffer-local minor mode that routes Emacs saves                                                                        
  through the `cotype` CLI, so a file can be edited concurrently by the
  user, AI agents, and other processes without lost updates. On save,                                                                       
  the buffer is piped through `cotype save --base-sha <captured>`. On                                                                       
  conflict, the file is rewritten with diff3 markers and the buffer is                                                                      
  reverted to show them in place; `M-x cotype-resolve` clears the                                                                           
  pending state once the user has edited them out. The mode silences                                                                        
  Emacs's two modtime prompts (`ask-user-about-supersession-threat` and                                                                     
  `basic-save-buffer`'s "Save anyway?") inside cotype-mode buffers only,                                                                    
  since the upstream `cotype` CLI already coordinates concurrent saves                                                                      
  through 3-way merge.                                                                                                                      
                                                                                                                                            
  ### Direct link to the package repository                                                                                                 
                                                                  
  https://github.com/yurug/cotype                                                                                                           
   
  ### Your association with the package                                                                                                     
                                                                  
  Maintainer.                                                                                                                               
   
  ### Relevant communications with the upstream package maintainer                                                                          
                                                                  
  None needed — single-author project; `editors/emacs/cotype.el` is part                                                                    
  of the same monorepo as the `cotype` CLI it wraps.
                                                                                                                                            
  ### Checklist                                                   
                                                                                                                                            
  - [x] The package is released under a [GPL-Compatible Free Software                                                                       
  License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
  - [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)                                           
  - [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in                           
  [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)                         
  - [ ] The package has been maintained in a public repository for 1 month or more                                                          
  - [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed
   its feedback                                                                                                                             
  - [x] My elisp byte-compiles cleanly
  - [x] I've used `M-x checkdoc` to check the package's documentation strings                                                               
  - [x] I've built and installed the package using the instructions in
  [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)                                          
                                                                  
  ### Notes for reviewer                                                                                                                    
                                                                  
  **Maintenance age**: cotype's first public release was **v0.1.0 on 2026-05-03**, so the public-history requirement of 1 month is not yet met (one box left unchecked above honestly). Happy to wait if MELPA's policy on this is strict; flagged here so the reviewer can decide whether to hold the PR until ~2026-06-03 or proceed early on the strength of the implementation. The package is already published on PyPI and the upstream CLI is feature-complete for v0.2.0.            

  The package on PyPI: https://pypi.org/project/cotype/0.2.0/
  GitHub release: https://github.com/yurug/cotype/releases/tag/emacs-v0.2.0
                                                                                                                                            
                                                             
                                                                   