### PR TITLE
Add todolog recipe

### DIFF
--- a/recipes/todolog
+++ b/recipes/todolog
@@ -1,0 +1,1 @@
+(todolog :fetcher github :repo "palozano/todolog")


### PR DESCRIPTION
Add a recipe for todolog, an Emacs interface for browsing TODO-style code comments tracked by the todolog CLI.

Repository: https://github.com/palozano/todolog

I am the maintainer of the upstream package.

Local checks run:
- emacs --batch -Q -L . --eval '(byte-compile-file "todolog.el")'
- emacs --batch -Q -L . --eval '(require '\''checkdoc)' --eval '(checkdoc-file "todolog.el")'
- make recipes/todolog
- package-install-file (smoke test from the generated tarball)