### PR TITLE
Add recipe for auto-side-windows

### DIFF
--- a/recipes/auto-side-windows
+++ b/recipes/auto-side-windows
@@ -1,0 +1,1 @@
+(auto-side-windows :fetcher github :repo "MArpogaus/auto-side-windows")


### PR DESCRIPTION
### Brief summary of what the package does

auto-side-windows puts buffers into side windows, based on rules you
write once. For each side you list buffer name patterns, major modes or
extra conditions, and the package builds the `display-buffer-alist`
entry that Emacs needs for it. It also picks a free slot on that side,
and it can reuse a side window that already shows a buffer of the same
major mode.

On top of that it adds a few commands: toggle the current buffer in and
out of its side window, send a buffer to a chosen side, and switch
between the buffers that live in side windows.

### Direct link to the package repository

https://github.com/MArpogaus/auto-side-windows

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Notes on the boxes above:

The repository is public since March 2025. A coding assistant helped
with the recent round of fixes, the test suite and the CI setup, so the
files carry an `Assisted-by:` line under the author line.

`make` in the repository runs byte-compilation with warnings as errors,
checkdoc, package-lint and an ERT suite. GitHub Actions runs the same on
Emacs 30.1, 30.2 and snapshot. I also built the recipe here with `make
recipes/auto-side-windows`, checked that the release channel picks up
the tag as version 0.1, and installed the resulting tarball into a clean
Emacs.
