### PR TITLE
Add recipe for notmuch-multi

### DIFF
--- a/recipes/notmuch-multi
+++ b/recipes/notmuch-multi
@@ -1,0 +1,3 @@
+(notmuch-multi
+   :fetcher github
+   :repo "pivaldi/notmuch-multi")


### PR DESCRIPTION
### Brief summary of what the package does

notmuch-multi extends the stock Notmuch Emacs UI to manage multiple mail accounts as separate, collapsible sections, something the default UI doesn't do.
Each account gets its own saved searches and  `notmuch-jump` key prefix, a prettified hello screen showing an unread/total count per search, and truncated, emoji-stripped subject formatting for the search and tree views.
It also adds a soft-delete/expire tagging workflow (with separate, explicit file deletion of delete/expire-tagged mail), per-account recipient address completion scoped to the active `From:` account, and optional scheduled per-account mail fetching.

### Direct link to the package repository

https://github.com/pivaldi/notmuch-multi

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
