### PR TITLE
Add recipe for testscript-mode

### DIFF
--- a/recipes/testscript-mode
+++ b/recipes/testscript-mode
@@ -1,0 +1,1 @@
+(testscript-mode :fetcher github :repo "wwade/emacs-testscript-mode")


### PR DESCRIPTION
### Brief summary of what the package does

A major mode for editing testscript/txtar files, as used by Go's [testscript](https://github.com/rogpeppe/go-internal/tree/master/testscript) testing framework. Provides syntax highlighting for built-in commands, condition guards, environment variables, comments, and file markers; imenu support for navigating between embedded file sections; and navigation commands to jump between `-- FILENAME --` markers.

### Direct link to the package repository

https://github.com/wwade/emacs-testscript-mode

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed** (I am the upstream maintainer.)

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)