### PR TITLE
Add recipe for nu-ts-mode

### DIFF
--- a/recipes/nu-ts-mode
+++ b/recipes/nu-ts-mode
@@ -1,0 +1,3 @@
+(nu-ts-mode
+ :fetcher github
+ :repo "ItsOleks/nu-ts-mode")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

Because nushell-ts-mode was broken and hadn't had a commit in the past 3 years, I wrote my own. It works based on the current version of the grammar and has tree-sitter-based highlighting and indentation.

I am not sure if this is fine with the "MELPA maintainers will reject packages that duplicate functionality provided by existing packages" line in the contributing guide, but as stated above, the other package is currently broken and the author doesn't seem to be reacting to issues/PRs.

Additionally, I am not an experienced emacs/treesitter plugin dev, so I am very open to any feedback or improvement suggestions.

### Direct link to the package repository

https://github.com/ItsOleks/nu-ts-mode

### Your association with the package

I am the author and maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] The package has been maintained in a public repository for 1 month or more
- [] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
- LLMs were not used to generate any of the code, so that checklist item is deleted

<!-- After submitting, please fix any problems the CI reports. -->
