### PR TITLE
Add recipe for pimacs

### DIFF
--- a/recipes/pimacs
+++ b/recipes/pimacs
@@ -1,0 +1,1 @@
+(pimacs :fetcher github :repo "ananthakumaran/pimacs.el")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

Emacs client for [Pi Coding Agent](https://pi.dev/)

### Direct link to the package repository

https://github.com/ananthakumaran/pimacs.el

### Your association with the package

maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->

I fixed most of the issues reported by melpazoid
1) I have documented all the public functions, remaining warnings are from private functions.
2) Regarding package name, I see there is potential conflict with couple of packages [pi](https://github.com/melpa/melpa/pull/10055) and pi-coding-agent. I am not sure what should be done here. I personally prefer to keep `pi` and if `pi-coding-agent` follows the prefix, it shouldn't conflict with mine.