### PR TITLE
Add recipe for nightpanel-theme

### DIFF
--- a/recipes/nightpanel-theme
+++ b/recipes/nightpanel-theme
@@ -1,0 +1,1 @@
+(nightpanel-theme :fetcher github :repo "gregfelice/nightpanel-theme")


### PR DESCRIPTION
### Brief summary of what the package does

`nightpanel-theme` is a dark theme modelled on a Saab instrument cluster seen at
night: a pure black canvas (`#0A0A0A`), instrument-scale green for body text,
and amber reserved for things that would be a needle or a warning lamp — search
matches, strings, constants, TODO keywords. Red appears only for genuine errors.
Comments and inactive chrome recede to a dim green so the code itself is the
brightest thing on screen.

Single file, no dependencies beyond Emacs 27.1 (the floor comes from the
`tab-bar` and `tab-line` faces it styles).

### Direct link to the package repository

https://github.com/gregfelice/nightpanel-theme

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed** — I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

### Notes on the unchecked box

Being upfront: the public repository is **new**, so the one-month item is not
yet true and I have left it unchecked rather than tick it. The theme itself has
been in use privately for some time; only its public packaging is recent. Happy
to have this held or closed and resubmitted once it has aged, if that is the
preference.

On the `Assisted-by` line: the face definitions are mine. An AI assistant was
used for the packaging work around them — header block, license boilerplate,
autoload cookie, commentary and README — and I reviewed all of it. Attribution
is in the file per the CONTRIBUTING guidance.

### Build verification

Both channels build locally from a clean checkout:

```
make recipes/nightpanel-theme                 -> nightpanel-theme-20260801.22.tar
make CHANNEL=stable recipes/nightpanel-theme  -> nightpanel-theme-0.1.0.tar
```

`package-lint`, `checkdoc`, and byte-compilation are all clean, and the package
installs and activates via `package-install-file` followed by
`(load-theme 'nightpanel t)`.
