### PR TITLE
Add recipe for gruber-darker-ayu-theme

### DIFF
--- a/recipes/gruber-darker-ayu-theme
+++ b/recipes/gruber-darker-ayu-theme
@@ -1,0 +1,3 @@
+(gruber-darker-ayu-theme
+ :repo "Hadi493/gruber-darker-ayu-theme"
+ :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

A blend of Gruber Darker's deep #181818 background with Ayu Dark's warm, high-contrast syntax palette.

### Direct link to the package repository

https://github.com/Hadi493/gruber-darker-ayu-theme

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a GPL-Compatible Free Software License
- [x] I've read CONTRIBUTING.org
- [x] LLMs were used to generate some of the code
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used package-lint to check for packaging issues
- [ ] My elisp byte-compiles cleanly
- [x] I've used checkdoc to check the package's documentation strings
- [x] I've built and installed the package using the instructions in CONTRIBUTING.org