### PR TITLE
Fix recipes/dicom: Include missing shell scripts

### DIFF
--- a/recipes/dicom
+++ b/recipes/dicom
@@ -1,3 +1,4 @@
 (dicom
  :fetcher github
- :repo "minad/dicom")
+ :repo "minad/dicom"
+ :files (:defaults "*.sh"))


### PR DESCRIPTION
This PR updates the recipe of the dicom.el package, since it misses a shell script. The package uses the script to convert DICOM images to pngs, which can be consumed by Emacs. Initially I had implemented the image conversion fully in Elisp, but things got more complicated, and a shell script turned out to be the better solution for the background conversion process. I am the author and maintainer of dicom.el. I learned about the missing script in the package, when I revisited #8287 in a discussion with @tarsius.