### PR TITLE
Add recipe for clutch

### DIFF
--- a/recipes/clutch
+++ b/recipes/clutch
@@ -1,0 +1,3 @@
+(clutch
+ :fetcher github
+ :repo "LuciusChen/clutch")


### PR DESCRIPTION
### Brief summary of what the package does

clutch is an interactive database client for Emacs.  It provides a SQL editing
mode, query consoles, result browsing/editing workflows, object/schema
navigation, native MySQL/PostgreSQL/SQLite backends, and JDBC support through a
Java sidecar.

### Direct link to the package repository

https://github.com/LuciusChen/clutch

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Validation:

- `make recipes/clutch USER_CONFIG='"(setq package-build-badge-data nil)"'`
- `package-lint` passed locally for `clutch.el`
- `checkdoc` passed locally for `clutch.el`
- `batch-byte-compile` passed locally for all `*.el`
- `package-install-file` installed `packages/clutch-20260505.303.tar`
- `emacs -Q --batch` with `package-initialize` and `(require 'clutch)` loaded the installed package without autoload warnings
- Upstream clutch CI passes on Emacs 28.2 and 29.4
- MELPA PR CI passes

AI assistance note: AI assistance was used while preparing this MELPA recipe PR.
The PR itself adds only `recipes/clutch`; it does not add upstream package
source files in the MELPA repository.

Note: the default local badge build also packaged `clutch` successfully, but
failed afterward because this machine's ImageMagick cannot find the
DejaVu-Sans font for badge generation.  Disabling badge generation locally
avoids that machine-specific font issue and leaves the recipe build itself
unchanged.
