### PR TITLE
Add recipe for context-clues

### DIFF
--- a/recipes/context-clues
+++ b/recipes/context-clues
@@ -1,0 +1,1 @@
+(context-clues :fetcher github :repo "mrcnski/context-clues")


### PR DESCRIPTION
### Brief summary of what the package does

Provides `M-x context-clues`, a transient menu for copying context about point and the current buffer to the kill ring: file name, project-relative and absolute paths (plain or with line number), git branch, the function at point, etc. Every entry shows a live preview of the value it would copy.

Handy for pasting precise context into LLM agents, issues, or chat.

Related work: [file-info.el](https://github.com/Artawower/file-info.el) shows a similar label/value popup, but is oriented toward metadata about the visited *file* (size, mode, owner, VC info). context-clues is about the current *context of point* (line, function, git branch), with only `transient` (a core package) as a dependency instead of hydra.

### Direct link to the package repository

https://github.com/mrcnski/context-clues

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed** (I am the author).

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
