### PR TITLE
Add recipe for denote-solo

### DIFF
--- a/recipes/denote-solo
+++ b/recipes/denote-solo
@@ -1,0 +1,3 @@
+(denote-solo
+ :fetcher github
+ :repo "pavlo/denote-solo")


### PR DESCRIPTION
### Brief summary of what the package does

Provides workspace-like switching between Denote silos (note directories). Keeps exactly one directory active at a time - the "solo" - remembered across sessions and shown in the mode line. Unlike denote-silo, which prompts for a directory on every command, denote-solo lets you switch once and stay there until you switch again. The previous solo is pre-selected in the prompt for quick toggling between two directories.

### Direct link to the package repository

https://github.com/pavlo/denote-solo

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed. I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

