### PR TITLE
Add recipe for shexc-ts-mode

### DIFF
--- a/recipes/shexc-ts-mode
+++ b/recipes/shexc-ts-mode
@@ -1,0 +1,4 @@
+(shexc-ts-mode
+ :fetcher github
+ :repo "ericprud/shexc-mode-for-emacs"
+ :files (:defaults (:exclude "shexc-mode.el")))


### PR DESCRIPTION
### Brief summary of what the package does

`shexc-ts-mode` is a tree-sitter major mode for ShExC (Shape Expressions
Compact Syntax), the Turtle-like syntax used by ShEx to describe and
validate the structure of RDF graphs. It is built on the
[tree-sitter-shexc](https://github.com/ericprud/tree-sitter-shexc) grammar
and provides syntax highlighting, structure-aware indentation, imenu,
xref (jump to shape definition/references), flymake diagnostics
(undefined shapes/prefixes, syntax errors, duplicate predicates),
shape-folding, and a "wrap/unwrap in shape" structural-editing pair.

### Direct link to the package repository

https://github.com/ericprud/shexc-mode-for-emacs

### Your association with the package

I'm the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (MIT)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)