### PR TITLE
Add recipe for sema-mode

### DIFF
--- a/recipes/sema-mode
+++ b/recipes/sema-mode
@@ -1,0 +1,1 @@
+(sema-mode :repo "sema-lisp/emacs-sema" :fetcher github)

--- a/recipes/sema-mode
+++ b/recipes/sema-mode
@@ -1,1 +1,4 @@
-(sema-mode :repo "sema-lisp/emacs-sema" :fetcher github)
+(sema-mode
+ :fetcher github
+ :repo "sema-lisp/emacs-sema"
+ :files ("*.el"))

--- a/recipes/sema-mode
+++ b/recipes/sema-mode
@@ -1,4 +1,3 @@
 (sema-mode
  :fetcher github
- :repo "sema-lisp/emacs-sema"
- :files ("*.el"))
+ :repo "sema-lisp/emacs-sema")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!-- Please use "Add recipe for name-of-package" as the title. -->
<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                -->

### Brief summary of what the package does

`sema-mode` is a major mode for editing [Sema](https://sema-lang.com) — a Lisp
dialect with first-class LLM primitives. It provides syntax highlighting,
Sema-aware indentation, comment/bracket handling, a comint-based REPL, and an
`sema-register-with-eglot` helper that registers Sema's language server
(`sema lsp`) with eglot.

### Direct link to the package repository

https://github.com/sema-lisp/emacs-sema

### Your association with the package

Author and maintainer (I also maintain the Sema language itself).

### Relevant communications with the upstream package maintainer

**None needed** — I am the upstream maintainer.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (MIT).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->

---

On the 1-month item: `sema-mode` was maintained publicly for ~5 months inside
the main Sema monorepo ([sema-lisp/sema](https://github.com/sema-lisp/sema),
public since 2026-02) at `editors/emacs/sema-mode.el`, and was recently split
into its own repository
([sema-lisp/emacs-sema](https://github.com/sema-lisp/emacs-sema)) for MELPA
packaging.

Follow-ups from review:
- Replaced the top-level `with-eval-after-load 'eglot` side effect with an
  autoloaded `sema-register-with-eglot` function; usage is now documented in the
  Commentary (`(with-eval-after-load 'eglot #'sema-register-with-eglot)`), so
  eglot registration stays explicit. `package-lint` is now clean.
- Reordered the recipe to put `:fetcher` before `:repo`.
- Added an `Assisted-by:` line under the Author header.
