### PR TITLE
Rename recipe browsel to browser-gt

### DIFF
--- a/recipes/browsel
+++ b/recipes/browsel
@@ -1,3 +1,0 @@
-(browsel
- :fetcher github
- :repo "dmgerman/browsel")

--- a/recipes/browser-gt
+++ b/recipes/browser-gt
@@ -1,5 +1,4 @@
 (browser-gt
  :fetcher github
  :repo "dmgerman/browser-gt"
- :old-names (browsel)
- )
+ :old-names (browsel))

--- a/recipes/browser-gt
+++ b/recipes/browser-gt
@@ -1,0 +1,5 @@
+(browser-gt
+ :fetcher github
+ :repo "dmgerman/browser-gt"
+ :old-names (browsel)
+ )


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!--  ╔════════════╤════════════════════════════════╤═══════════════╗  -->
<!--  ║ Please use │ Add recipe for name-of-package │ as the title. ║  -->
<!--  ╚════════════╧════════════════════════════════╧═══════════════╝  -->

### Brief summary of what the package does

browser-gt is a module that allows Emacs and a Web browser to communicate with each other, in both directions.

### Direct link to the package repository

https://github.com/dmgerman/browser-gt

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

I am renaming the package only.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [X] The package has been maintained in a public repository for 1 month or more
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->
