### PR TITLE
Move sol-mode from Codeberg to GitHub

### DIFF
--- a/recipes/sol-mode
+++ b/recipes/sol-mode
@@ -1,1 +1,1 @@
-(sol-mode :fetcher codeberg :repo "nlordell/sol-mode")
+(sol-mode :fetcher github :repo "nlordell/sol-mode")


### PR DESCRIPTION
### Description

Codeberg recently updated their ToC to disallow "cryptocurrency related projects". The ToC is unfortunately very vague, and makes it unclear whether or not an Emacs major mode for editing Solidity code (which is very much cryptocurrency related) falls under this category. As a precaution, I am moving the repository to GitHub, and wanted to update the MELPA recipe to reflect this.

The actual package code has not changed compared to the code currently hosted on Codeberg. As soon as this merges, I will _delete_ the repository on Codeberg (to avoid ToC violations).

### Direct link to the package repository

<https://github.com/nlordell/sol-mode>

Old package can be found here: <https://codeberg.org/nlordell/sol-mode>.

### Your association with the package

I am the maintainer.

(signed commit: https://codeberg.org/nlordell/sol-mode/commit/0d66f4ea4a113520e17ed60ddc237395392402e9). Let me know if any additional proof is needed.

