### PR TITLE
Add recipe for org-apple-reminders

### DIFF
--- a/recipes/org-apple-reminders
+++ b/recipes/org-apple-reminders
@@ -1,0 +1,1 @@
+(org-apple-reminders :fetcher github :repo "deno1011/org-apple-reminders")

--- a/recipes/org-apple-reminders
+++ b/recipes/org-apple-reminders
@@ -1,1 +1,1 @@
-(org-apple-reminders :fetcher github :repo "deno1011/org-apple-reminders")
+(org-apple-reminders :fetcher github :repo "deno1011/org-apple-reminders" :branch "stable")


### PR DESCRIPTION
### Brief summary of what the package does

`org-apple-reminders` provides bidirectional sync between an Org-mode file and macOS Apple Reminders, using JavaScript for Automation (JXA) via `osascript`. No third-party CLI tools are required.

Highlights:
- Full bidirectional sync, org-mode ↔ Apple Reminders, across multiple lists.
- Conflict resolution via dual Apple `modificationDate` timestamps (`REMINDER_APPLE_MOD` / `REMINDER_ORG_MOD`) — no content hashing.
- Fields synced: title, due date + time, priority (A/B/C ↔ 1/5/9), flagged/starred, notes.
- Selective list sync via `org-apple-reminders-included-lists` and the interactive `C-c r i` picker (multi-select, persisted via `customize`).
- Region-aware `org-apple-reminders-push-heading` (`C-c r p`, also `C-c r m`) — push/move a single heading or every heading in the selection.
- Region-aware `org-apple-reminders-delete-reminder` (`C-c r D`) and `org-apple-reminders-remove-from-apple` (`C-c r d`).
- Progress cookies `[N/M]` on list headings, recalculated each sync.
- Org-agenda integration, org-capture template, automatic background pull (configurable interval, non-blocking via `make-process`).

### Direct link to the package repository

https://github.com/deno1011/org-apple-reminders

### Your association with the package

I am the author and maintainer of `org-apple-reminders`.

### Relevant communications with the upstream package maintainer

**None needed** — I am the upstream maintainer of this package.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) — GPL-3.0-or-later (full short-form GPL boilerplate is now in the header above `;;; Commentary`, in addition to the `SPDX-License-Identifier` line; a `LICENSE` file is present in the repository root).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org).
- [x] LLMs were used to generate some of the code, and an `Assisted-by: Claude:claude-opus-4-7` line is present in the package header next to the `Author:` line, per the [AI-attribution policy](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code).
- [ ] The package has been maintained in a public repository for 1 month or more.
  *(The repository was created on 2026-05-17 and is currently three days old. I am happy to wait for the 1-month threshold — I'll re-ping this PR once it is met. I am leaving this box unchecked rather than misreport the date.)*
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback — output is clean.
- [x] My elisp byte-compiles cleanly (no warnings).
- [x] I've used `M-x checkdoc` to check the package's documentation strings. One pedantic finding remains: a literal `"C-c r"` appears inside a docstring describing the *default value* of `org-apple-reminders-keymap-prefix`, which checkdoc flags as a key reference. The literal is the variable's actual default; happy to rephrase if the reviewers prefer.
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe):
  - `CHANNEL=unstable make recipes/org-apple-reminders` → produces `org-apple-reminders-20260520.544.tar` with `org-apple-reminders.el` + generated `-pkg.el`.
  - `CHANNEL=stable make recipes/org-apple-reminders` → correctly detects the `v1.9.2` tag and produces `org-apple-reminders-1.9.2.tar`.
  - `package-install-file` on the stable tarball in a clean `--batch` Emacs installs the package, generates autoloads, byte-compiles every file without warnings, and `(require 'org-apple-reminders)` loads cleanly.
