### PR TITLE
Add recipe for magent

### DIFF
--- a/recipes/magent
+++ b/recipes/magent
@@ -1,0 +1,1 @@
+(magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/*.el" "prompt" "skills" "capabilities"))

--- a/recipes/magent
+++ b/recipes/magent
@@ -1,1 +1,1 @@
-(magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/*.el" "prompts" "skills" "capabilities"))
+(magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/magent*.el" "prompts" "skills" "capabilities"))

--- a/recipes/magent
+++ b/recipes/magent
@@ -1,1 +1,1 @@
-(magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/*.el" "prompt" "skills" "capabilities"))
+(magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/*.el" "prompts" "skills" "capabilities"))

--- a/recipes/magent
+++ b/recipes/magent
@@ -1,1 +1,1 @@
-(magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/magent*.el" "prompts" "skills" "capabilities"))
+(magent :fetcher github :repo "Jamie-Cui/magent" :files ("lisp/magent*.el" "prompts" "skills"))


### PR DESCRIPTION
### Brief summary of what the package does

Magent is an Emacs-native AI coding agent built on gptel and presented through agent-shell using an in-process ACP adapter. It provides project-scoped sessions, streaming responses, specialized agents, permission-controlled tools, skills, Actions, and multi-agent workflows while leaving provider and HTTP transport to gptel.

The explicit files list packages every production Magent library together with the bundled prompts, skills, and capabilities that Magent loads at runtime.

### Direct link to the package repository

https://github.com/Jamie-Cui/magent

### Your association with the package

I am the author and maintainer of Magent.

### Relevant communications with the upstream package maintainer

None needed; I am the upstream package author and maintainer.

### Validation

- The MELPA recipe CI passes with `lisp/magent*.el`, `prompts`, `skills`, and `capabilities` packaged explicitly.
- Upstream commit `acbba50` passes byte compilation, declaration and package lint on Emacs 29.4 and 30.1, 568 ERT unit tests, deterministic live smoke tests, coverage, and melpazoid.
- `check-declare` covers every production Elisp module, including generated external accessors, and melpazoid checks the packaged source and runtime data.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and I've added `Assisted-by:` lines as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
