### PR TITLE
Add recipe for consult-magit

### DIFF
--- a/recipes/consult-magit
+++ b/recipes/consult-magit
@@ -1,0 +1,1 @@
+(consult-magit :fetcher github :repo "nhojb/consult-magit")


### PR DESCRIPTION
### Brief summary of what the package does

Switch to a magit repository using `consult`. Offers open `magit-status` buffers, a history of previously opened repositories, and optionally repositories known to magit (see`consult-magit-include-known-repositories`)

### Direct link to the package repository

https://github.com/nhojb/consult-magit

### Your association with the package

Maintainer

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

