### PR TITLE
Add recipe for org-roam-stats

### DIFF
--- a/recipes/org-roam-stats
+++ b/recipes/org-roam-stats
@@ -1,0 +1,4 @@
+(org-roam-stats
+ :fetcher github
+ :repo "GerardoCendejas/org-roam-stats"
+ :files (:defaults "web"))


### PR DESCRIPTION
### Brief summary of what the package does

Org-Roam-Stats creates an interactive, browser-based dashboard for your [org-roam](https://github.com/org-roam/org-roam) notes, letting you track note creation over time, find orphaned nodes, and filter your knowledge base by file tags.

It is designed for researchers, writers, and anyone who wants to understand the shape and health of their knowledge base, not just its content.

### Direct link to the package repository

https://github.com/GerardoCendejas/org-roam-stats.git

### Your association with the package

Maintainer

### Relevant communications with the upstream package maintainer

NA

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)