### PR TITLE
Add recipe for fzf-native

### DIFF
--- a/recipes/fzf-native
+++ b/recipes/fzf-native
@@ -1,0 +1,8 @@
+(fzf-native
+ :fetcher github
+ :repo "dangduc/fzf-native"
+ :files (:defaults
+         "bin"
+         "CMakeLists.txt"
+         "*.c" "*.h"
+         (:exclude "*test*")))


### PR DESCRIPTION
### Brief summary of what the package does

`fzf-native` provides fuzzy match scoring based on junegunn's fzf algorithm, exposed to Emacs as a dynamic module written in C. It offers `fzf-native-score`, `fzf-native-score-all`, `fzf-native-highlight-all`, and an async streaming API (`fzf-native-async-start`/`-candidates`/`-stats`) usable by completion frameworks like `fussy`. The package vendors (https://github.com/melpa/melpa/issues/10011) prebuilt binaries for Darwin (Intel + Apple Silicon), Linux, FreeBSD, and Windows so most users don't need to compile; a CMake-based `fzf-native-module-compile` is provided as a fallback.

### Direct link to the package repository

https://github.com/dangduc/fzf-native

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->
