### PR TITLE
Add recipe for magnus-bridge

### DIFF
--- a/recipes/magnus-bridge
+++ b/recipes/magnus-bridge
@@ -1,3 +1,3 @@
 (magnus-bridge :fetcher github
                :repo "hrishikeshs/magnus-bridge"
-               :files ("*.el" "pwa"))
+               :files ("magnus-bridge.el"))

--- a/recipes/magnus-bridge
+++ b/recipes/magnus-bridge
@@ -1,0 +1,3 @@
+(magnus-bridge :fetcher github
+               :repo "hrishikeshs/magnus-bridge"
+               :files ("*.el" "pwa"))


### PR DESCRIPTION
### Brief summary of what the package does

magnus-bridge lets you chat with your [Magnus](https://github.com/hrishikeshs/magnus)-managed Claude Code agents from your phone. It runs a small HTTP server inside Emacs serving a chat PWA over a tailnet-only HTTPS URL (via `tailscale serve`) — message agents, watch their replies stream back, approve permission prompts with tappable buttons, send photos agents can Read, with typing indicators and history that survives Emacs restarts. No third-party service intermediates the traffic: the user's editor, their WireGuard tailnet, their agents. The PWA assets ship in-package via `:files` (same pattern as `skewer-mode` and `org-roam-ui`).

### Direct link to the package repository

https://github.com/hrishikeshs/magnus-bridge

### Your association with the package

Author and maintainer (same as `magnus`, already on MELPA).

### Relevant communications with the upstream package maintainer

**None needed.**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (MIT)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (0 findings across all files)
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

> **Note on the age checkbox:** the repository was created **2026-07-01**, so it does not yet meet the "1 month or more" requirement — I've left that box unchecked. It reaches one month on **2026-08-01**; happy to have the recipe reviewed then, or sooner at your discretion. Everything else is ready now.
