### PR TITLE
Add recipe for mise-tasks

### DIFF
--- a/recipes/mise-tasks
+++ b/recipes/mise-tasks
@@ -1,0 +1,3 @@
+(mise-tasks
+ :fetcher github
+ :repo "klochowicz/mise-tasks.el")


### PR DESCRIPTION
### Brief summary of what the package does

`mise-tasks` discovers, runs, and cancels [mise](https://mise.jdx.dev) tasks from inside Emacs, with a `compilation-mode` buffer per project. It complements the existing mise env-injection packages (`mise.el`, `gmise`, `emacs-misery`), none of which run tasks, and integrates with Projectile and Spacemacs. It also provides monorepo task discovery and lockfile syntax highlighting.

### Direct link to the package repository

https://github.com/klochowicz/mise-tasks.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed** (I am the upstream maintainer).

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
