### PR TITLE
Add recipe for lsp-ltex-plus

### DIFF
--- a/recipes/lsp-ltex-plus
+++ b/recipes/lsp-ltex-plus
@@ -1,0 +1,4 @@
+ (lsp-ltex-plus
+   :fetcher github
+   :repo "ltex-plus/emacs-ltex-plus"
+   :files (:defaults))

--- a/recipes/lsp-ltex-plus
+++ b/recipes/lsp-ltex-plus
@@ -1,4 +1,3 @@
  (lsp-ltex-plus
    :fetcher github
-   :repo "ltex-plus/emacs-ltex-plus"
-   :files (:defaults))
+   :repo "ltex-plus/emacs-ltex-plus")


### PR DESCRIPTION
### Brief summary of what the package does

`lsp-ltex-plus` is an `lsp-mode` client for the LTeX+ server ([`ltex-ls-plus`](https://ltex-plus.github.io/ltex-plus/index.html)).
LTeX+ is a LanguageTool-based grammar and spell checker. This package
`lsp-ltex-plus` registers as an `:add-on?` LSP client (`:priority -1`),
so it runs concurrently with primary language servers (texlab,
pyright, etc.) without competing. Works offline by default; optionally,
Premium LanguageTool users can use their credentials to take advantage
of additional spelling and grammar rules (AI-powered spell checking, etc.),
which are typically not shipped with the [free version of LanguageTool](https://github.com/languagetool-org/languagetool).

Per-language dictionaries, disabled rules, enabled rules, and hidden false-
positives are provided through external plist files under `user-emacs-directory`
and survive restarts. Default coverage spans 25+ markup/writing modes
(LaTeX, Markdown, Org, …) and supports 30+ programming language modes
(comments and string literals, opt-in via `lsp-ltex-plus-check-programming-languages`).

The package `lsp-ltex-plus`, together with the VS Code companion LSP client,
is an [official extension](https://ltex-plus.github.io/ltex-plus/installation-usage.html#official-extensions) of the `ltex-ls-plus` language server.

### Direct link to the package repository

https://github.com/ltex-plus/emacs-ltex-plus

### Your association with the package

I am the original developer and maintainer.

### Relevant communications with the upstream package maintainer

While developing this package, I filed 6 PRs that are now merged upstream in
`lsp-mode`. 5 of these 6 PRs are critical and needed to make `lsp-ltex-plus`
work at all. See the README's [Recommended lsp-mode Revision](https://github.com/ltex-plus/emacs-ltex-plus#recommended-lsp-mode-revision)
section for the per-PR breakdown and the cutoff commit (`0951bf38`,
2026-05-15) at which all five critical fixes are present.

If you test the package, please either:
- update to a recent `lsp-mode` (≥ commit `0951bf38`, 2026-05-15); recommended. Or
- set `(lsp-ltex-plus-apply-kind-first-patch t)`; *deprecated since v0.3.4;
  needed only on older `lsp-mode` builds*. This installs `:override` advice
  that mirrors the upstream fixes locally.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org]
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
