### PR TITLE
Repoint consult-notes, tabspaces, bibtex-capf to Codeberg

### DIFF
--- a/recipes/bibtex-capf
+++ b/recipes/bibtex-capf
@@ -1,1 +1,1 @@
-(bibtex-capf :fetcher github :repo "mclear-tools/bibtex-capf")
+(bibtex-capf :fetcher git :url "https://codeberg.org/mclear-tools/bibtex-capf.git")

--- a/recipes/consult-notes
+++ b/recipes/consult-notes
@@ -1,3 +1,1 @@
-(consult-notes
-:repo "mclear-tools/consult-notes"
-:fetcher github)
+(consult-notes :fetcher git :url "https://codeberg.org/mclear-tools/consult-notes.git")

--- a/recipes/tabspaces
+++ b/recipes/tabspaces
@@ -1,1 +1,1 @@
-(tabspaces :repo "mclear-tools/tabspaces" :fetcher github)
+(tabspaces :fetcher git :url "https://codeberg.org/mclear-tools/tabspaces.git")


### PR DESCRIPTION
These three packages' upstream repositories have moved from GitHub to Codeberg. I am the maintainer (Colin McLear, @mclearc). This updates each recipe to fetch from the new Codeberg git URL:

- consult-notes -> https://codeberg.org/mclear-tools/consult-notes
- tabspaces -> https://codeberg.org/mclear-tools/tabspaces
- bibtex-capf -> https://codeberg.org/mclear-tools/bibtex-capf

Same packages, same history and maintainer; only the hosting moved. The GitHub repositories are now archived read-only mirrors.