### PR TITLE
Add recipe for brewpage

### DIFF
--- a/recipes/brewpage
+++ b/recipes/brewpage
@@ -1,0 +1,1 @@
+(brewpage :fetcher github :repo "kochetkov-ma/brewpage-emacs")


### PR DESCRIPTION
### Brief summary of what the package does

`brewpage` publishes the current buffer or the active region to
[brewpage.app](https://brewpage.app), a simple pastebin service. Two interactive
commands are provided:

- `brewpage-publish-buffer` — publish the entire buffer
- `brewpage-publish-region` — publish the active region

The returned URL is added to the kill ring and shown in the echo area. The
package is a single file with no external dependencies (built-in `url` only) and
declares `Package-Requires: ((emacs "27.1"))`.

### Direct link to the package repository

https://github.com/kochetkov-ma/brewpage-emacs

### Your association with the package

I am the author and maintainer of the package, and the author of this recipe.

### Relevant communications with the upstream package maintainer

**None needed** — I maintain the upstream repository myself.

For full transparency, these upstream items are known and not yet fixed at the
commit this recipe currently builds:

1. `checkdoc` reports two warnings, both "Lisp symbol `kill-ring` should appear
   in quotes" (`brewpage.el` docstrings of `brewpage-publish-region` and
   `brewpage-copy-to-clipboard`).
2. The source file carries a `;; License: MIT` header but not the license
   boilerplate above `;;; Commentary:` that CONTRIBUTING.org asks for, and it has
   no `;; Copyright (C)` line. The repository does contain a `LICENSE` file that
   GitHub/licensee detects as MIT.
3. Neither interactive command has a `;;;###autoload` cookie, so after
   `package-install` the commands are not reachable via `M-x` until the user
   requires the feature. Verified: the generated `brewpage-autoloads.el` contains
   no entries.
4. `url-request-data` is passed as a multibyte string, so `url-http` re-encodes
   it as us-ascii and non-ASCII buffer content is replaced by `?`. Needs an
   explicit `encode-coding-string ... 'utf-8` and a `charset=utf-8` on the
   `Content-Type` header.
5. There are no release tags yet, so `MELPA_CHANNEL=stable make recipes/brewpage`
   reports "Cannot determine version". Tagging is listed as optional in
   CONTRIBUTING.org.

I will address 1–4 upstream. Happy to do that before merge if you prefer to
review the fixed state.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Notes on the checklist items, so nothing above is taken on trust:

- **License** — MIT (Expat), which is on the FSF GPL-compatible list. `LICENSE`
  is present in the repository root and the GitHub API reports
  `license.spdx_id = MIT`. See caveat 2 above about the in-file boilerplate.
- **`Assisted-by:` left unticked** — `brewpage.el` currently carries no
  `Assisted-by:` line. If any of the code qualifies under the AI-attribution
  policy I will add the line upstream rather than tick this now.
- **1 month in a public repository left unticked** — the repository has been
  public since 2026-05-06, so it clears the calendar age, but it still has only
  the initial commit and no activity since. I would rather not tick "maintained"
  on that record and let you judge the maturity requirement yourself.
- **package-lint** — version `20260903.2119` (latest on MELPA at the time of
  writing), run via `package-lint-batch-and-exit`: 0 issues, exit status 0.
- **Byte-compile** — `emacs -Q --batch -f batch-byte-compile brewpage.el` on GNU
  Emacs 31.1: no warnings. Note that this is partly luck: the file uses
  `json-encode-string` / `json-read` / `json-read-from-string` but only
  `(require 'url)`, and on 31.1 `json` happens to be pulled in transitively via
  `url` → `url-auth` → `auth-source`. I will add an explicit `(require 'json)`
  since the declared minimum is Emacs 27.1.
- **checkdoc** — run via `checkdoc-file`; the two warnings are quoted in caveat 1
  above.
- **Build and install** — `make recipes/brewpage` succeeds and produces
  `brewpage-20260506.1323.tar` containing only `brewpage-pkg.el` and
  `brewpage.el`; `package-install-file` on that tar installs cleanly and
  `(require 'brewpage)` loads without error. The recipe is the preferred default
  form, `(brewpage :fetcher github :repo "kochetkov-ma/brewpage-emacs")`, and the
  recipe filename matches both the provided feature and the source filename.
