### PR TITLE
Add recipe for md-mode

### DIFF
--- a/recipes/md-mode
+++ b/recipes/md-mode
@@ -1,0 +1,1 @@
+(md-mode :fetcher github :repo "yibie/md-mode")


### PR DESCRIPTION
### Brief summary of what the package does

`md-mode` is a Markdown major mode with styled, source-preserving editing, structural commands, and a read-only in-buffer rendered view.

### Direct link to the package repository

https://github.com/yibie/md-mode

### Your association with the package

I am the maintainer of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Validation performed:

- `217/217` ERT tests passed.
- `package-lint` passed for `md-mode.el` and `md-render.el` (the latter with `package-lint-main-file` set to `md-mode.el`).
- Snapshot and stable MELPA builds passed.
- The generated `md-mode-0.3.0.tar` was installed and loaded successfully.
