### PR TITLE
Add recipe for magit-gha-badge

### DIFF
--- a/recipes/magit-gha-badge
+++ b/recipes/magit-gha-badge
@@ -1,0 +1,1 @@
+(magit-gha-badge :fetcher github :repo "agzam/magit-gha-badge.el")


### PR DESCRIPTION
### Brief summary of what the package does

`magit-gha-badge` shows a README-style GitHub Actions status badge as a one-line section at the top of the magit status buffer, fetched asynchronously from the GitHub API via `ghub` on every status refresh. `RET` or `mouse-1` on the badge, and `magit-gha-badge-browse-run` from any buffer in the repo, refetch and open the newest run page. In a fork the upstream repo is queried too, since that is where the runs of a pull request from the fork live. There are no steady-state timers: a bounded poll runs only while a run is pending, or while a pushed commit has no run yet, and only while the status buffer stays displayed.

### Direct link to the package repository

https://github.com/agzam/magit-gha-badge.el

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Note on the unchecked box: the repository was created on 2026-08-18, so it is 10 days old rather than a month. I am the author and maintainer, the package is tested and in daily use, and I will keep maintaining it. Happy to have this sit until the month is up if you prefer.

Some detail on the checked boxes:

- `package-lint` 20260808.1622 (current MELPA build) reports nothing.
- Byte-compiled with `byte-compile-error-on-warn` set, no output.
- `checkdoc` produces no warnings on either elisp file.
- Built with `make recipes/magit-gha-badge`; the tar holds only `magit-gha-badge.el` and the generated `magit-gha-badge-pkg.el`. Installed the result with `package-install-file` in a clean sandbox, dependencies resolved from MELPA and both entry points bound.
- The package has 78 buttercup specs, run in CI on Emacs 29.4 and 31.1.
