### PR TITLE
Add recipe for org-history

### DIFF
--- a/recipes/org-history
+++ b/recipes/org-history
@@ -1,0 +1,1 @@
+(org-history :fetcher github :repo "Anoncheg1/emacs-org-history")


### PR DESCRIPTION
Re-open of https://github.com/melpa/melpa/pull/10050 old pull request. Reason for reject: 1 month didn't pass.

At may 23 first commit was made. It is 7 jul now. v0.4 stable. Time has come. :)



### Brief summary of what the package does

Show Dates column in Org for headers from git VCS + auto-commit with --amend per day 

This package allows to:
1) Attach the dates of the last modification to Org headers as non-editable overlays.
2) Auto-commit with --amend once per day.
3) Request your confirmation only once.
4) Accurately save your answer to the .dir-locals.el file in the current directory.

<img src="https://raw.githubusercontent.com/Anoncheg1/public-share/main/org-history.png" alt="Description" width="50%">

### Direct link to the package repository

https://github.com/Anoncheg1/emacs-org-history

### Your association with the package

Author, maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [X] The package has been maintained in a public repository for 1 month or more
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
