### PR TITLE
Add recipe for fzfa

### DIFF
--- a/recipes/fzfa
+++ b/recipes/fzfa
@@ -1,0 +1,1 @@
+(fzfa :fetcher github :repo "jojojames/fzfa")


### PR DESCRIPTION

### Brief summary of what the package does

fzfa provides fuzzy async shell-command completion (completing-read interface) backed by fzf-native for scoring, analogous to counsel, helm, consult. It also provides various integrations using fzfa with notmuch, chrome, pass, mail, music.app, etc.

### Direct link to the package repository

https://github.com/jojojames/fzfa

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [] The package has been maintained in a public repository for 1 month or more

2 weeks currently.

- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback

1 warning:

1881:5: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.

Seems like we should ignore this warning?

- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->
