### PR TITLE
Add recipe for bitbucket-devops

### DIFF
--- a/recipes/bitbucket-devops
+++ b/recipes/bitbucket-devops
@@ -1,0 +1,3 @@
+(bitbucket-devops
+ :fetcher github
+ :repo "will-abb/bitbucket-devops.el")


### PR DESCRIPTION
### Brief summary of what the package does

`bitbucket-devops` provides an Emacs interface for Bitbucket Cloud Pipelines
and pull-request workflows.

It supports browsing pipeline history, viewing pipeline details and logs,
watching pipeline progress, triggering and canceling pipelines, running manual
steps, rerunning failed pipelines, and working with pull requests, builds,
comments, activity, commits, diffs, reviewers, inline comments, merges, and
declines.

The main entry point is `M-x bitbucket-devops-dispatch`. Repository context is
derived from the current Git repository's SSH remote, and credentials are read
through Emacs `auth-source`.

The package supports Bitbucket Cloud. Bitbucket Data Center is not supported.

### Direct link to the package repository

https://github.com/will-abb/bitbucket-devops.el

### Your association with the package

I am the package author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed.** I am the upstream package maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)