### PR TITLE
Add recipe for now-playing

### DIFF
--- a/recipes/now-playing
+++ b/recipes/now-playing
@@ -1,0 +1,4 @@
+(now-playing
+ :fetcher github
+ :repo "kickingvegas/now-playing"
+ :files (:defaults "docs/images"))


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!--  ╔════════════╤════════════════════════════════╤═══════════════╗  -->
<!--  ║ Please use │ Add recipe for name-of-package │ as the title. ║  -->
<!--  ╚════════════╧════════════════════════════════╧═══════════════╝  -->

### Brief summary of what the package does

**now-playing.el** is an Emacs [Transient](https://docs.magit.vc/transient/) interface for the macOS [Music app](https://en.wikipedia.org/wiki/Music_%28app%29).

### Direct link to the package repository

https://github.com/kickingvegas/now-playing

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->
