### PR TITLE
Update epx: move to codeberg

### DIFF
--- a/recipes/epx
+++ b/recipes/epx
@@ -1,1 +1,1 @@
-(epx :fetcher sourcehut :repo "alex-iam/epx")
+(epx :fetcher codeberg :repo "alex-iam/epx")


### PR DESCRIPTION
epx is moved from SourceHut to Codeberd as part of consolidation of personal repositories. 

I am the author and maintainer of the package.

New link: https://codeberg.org/alex-iam/epx