### PR TITLE
Add recipe for gptel-commit-msg

### DIFF
--- a/recipes/gptel-commit-msg
+++ b/recipes/gptel-commit-msg
@@ -1,0 +1,1 @@
+(gptel-commit-msg :fetcher github :repo "fniessen/gptel-commit-msg")


### PR DESCRIPTION
<!-- Use this template when adding a new package recipe. -->
<!-- You don't have to use this when modifing an existing recipe. -->

<!--  ╔════════════╤════════════════════════════════╤═══════════════╗  -->
<!--  ║ Please use │ Add recipe for name-of-package │ as the title. ║  -->
<!--  ╚════════════╧════════════════════════════════╧═══════════════╝  -->

### Brief summary of what the package does

Generate Git commit messages from a diff buffer using GPTel.

The current diff buffer, regardless of how the diff was produced (Magit, VC, diff-mode, git diff output, etc.), is sent to the configured GPTel backend,which returns a commit message describing the changes.

The resulting message is displayed in a separate buffer and copied to the kill ring.

### Direct link to the package repository

https://github.com/fniessen/gptel-commit-msg

### Your association with the package

Author

### Relevant communications with the upstream package maintainer

None Needed.

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [] The package has been maintained in a public repository for 1 month or more
- [] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

<!-- After submitting, please fix any problems the CI reports. -->
