### PR TITLE
Publish two new transitional MELPA channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ pull-package-build:
 # To build all channels use "unstable stable snapshots releases".
 # To fetch without building use "", which the "docker-build-fetch"
 # target does.  (Keep in sync with "docker/builder/run.sh".)
-DOCKER_CHANNELS ?= unstable stable
+DOCKER_CHANNELS ?= unstable stable snapshots releases
 
 # Only intended for "docker/builder/run.sh" and similar scripts.  That
 # is also why we add extra quoting when setting EMACS_EVAL, instead of

--- a/docker/builder/run.sh
+++ b/docker/builder/run.sh
@@ -4,7 +4,7 @@
 # - INHIBIT_PACKAGE_PULL
 # - INHIBIT_MELPA_PULL
 
-: ${DOCKER_CHANNELS="unstable stable"}
+: ${DOCKER_CHANNELS="unstable stable snapshots releases"}
 
 # Break taken between runs, in seconds.
 : ${BUILD_PAUSE=300}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - /mnt/volume/log:/mnt/store/log
       - /mnt/volume/log-stable:/mnt/store/log-stable
       - /mnt/volume/log-snapshots:/mnt/store/log-snapshots
+      - /mnt/volume/log-releases:/mnt/store/log-releases
     ports:
       - "80:80"
       - "443:443"
@@ -34,6 +35,7 @@ services:
       - /mnt/volume/log:/mnt/store/log:ro
       - /mnt/volume/log-stable:/mnt/store/log-stable:ro
       - /mnt/volume/log-snapshots:/mnt/store/log-snapshots:ro
+      - /mnt/volume/log-releases:/mnt/store/log-releases:ro
   syncer:
     build: ./syncer
     image: melpa/syncer:v2
@@ -50,3 +52,4 @@ services:
       - /mnt/volume/melpa/packages:/packages:ro
       - /mnt/volume/melpa/packages-stable:/packages-stable:ro
       - /mnt/volume/melpa/packages-snapshots:/packages-snapshots:ro
+      - /mnt/volume/melpa/packages-releases:/packages-releases:ro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - /mnt/volume/letsencrypt:/etc/letsencrypt
       - /mnt/volume/log:/mnt/store/log
       - /mnt/volume/log-stable:/mnt/store/log-stable
+      - /mnt/volume/log-snapshots:/mnt/store/log-snapshots
     ports:
       - "80:80"
       - "443:443"
@@ -32,6 +33,7 @@ services:
       - /mnt/volume/melpa:/mnt/store/melpa
       - /mnt/volume/log:/mnt/store/log:ro
       - /mnt/volume/log-stable:/mnt/store/log-stable:ro
+      - /mnt/volume/log-snapshots:/mnt/store/log-snapshots:ro
   syncer:
     build: ./syncer
     image: melpa/syncer:v2
@@ -47,3 +49,4 @@ services:
     volumes:
       - /mnt/volume/melpa/packages:/packages:ro
       - /mnt/volume/melpa/packages-stable:/packages-stable:ro
+      - /mnt/volume/melpa/packages-snapshots:/packages-snapshots:ro

--- a/docker/logprocessor/run.sh
+++ b/docker/logprocessor/run.sh
@@ -13,5 +13,8 @@ THIS_DIR=$(dirname "$0")
 # Snapshots
 "$THIS_DIR/buildstats" /mnt/store/log-snapshots /mnt/db/parquet-snapshots html-snapshots/download_counts.json
 
+# Releases
+"$THIS_DIR/buildstats" /mnt/store/log-releases /mnt/db/parquet-releases html-releases/download_counts.json
+
 echo "Sleeping"
 sleep 1800

--- a/docker/logprocessor/run.sh
+++ b/docker/logprocessor/run.sh
@@ -10,5 +10,8 @@ THIS_DIR=$(dirname "$0")
 # Stable
 "$THIS_DIR/buildstats" /mnt/store/log-stable /mnt/db/parquet-stable html-stable/download_counts.json
 
+# Snapshots
+"$THIS_DIR/buildstats" /mnt/store/log-snapshots /mnt/db/parquet-snapshots html-snapshots/download_counts.json
+
 echo "Sleeping"
 sleep 1800

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -162,6 +162,50 @@ server {
 	}
 }
 
