### PR TITLE
Add recipe for jsonyter

### DIFF
--- a/recipes/jsonyter
+++ b/recipes/jsonyter
@@ -1,0 +1,1 @@
+(jsonyter :fetcher github :repo "EGuthrieWasTaken/jsonyter.el")


### PR DESCRIPTION
### Brief summary of what the package does

jsonyter.el brings Jupyter into Emacs natively: interactive REPLs, rendered
.ipynb notebooks with lossless byte-identical saving, and `# %%` script
cells, all running against Python, Julia, R or SAS kernels on a local or
remote Jupyter server. It's backed by jsonyter
(https://github.com/EGuthrieWasTaken/jsonyter), a companion JSON-over-stdio
Python bridge.

### Direct link to the package repository

https://github.com/EGuthrieWasTaken/jsonyter.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)


### Note

I have worked on this package over the last few days in an effort to make an Emacs library which can interface with both local and remote Jupyter servers. Current packages are unable to interface with remote instances of Jupyter; this package fulfills this need.