### PR TITLE
Add recipe for pgsql

### DIFF
--- a/recipes/pgsql
+++ b/recipes/pgsql
@@ -1,0 +1,4 @@
+(pgsql
+ :fetcher github
+ :repo "LuciusChen/pgsql.el"
+ :files ("pgsql.el" "pgsql-saslprep.el"))

--- a/recipes/pgsql
+++ b/recipes/pgsql
@@ -1,4 +1,1 @@
-(pgsql
- :fetcher github
- :repo "LuciusChen/pgsql.el"
- :files ("pgsql.el" "pgsql-saslprep.el"))
+(pgsql :fetcher github :repo "LuciusChen/pgsql.el")


### PR DESCRIPTION
### Brief summary of what the package does

`pgsql` is a focused synchronous PostgreSQL protocol 3.0 client for Emacs Lisp. It supports TCP/TLS, cleartext/MD5/SCRAM authentication (including SASLprep), simple and extended queries, explicit SQL NULL values, structured errors and notices, transaction status, timeouts, and cancellation with protocol resynchronization.

MELPA already contains the mature [`pg`](https://github.com/emarsden/pg-el) library. `pgsql` is neither a fork nor a drop-in replacement: it deliberately provides a smaller, dependency-free runtime API with opaque connection/result values, a single-request synchronous lifecycle, and completion synchronized on `ReadyForQuery`. These public invariants were designed for application libraries such as [`clutch`](https://github.com/LuciusChen/clutch/tree/refactor/pgsql). Users who need `pg` features such as COPY, idle asynchronous LISTEN/NOTIFY handling, Unix sockets, or extensible type decoders should continue to choose `pg`. The distinction is documented in the [README](https://github.com/LuciusChen/pgsql.el#relationship-to-pgel).

### Direct link to the package repository

https://github.com/LuciusChen/pgsql.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed; I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

The repository has been public since 2026-07-17 (22 days at submission), so the one-month item is intentionally left unchecked. The package is already exercised by the public `clutch` integration above; its CI covers Emacs 29.1 and 29.4, and I also ran the PostgreSQL 16 and TLS live suites before submission. I understand if review or merge should wait until 2026-08-17.
