### PR TITLE
Add recipe for shpaste

### DIFF
--- a/recipes/shpaste
+++ b/recipes/shpaste
@@ -1,0 +1,2 @@
+(shpaste :fetcher git
+         :url "https://git.sr.ht/~bounga/shpaste")


### PR DESCRIPTION
### Brief summary of what the package does

`shpaste` is an Emacs client for [paste.sr.ht](https://paste.sr.ht) (sourcehut's
paste service), built on its GraphQL API. It creates pastes from a region or the
current buffer and manages existing pastes from a `tabulated-list` buffer
(open, copy URL, delete, refresh).

### Direct link to the package repository

https://git.sr.ht/~bounga/shpaste

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed** 

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
