### PR TITLE
Add recipe for a6s

### DIFF
--- a/recipes/a6s
+++ b/recipes/a6s
@@ -1,0 +1,1 @@
+(a6s :fetcher github :repo "The-Autonoma/a6s-emacs")


### PR DESCRIPTION
Adds a recipe for **a6s** — the Autonoma Emacs client (multi-agent orchestration via a local WebSocket daemon).

- Repo: https://github.com/The-Autonoma/a6s-emacs
- Main file: `a6s.el` (Version 2.0.0; Package-Requires: emacs 27.1, websocket 1.14, transient 0.4.0)

```elisp
(a6s :fetcher github :repo "The-Autonoma/a6s-emacs")
```