### PR TITLE
Update lirve recipe: repository moved

### DIFF
--- a/recipes/lirve
+++ b/recipes/lirve
@@ -1,1 +1,1 @@
-(lirve :repo "tanrax/lirve.el" :fetcher github)
+(lirve :fetcher git :url "https://git.andros.dev/andros/lirve.el")


### PR DESCRIPTION
The lirve.el repository has moved from GitHub to my self-hosted Forgejo instance: https://git.andros.dev/andros/lirve.el

I am the author and maintainer of the package.