### PR TITLE
Update rimel  repository

### DIFF
--- a/recipes/rimel
+++ b/recipes/rimel
@@ -1,1 +1,1 @@
-(rimel :fetcher github :repo "jixiuf/rimel")
+(rimel :fetcher github :repo "emacs-rime/rimel")


### PR DESCRIPTION
moved https://github.com/jixiuf/rimel  to https://github.com/emacs-rime/rimel 