### PR TITLE
Add recipe for pg-propre

### DIFF
--- a/recipes/pg-propre
+++ b/recipes/pg-propre
@@ -1,0 +1,1 @@
+(pg-propre :fetcher github :repo "madtibo/emacs-pg-propre")


### PR DESCRIPTION
## Add recipe for pg-propre

### Brief summary of what the package does

pg-propre integrates pg_propre (https://gitlab.com/madtibo/pg_propre), a fast Rust PostgreSQL SQL formatter and linter built on PostgreSQL's own parser, into Emacs. It uses the reformatter library to provide pg-propre-format-buffer/pg-propre-format-region commands and a pg-propre-format-on-save-mode minor mode, plus a Flymake backend (pg-propre-flymake) that surfaces pg_propre --lint diagnostics live.

### Direct link to the package repository

https://github.com/madtibo/emacs-pg-propre

### Your association with the package

I am the package author of pg_propre and emacs-pg-propre.

### Relevant communications with the upstream package maintainer

None needed — I am the upstream maintainer.

### Checklist

- [x] The package is released under a GPL-Compatible Free Software License
(https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read CONTRIBUTING.org
(https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an
Assisted-by: line as described in CONTRIBUTING.org (https://github.com/melpa/m
elpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or
more
- [x] I've used the latest version of package-lint
(https://github.com/purcell/package-lint) to check for packaging issues, and
addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used M-x checkdoc to check the package's documentation strings
- [x] I've built and installed the package using the instructions in
CONTRIBUTING.org
(https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
