### PR TITLE
Add recipe for elfeed-protocol-freshrss

### DIFF
--- a/recipes/elfeed-protocol-freshrss
+++ b/recipes/elfeed-protocol-freshrss
@@ -1,0 +1,3 @@
+(elfeed-protocol-freshrss
+ :fetcher codeberg
+ :repo "lou/elfeed-protocol-freshrss")


### PR DESCRIPTION
### Brief summary of what the package does

The package adds support for FreshRSS' greader-protocol implementation to elfeed-protocol, making it possible to sync elfeed with a FreshRSS instance.

### Direct link to the package repository

https://codeberg.org/lou/elfeed-protocol-freshrss

### Your association with the package

I forked [this](https://gitlab.com/bricka/elfeed-protocol-theoldreader) greader-protocol implementation, adapted and extended it for use with FreshRSS and am maintaining the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback. (I've run it, it tells me none of my dependencies is installable, which is clearly not true?)
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)