### PR TITLE
Add recipe for latex-to-svg-backend

### DIFF
--- a/recipes/latex-to-svg-backend
+++ b/recipes/latex-to-svg-backend
@@ -1,0 +1,3 @@
+(latex-to-svg-backend
+ :fetcher github
+ :repo "alberti42/latex-to-svg-backend")


### PR DESCRIPTION
### Brief summary of what the package does

A family of packages that render LaTeX math to SVG in Emacs, sharing one
compile backend:

- **latex-to-svg-backend** — LaTeX → SVG compile engine (`latex` + `dvisvgm`),
  color-independent output, on-disk + in-memory caching. No deps beyond Emacs.
- **latex-to-svg-frontend** — buffer/overlay front-end core: live previews,
  equation numbering, `\eqref`/`\ref`, reveal-on-cursor, async render-on-leave.
- **latex-to-svg-for-markdown** / **latex-to-svg-for-org** — thin mode adaptors
  that wire the front-end into `markdown-mode` and `org-mode`.
- **agent-shell-math-renderer** — renders LaTeX math in `agent-shell`'s streamed
  markdown output (independent front-end on the same backend).

The five packages cross-depend, which is why they are in a single PR:

```
latex-to-svg-backend            (leaf — only depends on Emacs)
├─ latex-to-svg-frontend        (needs latex-to-svg-backend)
│  ├─ latex-to-svg-for-markdown (needs latex-to-svg-frontend)
│  └─ latex-to-svg-for-org      (needs latex-to-svg-frontend)
└─ agent-shell-math-renderer    (needs latex-to-svg-backend + agent-shell)
```

`package-lint` flags the sibling deps as "not installable" only until this PR
merges; building the recipes together (`make recipes/<name>`) resolves them.
`agent-shell` (already on MELPA) is the only external dependency.

### Direct link to the package repository

- https://github.com/alberti42/latex-to-svg-backend
- https://github.com/alberti42/latex-to-svg  (frontend + the two adaptors)
- https://github.com/alberti42/agent-shell-math-renderer

### Your association with the package

Author and maintainer of all five packages.

### Relevant communications with the upstream package maintainer

**None needed** for `package.el` compatibility — I maintain all five packages
and they use only public API of their dependencies.

One naming note, to pre-empt a namespace concern: `agent-shell-math-renderer`
is an *add-on* to `agent-shell`, not a claim on its namespace.
`agent-shell-<extension>` is the de-facto naming pattern that agent-shell's
maintainer (Álvaro Ramírez, xenodium) uses for third-party extensions; this
package is listed in agent-shell's own "Related projects" section
(<https://github.com/xenodium/agent-shell#related-projects>) alongside other
`agent-shell-*` extensions, and its addition there was welcomed by the
maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (GPL-3.0-or-later)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

### On the 1-month-public requirement

The three repositories have different effective ages:

- **agent-shell-math-renderer** — public since **2026-07-02**, over one month.
- **latex-to-svg-backend** — the standalone repo dates from 2026-08-01, but its
  code is not new: the `latex` + `dvisvgm` rendering engine was originally
  written *inside* `agent-shell-math-renderer` (commit "Render display math
  with real latex + dvisvgm", 2026-07-02) and only **extracted** into its own
  repository on 2026-08-01 (agent-shell-math-renderer's "Delegate rendering to
  the latex-to-svg library"). So the engine has been maintained in public for
  over a month; only the split-out repo is younger.
- **latex-to-svg** (frontend + the two adaptors) — genuinely newer work, public
  since 2026-08-01, built on top of the extracted backend. It reaches one month
  around **~2026-09-01**.

Given this, a reasonable split would be to proceed with **latex-to-svg-backend**
and **agent-shell-math-renderer** now (both satisfy the rule in substance — the
backend by extraction lineage, agent-shell-math-renderer by repo age) and, if
you prefer, **hold the `latex-to-svg` frontend and adaptors** until they reach one month.
agent-shell-math-renderer depends only on the backend, not on the frontend, so
that partial merge is clean. I'm equally happy to wait for the whole set until
~2026-09-01 -- whichever you prefer.

### Disclaimer
This submission has been composed with the help of Claude Opus 4.8, providing
assistance in drafting, fact-checking, and running mechanical checks such as
byte-compilation, checkdoc, package-lint, and melpazoid.
