### PR TITLE
Add recipe for nightpanel-theme

### DIFF
--- a/recipes/nightpanel-theme
+++ b/recipes/nightpanel-theme
@@ -1,0 +1,1 @@
+(nightpanel-theme :fetcher github :repo "gregfelice/nightpanel-theme")


### PR DESCRIPTION
Resubmission of #10137, per @riscy's request there to open a fresh PR rather than
reopen. Recipe is unchanged; this adds the public history that was asked for.

### Provenance — the older public commits

> if you can show me some commits or something from a month ago, that would be fine

The theme's palette and the code that generates `nightpanel-theme.el` have been
in a public repository since 2026-05-25:
**[gregfelice/nightpanel](https://github.com/gregfelice/nightpanel)** — public
since 2026-01-28, ~100 commits, tags `v0.1.0-alpha` through `v0.2.6`.

| Commit | Date | What |
| --- | --- | --- |
| [`6a2fe15`](https://github.com/gregfelice/nightpanel/commit/6a2fe157764003dadd7fc9bbbd810100088f709a) | 2026-05-25 | First public commit carrying the nightpanel palette |
| [`0e6f61a`](https://github.com/gregfelice/nightpanel/commit/0e6f61a26af765d1bd595a72e375cb1f6a04517a) | 2026-05-26 | Adds [`palette.py`](https://github.com/gregfelice/nightpanel/blob/0e6f61a26af765d1bd595a72e375cb1f6a04517a/src/nightpanel/palette.py) and [`renderers/emacs.py`](https://github.com/gregfelice/nightpanel/blob/0e6f61a26af765d1bd595a72e375cb1f6a04517a/src/nightpanel/renderers/emacs.py) — the renderer that emits this theme |
| [`653376a`](https://github.com/gregfelice/nightpanel/commit/653376a9c216f5ec7ce8165c330b13bf92b6e636) | 2026-05-26 | Tagged `v0.2.1` |

All fourteen hex values in `nightpanel-theme.el` appear in that public
`palette.py` from 2026-05-26 — `#0A0A0A`, `#26DE81`, `#E8930A`, `#EF4444`, and
the rest. The renderer at `0e6f61a` emits the header line
`;; Generated from nightpanel.palette — edit there, not here.`

**What this does and does not show.** It is a different repository, and the
`.el` is generated output rather than a tracked file there — so what is public
from May is the palette and the renderer, not the theme file itself. The repo
where the rendered `.el` has been under version control since 2026-07-01 is my
private dotfiles repo, which is no use to you as evidence. I would rather state
that plainly than overstate the record. If the palette-and-renderer history is
not what you meant, I am content to wait and resubmit in September.

`nightpanel-theme` is a standalone extraction: the theme now lives on its own so
it can be installed without the rest of that project, with MELPA-conforming
headers, a GPL notice, and an autoload cookie added during extraction.

### Brief summary of what the package does

`nightpanel-theme` is a dark theme modelled on a Saab instrument cluster seen at
night: a pure black canvas (`#0A0A0A`), instrument-scale green for body text,
and amber reserved for things that would be a needle or a warning lamp — search
matches, strings, constants, TODO keywords. Red appears only for genuine errors.
Comments and inactive chrome recede to a dim green so the code itself is the
brightest thing on screen.

Single file, no dependencies beyond Emacs 27.1 (the floor comes from the
`tab-bar` and `tab-line` faces it styles).

### Direct link to the package repository

https://github.com/gregfelice/nightpanel-theme

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed** — I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more

  Left unchecked deliberately. `nightpanel-theme` itself is two days old; the
  palette and Emacs renderer behind it have been public since 2026-05-25 —
  see **Provenance** above. Your call whether that satisfies the intent.

- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

On the `Assisted-by` line: the face definitions are mine. An AI assistant was
used for the packaging work around them — header block, license boilerplate,
autoload cookie, commentary and README — and I reviewed all of it. Attribution
is in the file per the CONTRIBUTING guidance.

### Build verification

Both channels build clean from a fresh checkout of current `master`:

```
make recipes/nightpanel-theme                 -> nightpanel-theme-20260801.22.tar
make CHANNEL=stable recipes/nightpanel-theme  -> nightpanel-theme-0.1.0.tar
```

`package-lint`, `checkdoc`, and byte-compilation are all clean, and the package
installs and activates via `package-install-file` followed by
`(load-theme 'nightpanel t)`.
