### PR TITLE
Add recipe for gruber-darker-ayu-theme

### DIFF
--- a/recipes/gruber-darker-ayu-theme
+++ b/recipes/gruber-darker-ayu-theme
@@ -1,0 +1,3 @@
+(gruber-darker-ayu-theme
+ :repo "Hadi493/gruber-darker-ayu-theme"
+ :fetcher github)

--- a/recipes/gruber-darker-ayu-theme
+++ b/recipes/gruber-darker-ayu-theme
@@ -1,3 +1,3 @@
 (gruber-darker-ayu-theme
- :repo "Hadi493/gruber-darker-ayu-theme"
- :fetcher github)
+ :fetcher github
+ :repo "Hadi493/gruber-darker-ayu-theme")


### PR DESCRIPTION
### Brief summary of what the package does

A blend of Gruber Darker's deep #181818 background with Ayu Dark's warm, high-contrast syntax palette. Provides faces for Avy, Company, Compilation, Consult, Corfu, Diff, Dired, Doom Modeline, Ediff, Eglot, Flycheck, Flymake, Font Lock, Git Gutter, Magit, Marginalia, Markdown, Mode Line, Multiple Cursors, Orderless, Org, Org Roam, PDF Tools, Rainbow Delimiters, Tab Bar, Transient, Vertico, Which Key, Whitespace, Yasnippet, and more.

### Direct link to the package repository

https://github.com/Hadi493/gruber-darker-ayu-theme

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)