### PR TITLE
Fix elfeed-web

### DIFF
--- a/recipes/elfeed-web
+++ b/recipes/elfeed-web
@@ -1,1 +1,4 @@
-(elfeed-web :fetcher github :repo "emacs-elfeed/elfeed-web")
+(elfeed-web
+ :fetcher github
+ :repo "emacs-elfeed/elfeed-web"
+ :files (:defaults "*.html"))


### PR DESCRIPTION
index.html file is missing in the MELPA package build.

cc @tarsius This is another recipe where a file is missing, like in #10077.

(I am the maintainer of elfeed-web.)