### PR TITLE
Add recipe for fz-index

### DIFF
--- a/recipes/fz-index
+++ b/recipes/fz-index
@@ -1,0 +1,3 @@
+(fz-index :fetcher github :repo "uppet/fz-index"
+          :files ("fz-index.el" "fz-index.c" "emacs-module.h"
+                  "Makefile" "README.org"))


### PR DESCRIPTION
### Brief summary of what the package does

Sublime-style fuzzy file open (Goto Anything) backed by a native C dynamic module that holds the whole file index outside the Emacs Lisp heap.  Stays responsive at Chromium scale (400k+ files: ~0.7 s cold index, 24–38 ms per keystroke), with Sublime-style scoring, background indexing, .gitignore support, preview and frecency.

The `:files` list includes the C source and Makefile because the package auto-installs its module on first use: a prebuilt binary (Linux/macOS/Windows, x86_64 + aarch64) is downloaded from GitHub Releases with SHA-256 verification, and the bundled source is compiled locally as fallback.

### Direct link to the package repository

https://github.com/uppet/fz-index

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (GPL-3.0, LICENSE in the repo)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code) — `;; Assisted-by: Kimi Code CLI` under the Author line of fz-index.el; I reviewed every line before committing
- [ ] The package has been maintained in a public repository for 1 month or more — the repository is new (created 2026-08-28); I understand if this has to wait and am happy to be pinged or to re-open then
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback (clean)
- [x] My elisp byte-compiles cleanly (Emacs 28.2, 29.4, 30.2 in CI)
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe) — `make recipes/fz-index` produced fz-index-20260828.345.tar with all intended files
