### PR TITLE
Add recipe for hutch

### DIFF
--- a/recipes/hutch
+++ b/recipes/hutch
@@ -1,0 +1,1 @@
+(hutch :fetcher github :repo "adjaecent/magit-hutch")


### PR DESCRIPTION
### Brief summary of what the package does

An Emacs-local code-review agent that runs alongside Magit. Invoke it from any magit-diff buffer to get LLM-generated patch suggestions you can accept or reject inline.

The repository name is intentionally `magit-hutch` to establish its relationship with Magit, but the package name does not have any conflicting names, and is simply `hutch` as the official name.

**Note:** the `with-eval-after-load 'magit` in `hutch.el:52` is the standard `;;;###autoload`-wrapped pattern for extending Magit's transient. It's wrapped in the autoload cookie so it fires at activation, deferred via `with-eval-after-load` until Magit loads. Same pattern as `magit-todos` etc. Calling this out upfront because `package-lint` flags it as a warning.

### Direct link to the package repository

https://github.com/adjaecent/magit-hutch

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
