### PR TITLE
Add recipe for desert-theme

### DIFF
--- a/recipes/desert-theme
+++ b/recipes/desert-theme
@@ -1,0 +1,3 @@
+(desert-theme
+ :fetcher github
+ :repo "bkc39/desert-theme")


### PR DESCRIPTION
### Brief summary of what the package does

`desert-theme` is a warm, earthy Emacs color theme — a port of the classic *desert* colorscheme from Vim. It ships a fairly complete face set: font-lock, mode-line, line numbers, isearch/lazy-highlight, show-paren, whitespace, org-mode, diff, magit, and generic completion UI.

### Direct link to the package repository

https://github.com/bkc39/desert-theme

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (CC0 1.0 / public domain)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code) (`;; Assisted-by: Claude:claude-opus-4-8`)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe) — built with `package-build` and installed via `package-install-file`; the theme loads correctly