### PR TITLE
Add recipe for pyfun-mode

### DIFF
--- a/recipes/pyfun-mode
+++ b/recipes/pyfun-mode
@@ -1,0 +1,4 @@
+(pyfun-mode
+ :fetcher github
+ :repo "simontreanor/Pyfun"
+ :files ("editors/emacs/pyfun-mode.el"))


### PR DESCRIPTION
### Brief summary of what the package does

`pyfun-mode` is a major mode for [Pyfun](https://github.com/simontreanor/Pyfun), an F#-inspired, functional-first language that compiles to readable Python. It provides syntax highlighting, comment support, and (on Emacs 29+) eglot integration with the language server that ships in the Pyfun compiler (`pip install pyfun-lang` puts `pyfun` on PATH; the mode registers `pyfun lsp` with eglot).

### Direct link to the package repository

https://github.com/simontreanor/Pyfun

The package lives at `editors/emacs/pyfun-mode.el`; the recipe's `:files` spec selects only that file. The repository is Apache-2.0 licensed (GPLv3-compatible), with the license boilerplate in the file header.

### Your association with the package

I am the author and maintainer of both the package and the upstream Pyfun compiler.

### Relevant communications with the upstream package maintainer

None needed (same person).

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (Apache-2.0)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more — being upfront: the Pyfun repository is public since 2026-06-18 (just under a month) and `pyfun-mode.el` itself is recent; the compiler and its LSP that the mode fronts have been under active development and releases (currently v0.0.9 on PyPI) for that period. Happy to wait if you'd prefer more soak time.
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback — one remaining warning: `with-eval-after-load` at the eglot registration (`(with-eval-after-load 'eglot (add-to-list 'eglot-server-programs ...))`). I kept it because it only registers the server command for `pyfun-mode` buffers and doesn't change behavior for users who don't invoke eglot; glad to change the approach if you prefer.
- [x] My elisp byte-compiles cleanly (Emacs 30.2 on Windows, `emacs -Q --batch -f batch-byte-compile`)
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe) — `make` isn't available on this Windows machine, so I ran the exact `emacs --batch` invocation the `recipes/<NAME>` make target expands to (unstable channel, package-build from this repo): the package builds cleanly, and the resulting tar installs via `package-install-file` and loads. I also verified the stable channel detects the latest tag (v0.0.9) correctly; note `pyfun-mode.el` post-dates that tag, so MELPA Stable will pick the package up from the next upstream release tag onward. Beyond the sandbox, I've driven the mode interactively (font-lock and eglot attach against `pyfun lsp`) on Windows Emacs 30.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
