### PR TITLE
Add recipe for org-relative-date

### DIFF
--- a/recipes/org-relative-date
+++ b/recipes/org-relative-date
@@ -1,0 +1,1 @@
+(org-relative-date :fetcher github :repo "RobertPlant/org-relative-date")


### PR DESCRIPTION
### Brief summary of what the package does

`org-relative-date` paints a live "(N days away)" / "(N days ago)" annotation
*after* every Org timestamp, without modifying the buffer. It uses an
`after-string` overlay (so the raw `<2027-01-09 Sat>` stays visible and editable),
scans lazily via `jit-lock`, and refreshes counts daily so they don't go stale.
Org's agenda shows relative days only in the agenda buffer; this shows them inline
in the file.

Related: this is a spiritual successor to my earlier
[`time-uuid-mode`](https://github.com/RobertPlant/time-uuid-mode) (already on
MELPA), which overlaid relative times onto UUIDv1 timestamps — same overlay
technique, applied here to Org timestamps.

### Direct link to the package repository

https://github.com/RobertPlant/org-relative-date

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed — I am the maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (GPL-3.0-or-later)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe) (built on both channels — `make recipes/org-relative-date` and `make CHANNEL=stable …` correctly detects tag `0.1.0` — then installed the tarball via `package-install-file`)

