### PR TITLE
Add recipe for auto-tab-groups

### DIFF
--- a/recipes/auto-tab-groups
+++ b/recipes/auto-tab-groups
@@ -1,0 +1,1 @@
+(auto-tab-groups :fetcher github :repo "MArpogaus/auto-tab-groups")


### PR DESCRIPTION
### Brief summary of what the package does

auto-tab-groups creates and closes tab bar groups around the commands
you name. You map a command, or a list of commands, to a group name or
to a function that computes one. When such a command runs, the package
switches to that group or creates it first. Closing works the same way,
so a group disappears when the command that owns it is done.

A companion mode does this for `project.el`, which gives every project
its own tab group. A second companion styles the tab bar and shows an
icon per group.

### Direct link to the package repository

https://github.com/MArpogaus/auto-tab-groups

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Notes on the boxes above:

The repository is public since November 2024. A coding assistant helped
with the recent round of fixes, the test suite and the CI setup, so the
files carry an `Assisted-by:` line under the author line.

`make` in the repository runs byte-compilation with warnings as errors,
checkdoc, package-lint and an ERT suite. GitHub Actions runs the same on
Emacs 29.1, 30.1, 30.2 and snapshot. I also built the recipe here with
`make recipes/auto-tab-groups`, checked that the release channel picks
up the tag as version 0.3, and installed the resulting tarball into a
clean Emacs.