+server {
+	listen 443 ssl;
+
+	server_name snapshots.melpa.org;
+
+	root /mnt/store/melpa/html-snapshots;
+
+	access_log /mnt/store/log-snapshots/melpa.access.log combined;
+	error_log /mnt/store/log-snapshots/melpa.error.log info;
+
+	ssl_certificate /etc/letsencrypt/live/melpa.org/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/melpa.org/privkey.pem;
+
+	# Lock down ciphers / SSL versions to attain a good security rating
+	# https://www.ssllabs.com/ssltest/analyze.html?d=melpa.org
+	ssl_protocols TLSv1.2 TLSv1.3;
+	ssl_dhparam /etc/letsencrypt/ssl/dhparam.pem;
+	ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+	ssl_session_timeout 1d;
+	ssl_session_cache shared:SSL:50m;
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	add_header Strict-Transport-Security max-age=15768000;
+	# Installing a set of packages is bursty
+
+	error_page 500 502 503 504 /50x.html;
+	location = /50x.html {
+		root /usr/share/nginx/html;
+	}
+	location = /packages/archive-contents {
+		default_type text/plain;
+		limit_req zone=ip burst=10 nodelay;
+	}
+	location ~ ^/packages/.*\.el {
+		default_type text/plain;
+	}
+	location ~ ^/packages/.*\.log {
+		default_type text/plain;
+	}
+	location ~ ^/packages/.*\.svg {
+		add_header Cache-Control no-cache;
+	}
+}
+
 # Local Variables:
 #   indent-tabs-mode: t
 # End:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -206,6 +206,50 @@ server {
 	}
 }
 
+server {
+	listen 443 ssl;
+
+	server_name releases.melpa.org;
+
+	root /mnt/store/melpa/html-releases;
+
+	access_log /mnt/store/log-releases/melpa.access.log combined;
+	error_log /mnt/store/log-releases/melpa.error.log info;
+
+	ssl_certificate /etc/letsencrypt/live/melpa.org/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/melpa.org/privkey.pem;
+
+	# Lock down ciphers / SSL versions to attain a good security rating
+	# https://www.ssllabs.com/ssltest/analyze.html?d=melpa.org
+	ssl_protocols TLSv1.2 TLSv1.3;
+	ssl_dhparam /etc/letsencrypt/ssl/dhparam.pem;
+	ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+	ssl_session_timeout 1d;
+	ssl_session_cache shared:SSL:50m;
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	add_header Strict-Transport-Security max-age=15768000;
+	# Installing a set of packages is bursty
+
+	error_page 500 502 503 504 /50x.html;
+	location = /50x.html {
+		root /usr/share/nginx/html;
+	}
+	location = /packages/archive-contents {
+		default_type text/plain;
+		limit_req zone=ip burst=10 nodelay;
+	}
+	location ~ ^/packages/.*\.el {
+		default_type text/plain;
+	}
+	location ~ ^/packages/.*\.log {
+		default_type text/plain;
+	}
+	location ~ ^/packages/.*\.svg {
+		add_header Cache-Control no-cache;
+	}
+}
+
 # Local Variables:
 #   indent-tabs-mode: t
 # End:

--- a/docker/nginx/logrotate
+++ b/docker/nginx/logrotate
@@ -58,6 +58,26 @@
 	endscript
 }
 
