### PR TITLE
Add keydrill

### DIFF
--- a/recipes/keydrill
+++ b/recipes/keydrill
@@ -1,0 +1,1 @@
+(keydrill :fetcher github :repo "paradox1021/keydrill")


### PR DESCRIPTION
### Brief summary of what the package does

keydrill drills Emacs key bindings in short sessions until they become automatic.
Each session introduces at most five new moves, then shuffles them into a recall
rotation where you answer before seeing anything.

The distinguishing feature is **live-keymap resolution**: at session start,
keydrill looks up each deck command in the buffer you launched from, and when the
vanilla default binding is no longer live, it drills *your* binding instead. It
also ships an opt-in usage observer (off by default) that reports commands you
invoke via `M-x`, the menu, or the mouse which already have a key in your live
keymap, and a cold benchmark that writes nothing to the progress store.

The pass condition is speed, not retrievability: a move counts as learned at three
or more recall samples, at least 90% first-try, with a last latency under 800 ms.

Prior art, stated plainly: [[key-quiz](https://github.com/federicotdn/key-quiz)](https://github.com/federicotdn/key-quiz) and
keywiz already drill Emacs keys from a fixed list. keydrill adds live-keymap
resolution, the usage-gap observer, and the cold benchmark with an answer journal
behind it. I don't think it duplicates them, but I'd rather raise that myself than
have you find it.

Requires GNU Emacs 27.1+. No network code, no account, no telemetry, no upsell.

### Direct link to the package repository

https://github.com/paradox1021/keydrill

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed — I am the upstream maintainer.

### Checklist

- [x] The package is released under a [[GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [[CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [[CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [[package-lint](https://github.com/purcell/package-lint)](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [[CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

### Notes on the two items above

**One-month maturity.** The repository was created 2026-08-14, so I reach the
one-month mark on 2026-09-14. I've left that box unchecked rather than tick it
inaccurately. I'm in no hurry — happy for this to sit until then, and I'll keep
committing in the meantime.

**AI assistance.** The design, specification, deck, and milestone plan are mine and
predate any code. Most of the Elisp was then written by AI coding agents under my
direction, with byte-compilation, package-lint, checkdoc, and the ERT suite gating
each milestone. `Assisted-by:` lines are in the source file headers. I was the
first and most thorough reviewer of the output, and the two defects that mattered
most were found by hand, not by CI: a "your binding" note appearing on a stock
keymap because `where-is-internal` listed `C-<home>` before `M-<`, and a summary
printing "0 ms" for a session in which nothing had actually been timed. Both are
the same class of bug — correct inputs, wrong conclusion — and batch tests don't
tend to ask about that. This is also disclosed in the README.

**Testing.** 122 ERT tests in batch, byte-compilation with warnings as errors,
package-lint and checkdoc clean. Beyond that I hand-walked a terminal-translation
matrix (`C-g`, `C-x C-c`, `C-/`→`C-_`, `C-SPC`→`C-@`, `M-<`→`ESC <`, `C-M-\`→`ESC C-\`)
in GUI Emacs and in `emacs -nw` on GNU Emacs 30.2, since no batch test can observe
how a key actually arrives from a real terminal.