### PR TITLE
Add recipe for org-draw

### DIFF
--- a/recipes/org-draw
+++ b/recipes/org-draw
@@ -1,4 +1,4 @@
 (org-draw
  :fetcher github
  :repo "larrasket/org-draw"
- :files ("*.el" ("web" "web/canvas.html")))
+ :files (:defaults ("web" "web/canvas.html")))

--- a/recipes/org-draw
+++ b/recipes/org-draw
@@ -1,0 +1,4 @@
+(org-draw
+ :fetcher github
+ :repo "larrasket/org-draw"
+ :files ("*.el" ("web" "web/canvas.html")))


### PR DESCRIPTION

### Brief summary of what the package does

org-draw lets you draw on a remote device using tl;draw, and have the result land as an inline, re-editable PNG figure in Org-mode buffer. 

https://github.com/larrasket/org-draw

### Your association with the package

Author and maintainer. 

### Relevant communications with the upstream package maintainer

None.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->
