### PR TITLE
Update upstream for password-store

### DIFF
--- a/recipes/password-store
+++ b/recipes/password-store
@@ -1,4 +1,3 @@
-(password-store :fetcher github
-                :repo "zx2c4/password-store"
+(password-store :fetcher git
+                :url "https://git.zx2c4.com/password-store"
                 :files ("contrib/emacs/*.el"))
-

--- a/recipes/password-store
+++ b/recipes/password-store
@@ -1,3 +1,3 @@
 (password-store :fetcher git
                 :url "https://git.zx2c4.com/password-store"
-                :files ("contrib/emacs/*.el"))
+                :files ("contrib/emacs/password-store*.el"))


### PR DESCRIPTION
The [GitHub mirror for password-store](https://github.com/zx2c4/password-store) is read only and has been for some time (uses 1.7.4, upstream is now on [2.3.3](https://git.zx2c4.com/password-store/tree/contrib/emacs/password-store.el)).

This switches the recipe to use up-stream rather than the mirror.

