### PR TITLE
Add recipe for tya-mode

### DIFF
--- a/recipes/tya-mode
+++ b/recipes/tya-mode
@@ -1,0 +1,4 @@
+(tya-mode
+ :fetcher github
+ :repo "komagata/tya"
+ :files ("editors/emacs/tya-mode.el"))


### PR DESCRIPTION
Adds a MELPA recipe for tya-mode, the Emacs major mode for the Tya programming language.\n\nSource: https://github.com/komagata/tya/tree/main/editors/emacs\n\nNotes:\n- The mode provides syntax highlighting for .tya files.\n- The source repository also contains LSP setup examples for eglot/lsp-mode.\n- I could not run MELPA's local build here because this environment does not provide emacs.