### PR TITLE
Removed 'rules' from the list of files to fetch for gptel-agent-harness

### DIFF
--- a/recipes/gptel-agent-harness
+++ b/recipes/gptel-agent-harness
@@ -1,4 +1,4 @@
 (gptel-agent-harness
  :fetcher github
  :repo "beacoder/gptel-agent-harness"
- :files (:defaults "agents" "prompts" "rules"))
+ :files (:defaults "agents" "prompts"))


### PR DESCRIPTION
Removed 'rules' from the list of files to fetch, since the rule files have been moved to prompts directory.