### PR TITLE
Add recipe for emagent

### DIFF
--- a/recipes/emagent
+++ b/recipes/emagent
@@ -1,0 +1,4 @@
+(emagent
+ :fetcher github
+ :repo "etyurkin/emagent"
+ :files ("emagent.el" "lisp/*/*.el"))


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

emagent is an Emacs-native ACP (Agent Client Protocol) chat client. It talks to external coding agents such as cursor-agent-acp and claude-agent-acp and executes Emacs-side operations locally through org-mode scratch buffers.

### Direct link to the package repository

https://github.com/etyurkin/emagent

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->

### Notes

The recipe's `:files` clause (`"emagent.el" "lisp/*/*.el"`) is required because modules live under `lisp/<subdir>/`. Filenames are globally unique, so the flattened build has no collisions; a flattened install byte-compiles and `(require 'emagent)` loads all entry points.

Upstream compliance (v1.2.3):
- `;; Assisted-by: Cursor:claude-sonnet-4.6` on recipe files
- MIT license comment boilerplate above Commentary in every Melpa recipe `.el`
- `checkdoc` clean on `emagent.el` + `lisp/**/*.el` (gated by `make checkdoc` / `make ci`)
- `package-lint` clean; `make compile-strict` (warnings-as-errors) clean
- Face specs use `:inherit` without attribute overrides
- Verified with `make recipes/emagent`, `CHANNEL=stable make recipes/emagent`, and `package-install-file`