### PR TITLE
Add recipe for annotated-completing-read

### DIFF
--- a/recipes/annotated-completing-read
+++ b/recipes/annotated-completing-read
@@ -1,0 +1,3 @@
+(annotated-completing-read
+ :fetcher github
+ :repo "tychoish/annotated-completing-read.el")


### PR DESCRIPTION
### Brief summary of what the package does

Provides an `completing-read` wrapper to support writing one off (or more) completing-read functions without dealing with the long list of arguments and a somewhat arcane calling convention for anntoations, or needing to reach into other packages internal functions (e.g. `consult--read`) with their own problems, or just avoiding all non-trivial functionality.

### Direct link to the package repository

https://github.com/tychoish/annotated-completing-read.el

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

All good.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [] The package has been maintained in a public repository for 1 month or more
  I moved this out of [my (public) config](https://github.com/tychoish/.emacs.d/) more recently than that, but (nearly) true, I believe.
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
