### PR TITLE
Add recipe for objectscript-ts-mode

### DIFF
--- a/recipes/objectscript-ts-mode
+++ b/recipes/objectscript-ts-mode
@@ -1,0 +1,3 @@
+(objectscript-ts-mode
+ :fetcher github
+ :repo "intersystems/emacs-objectscript-ts-mode")


### PR DESCRIPTION
### Brief summary of what the package does
This package provides a major mode for ObjectScript powered by tree-sitter.

### Direct link to the package repository
https://github.com/intersystems/emacs-objectscript-ts-mode

### Your association with the package
I am the author.

### Relevant communications with the upstream package maintainer
None needed.
### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [X] The package has been maintained in a public repository for 1 month or more
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->
