### PR TITLE
Move dieggsy package sources to sourcehut

### DIFF
--- a/recipes/difflib
+++ b/recipes/difflib
@@ -1,1 +1,1 @@
-(difflib :fetcher github :repo "dieggsy/difflib.el")
+(difflib :fetcher sourcehut :repo "dieggsy/difflib.el")

--- a/recipes/esh-autosuggest
+++ b/recipes/esh-autosuggest
@@ -1,4 +1,4 @@
 (esh-autosuggest
- :fetcher github
+ :fetcher sourcehut
  :repo "dieggsy/esh-autosuggest"
  :old-names (company-eshell-autosuggest))

--- a/recipes/eterm-256color
+++ b/recipes/eterm-256color
@@ -1,1 +1,1 @@
-(eterm-256color :fetcher github :repo "dieggsy/eterm-256color" :files (:defaults "eterm-256color.ti"))
+(eterm-256color :fetcher sourcehut :repo "dieggsy/eterm-256color" :files (:defaults "eterm-256color.ti"))

--- a/recipes/hacker-typer
+++ b/recipes/hacker-typer
@@ -1,3 +1,3 @@
-(hacker-typer :fetcher github
+(hacker-typer :fetcher sourcehut
 	      :repo "dieggsy/emacs-hacker-typer"
 	      :files (:defaults "hackerman.png"))

--- a/recipes/turing-machine
+++ b/recipes/turing-machine
@@ -1,1 +1,1 @@
-(turing-machine :fetcher github :repo "dieggsy/turing-machine")
+(turing-machine :fetcher sourcehut :repo "dieggsy/turing-machine")


### PR DESCRIPTION
Most of my development happens on sourcehut these days. This is just to update my existing packages to point to the sourcehut equivalents. I'll be archiving the Github versions.