### PR TITLE
Add recipe for hermes

### DIFF
--- a/recipes/hermes
+++ b/recipes/hermes
@@ -1,0 +1,1 @@
+(hermes :fetcher git :url "https://git.thanosapollo.org/emacs-hermes")


### PR DESCRIPTION
Adds the recipe for emacs-hermes, an Emacs interface to [Hermes Agent](https://github.com/NousResearch/hermes-agent).

Tested with `make recipes/hermes` and `make sandbox INSTALL=hermes`.