### PR TITLE
Add recipe for clatter

### DIFF
--- a/recipes/clatter
+++ b/recipes/clatter
@@ -1,0 +1,3 @@
+(clatter
+ :fetcher github
+ :repo "parenworks/clatter.el")


### PR DESCRIPTION
### Brief summary of what the package does

clatter.el is a dedicated, IRCv3-compliant IRC client for Emacs, written in pure Emacs Lisp (requires only Emacs 30.1+ and curl for async URL fetching).
It supports the full IRC protocol plus IRCv3 features: CAP LS 302, SASL (PLAIN/EXTERNAL/SCRAM-SHA-256), message tags, batch, labeled-response, and chathistory. It also provides TLS with client certificates, a buffer per channel with nick colorization, a nick sidebar, desktop notifications, logging, full-text log search, and optional org-mode integration.

### Direct link to the package repository

https://github.com/parenworks/clatter.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a GPL-Compatible Free Software License (MIT)
- [x] I've read CONTRIBUTING.org
- [ ] LLMs were used to generate some of the code, and I've added an `Assisted-by:` line as described in CONTRIBUTING.org
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of package-lint to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in CONTRIBUTING.org
