### PR TITLE
Add recipe for eglotx

### DIFF
--- a/recipes/eglotx
+++ b/recipes/eglotx
@@ -1,0 +1,1 @@
+(eglotx :fetcher github :repo "cxa/eglotx")


### PR DESCRIPTION
### Brief summary of what the package does

Eglotx is an in-process Language Server Protocol multiplexer for Eglot. It lets one Eglot session use several complementary language servers without adding another executable, socket, or JSON encode/decode hop.

### Direct link to the package repository

https://github.com/cxa/eglotx

### Your association with the package

I am the package author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Validation notes

- `make recipes/eglotx` builds the snapshot package from the current upstream commit.
- `make CHANNEL=stable recipes/eglotx` builds version 0.1.3 from tag `v0.1.3`.
- The snapshot and stable tarballs install, generate autoloads, byte-compile all seven source files, and load `eglotx-presets` successfully in a clean `package-user-dir`.
- package-lint 20260808.1622 reports only three Emacs-version false positives for `eglot-uri-to-path` and `eglot--languages`. These functions are supplied by the declared `(eglot "1.24")` GNU ELPA dependency on Emacs 29; package-lint's backport table currently includes jsonrpc but not eglot. Registering eglot as a backport makes the lint run pass with no findings.
- `checkdoc` was run across all packaged source files. Its remaining findings concern internal helper argument mentions and capitalization of the protocol field name `workDoneToken`, not package metadata or public API documentation.
- `check-declare-file` passes for `eglotx-preset-engine.el`; the redundant Eglot declaration and the reported melpazoid findings have been addressed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] Codex assisted with package source changes, validation, and pull-request preparation; I reviewed the resulting changes and added `Assisted-by` metadata to every packaged source file
- [x] The package has been maintained in a public repository for 1 month or more — the repository became public on 2026-07-19, so this became true on 2026-08-19
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback as documented above
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Closes cxa/eglotx#1 when merged.
