### PR TITLE
Add blame-reveal recipe

### DIFF
--- a/recipes/blame-reveal
+++ b/recipes/blame-reveal
@@ -1,0 +1,2 @@
+(blame-reveal :fetcher github
+              :repo "LuciusChen/blame-reveal")


### PR DESCRIPTION
Add a MELPA recipe for blame-reveal, a Git blame visualization package for Emacs.

Validation:
- make recipes/blame-reveal USER_CONFIG='"(setq package-build-badge-data nil)"'