### PR TITLE
Add recipe for ob-agent-shell

### DIFF
--- a/recipes/ob-agent-shell
+++ b/recipes/ob-agent-shell
@@ -1,0 +1,1 @@
+(ob-agent-shell :fetcher github :repo "eddof13/ob-agent-shell")


### PR DESCRIPTION
### Brief summary of what the package does

`ob-agent-shell` is an Org Babel backend for [agent-shell](https://github.com/xenodium/agent-shell). It lets you execute `#+begin_src agent-shell` blocks against a running agent-shell buffer and capture the agent response as the block result.

### Direct link to the package repository

https://github.com/eddof13/ob-agent-shell

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed. This is a separate package that depends on public `agent-shell` APIs already on MELPA (`agent-shell-shell-buffer`, `agent-shell-goto-last-interaction`, `agent-shell-interaction-at-point`).

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

### Verification notes

- `package-lint-batch-and-exit` → exit 0
- `checkdoc-current-buffer` → no style warnings
- `batch-byte-compile` → clean (with deps available)
- `make recipes/ob-agent-shell` → snapshot tarball builds
- `make CHANNEL=stable recipes/ob-agent-shell` → `ob-agent-shell-0.2.0.tar` from tag `v0.2.0`
- `package-install-file` on the built tarball → feature loads; `org-babel-execute:agent-shell` bound
- Public repo since 2026-04-24 (~91 days)
- LICENSE + GPL-3.0-or-later header boilerplate; GitHub license detection: GPL-3.0
- `;; Assisted-by: Claude Code` under Author (Claude used during development)