### PR TITLE
Add recipe for keycoach

### DIFF
--- a/recipes/keycoach
+++ b/recipes/keycoach
@@ -1,0 +1,1 @@
+(keycoach :fetcher github :repo "mrcnski/keycoach")


### PR DESCRIPTION
### Brief summary of what the package does

Provides `global-keycoach-mode`, a minor mode that helps you learn your keybindings: it shows the keys you want to practice in a configurable indicator (mode-line, frame title, etc.), removes each key from the display once you actually type it, and optionally signals an error when you invoke a learned command some other way (e.g. via `M-x`).

### Direct link to the package repository

https://github.com/mrcnski/keycoach

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed** (I am the author).

**Note:** I previously submitted this package in #8870 and closed it myself, because at the time I wasn't committed to maintaining it (the README even said so). That has changed: since then the package has seen active development (tagged releases, ERT tests, CI byte-compiling and testing across Emacs 25.3 through snapshot, and a changelog) and I'm committed to maintaining it going forward.

**Note:** this package was submitted as `keys` and has been renamed to `keycoach` per the review feedback below. The repository moved to https://github.com/mrcnski/keycoach and every symbol now uses the `keycoach-` prefix.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
