### PR TITLE
Add recipe for promptu

### DIFF
--- a/recipes/promptu
+++ b/recipes/promptu
@@ -1,0 +1,1 @@
+(promptu :fetcher github :repo "mrcnski/promptu.el")


### PR DESCRIPTION
Resubmitting #10108, which was closed pending the 30-day requirement.

`mrcnski/promptu.el` has been public since 2026-06-28, so it passed the 30-day mark on
2026-07-28. This is my only open recipe PR.

### Brief summary of what the package does

Promptu provides a transient menu that composes an LLM prompt from small,
user-customizable building blocks. You pick blocks one at a time with single keys while
the menu stays open and shows a live preview of the prompt being built; `RET` copies the
composed prompt to the kill ring for pasting into any agent or chat. Blocks can be
configured in elisp or via a JSON file (shared with a companion macOS menu-bar app).

### Direct link to the package repository

https://github.com/mrcnski/promptu.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed (I am upstream).

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (GPL-3.0-or-later)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (clean)
- [x] My elisp byte-compiles cleanly (no warnings with `byte-compile-error-on-warn`)
- [x] I've used `M-x checkdoc` to check the package's documentation strings (clean)
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe) (`make sandbox INSTALL=promptu` succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
