### PR TITLE
Add recipe for makinda-icons

### DIFF
--- a/recipes/makinda-icons
+++ b/recipes/makinda-icons
@@ -1,0 +1,4 @@
+(makinda-icons
+  :fetcher github
+  :repo "makinda-jackson/makinda-icons"
+  :files ("packages/emacs/makinda-icons.el"))

--- a/recipes/makinda-icons
+++ b/recipes/makinda-icons
@@ -2,3 +2,4 @@
   :fetcher github
   :repo "makinda-jackson/makinda-icons"
   :files ("packages/emacs/makinda-icons.el"))
+


### PR DESCRIPTION
### Brief summary of what the package does

Makinda Icons is a file-icon overlay for `nerd-icons.el`, mapping 84 file types to Nerd Font glyphs with Makinda palette colors. Supports dark and light terminal themes — light-theme icon colors use `#8b949e` (visible on both themes). Companion packages exist for VS Code, JetBrains, Neovim, Sublime Text, and Visual Studio.

### Direct link to the package repository

https://github.com/makinda-jackson/makinda-icons

### Your association with the package

I am the maintainer and sole author of this package.

### Relevant communications with the upstream package maintainer

**None needed** — I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- Previous PR #10003 closed: repo was < 1 month old. Repo is now public since May 2026 (2+ months). All checklist items verified locally. -->