### PR TITLE
Update org-social recipe

### DIFF
--- a/recipes/org-social
+++ b/recipes/org-social
@@ -1,3 +1,3 @@
-(org-social :fetcher github
-            :repo "tanrax/org-social.el"
+(org-social :fetcher git
+            :url "https://git.andros.dev/org-social/org-social.el.git"
             :files (:defaults "ui/org-social*.el" "ui/buffers/org-social*.el"))


### PR DESCRIPTION
Modification of an existing recipe (not a new package).

Switches the `org-social` recipe from the GitHub fetcher to a plain `git` fetcher pointing at the project's own Forgejo instance:

```elisp
(org-social :fetcher git
            :url "https://git.andros.dev/org-social/org-social.el.git"
            :files (:defaults "ui/org-social*.el" "ui/buffers/org-social*.el"))
```

I'm the package maintainer (Andros Fenollosa). The repository has been public and maintained for well over a month. The `:files` spec is unchanged.

- Repository: https://git.andros.dev/org-social/org-social.el
- License: GPL-3.0