### PR TITLE
Add recipe for stops

### DIFF
--- a/recipes/stops
+++ b/recipes/stops
@@ -1,0 +1,3 @@
+(stops
+ :fetcher github
+ :repo "k3jph/stops-el")


### PR DESCRIPTION
### Brief summary of what the package does

Stops provides two small guard macros for Emacs Lisp.

- `stops-if!` signals an error when a condition is non-nil.
- `stops-if-not!` signals an error when a condition is nil.

Both macros support custom error types and messages and return `t` when the guard passes.

### Direct link to the package repository

https://github.com/k3jph/stops-el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a GPL-compatible free software license
- [x] I've read `CONTRIBUTING.org`
- [x] I've used the latest version of `package-lint` to check for packaging issues and addressed its feedback
- [x] My Elisp byte-compiles cleanly
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used `checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in `CONTRIBUTING.org`
- [x] LLMs were used to generate some of the code, and I've added an `Assisted-by:` line as described in `CONTRIBUTING.org`