### PR TITLE
Add recipe for efinger

### DIFF
--- a/recipes/efinger
+++ b/recipes/efinger
@@ -1,0 +1,1 @@
+(efinger :fetcher git :url "https://git.andros.dev/andros/efinger.el.git")


### PR DESCRIPTION
### Brief summary of what the package does

A client for the Finger protocol (RFC 1288) with an Elfeed-inspired reader. Keep a list of accounts and browse their `.plan` files from a two-pane interface: the account list on one side and the fingered content on the other. Connections are asynchronous, so Emacs never blocks.

### Direct link to the package repository

https://git.andros.dev/andros/efinger.el

### Your association with the package

I am the author and maintainer of the package.

### Relevant communications with the upstream package maintainer

No.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