+/mnt/store/log-releases/melpa*.log {
+	daily
+	create 0640 root root
+	compress
+	dateext
+	missingok
+	missingok
+	notifempty
+	rotate 36500
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi; \
+	endscript
+	postrotate
+		[ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`
+	endscript
+}
+
 # Local Variables:
 #   indent-tabs-mode: t
 # End:

--- a/docker/nginx/logrotate
+++ b/docker/nginx/logrotate
@@ -38,6 +38,26 @@
 	endscript
 }
 
+/mnt/store/log-snapshots/melpa*.log {
+	daily
+	create 0640 root root
+	compress
+	dateext
+	missingok
+	missingok
+	notifempty
+	rotate 36500
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi; \
+	endscript
+	postrotate
+		[ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`
+	endscript
+}
+
 # Local Variables:
 #   indent-tabs-mode: t
 # End:

--- a/docker/nginx/run.sh
+++ b/docker/nginx/run.sh
@@ -43,6 +43,7 @@ while true; do
         --expand \
         -d melpa.org \
         -d stable.melpa.org \
+        -d snapshots.melpa.org \
         -d test.melpa.org \
         -d stable-test.melpa.org \
         -d www.melpa.org

--- a/docker/nginx/run.sh
+++ b/docker/nginx/run.sh
@@ -44,6 +44,7 @@ while true; do
         -d melpa.org \
         -d stable.melpa.org \
         -d snapshots.melpa.org \
+        -d releases.melpa.org \
         -d test.melpa.org \
         -d stable-test.melpa.org \
         -d www.melpa.org

--- a/docker/rsyncd/rsyncd.conf
+++ b/docker/rsyncd/rsyncd.conf
@@ -15,3 +15,10 @@ path = /packages-stable
 read only = yes
 list = yes
 exclude = index.html *.svg *.entry
+
+[packages-snapshots]
+comment = MELPA Snapshots
+path = /packages-snapshots
+read only = yes
+list = yes
+exclude = index.html *.svg *.entry

--- a/docker/rsyncd/rsyncd.conf
+++ b/docker/rsyncd/rsyncd.conf
@@ -22,3 +22,10 @@ path = /packages-snapshots
 read only = yes
 list = yes
 exclude = index.html *.svg *.entry
+
+[packages-releases]
+comment = MELPA Releases
+path = /packages-releases
+read only = yes
+list = yes
+exclude = index.html *.svg *.entry

--- a/docker/syncer/run.sh
+++ b/docker/syncer/run.sh
@@ -3,6 +3,7 @@
 CHANNEL=unstable  make archive-contents json html
 CHANNEL=stable    make archive-contents json html
 CHANNEL=snapshots make archive-contents json html
+CHANNEL=releases  make archive-contents json html
 
 # Sync every 5 minutes.
 sleep 5m

--- a/docker/syncer/run.sh
+++ b/docker/syncer/run.sh
@@ -2,6 +2,7 @@
 
 CHANNEL=unstable  make archive-contents json html
 CHANNEL=stable    make archive-contents json html
+CHANNEL=snapshots make archive-contents json html
 
 # Sync every 5 minutes.
 sleep 5m


### PR DESCRIPTION
This adds two new MELPA channels, named MELPA `snapshots` and MELPA `releases`.  These channels are intended to *eventually* replace the two existing channels MELPA (unnamed, aka "unstable") and MELPA `stable`.  The plan is to keep the existing channels available for quite some time; the current thinking is a year or so.  Users can switch to the new channels once they are ready to make the transition.

We will also open a tracker issue with more details and post an announcement.  This pull-request is mainly intended for the people who actually review the changes it introduces.

Just on detail up front: the new `snapshots` channel uses version strings of the form `RELEASE.0.DATE.COUNT`, which is the same format as (Non)GNU-devel ELPA started using a few weeks ago, and IMO a huge improvement over the old `DATE.TIME` format, that the existing MELPA ("unstable") channel uses.

----

This pull-requests consists of two parts.

1. The last commit `Publish "snapshots" and "releases" channels` activates building and distribution of the new channels.

   This could be applied without also applying the other two commits.  Doing so would make the new channels available to `package.el` and other package managers, but no web pages would be published for the new channels.
   
2. The other two commits arrange for the web pages of two new channels to be published.

   Everywhere nginx, logrotate and rsyncd are told to "do X for stable" and "do X for unstable", this adds "do X for releases" and "do X for snapshots".  So what has to be reviewed is whether such a place was overlooked and whether I made a typo when replacing the name of one channel with that of another.
   
   These are not the only commits that are necessary to publish the pages for the new channels, but the other relevant commits have already been merged into `master` a long time ago.
   
   So maybe you might also want to review these earlier commits:
   
   - 3df882d55e00405dd40316431809ee86d449ce64
   - 0eb4c5156848d2334f440d0d4d295c4826b8590a
   - ae07c9731f2aade130ff48a75787d68368a6188f
   
   The first of these copies a lot of symlinks from the html folder of an old channel to the new folders to be used for the two new channels.  Given the current machinery, this boilerplate has to exist for each channel individually.  The second commit fixes the names of two symlinks.  And the third changes makes the names of the new channels plural.
   
   When reviewing these changes, it might be better to compare the contents of two directories directly, using an appropriate tool in a terminal or emacs, instead of looking at a sequence of commits on a web page.  Any found issues, should of course be reported here, but feel free to push fixup commits yourself.

(We know that the new web pages require further work.  E.g., there aren't any links to the pages of the new channels yet, and the documentation has to be updated.  Such changes are not intended to be part of this pull-request, and will be worked on after this has been merged.)