### PR TITLE
Add recipe for pyfun-mode

### DIFF
--- a/recipes/pyfun-mode
+++ b/recipes/pyfun-mode
@@ -1,0 +1,4 @@
+(pyfun-mode
+ :fetcher github
+ :repo "simontreanor/Pyfun"
+ :files ("editors/emacs/pyfun-mode.el"))


### PR DESCRIPTION
Follow-up to #10094, which @riscy closed on 2026-07-19 with an invitation to come back in about 25 days. The recipe is unchanged.

### Brief summary of what the package does

`pyfun-mode` is a major mode for [Pyfun](https://github.com/simontreanor/Pyfun), an F#-inspired, functional-first language that compiles to readable Python. It provides syntax highlighting, comment support, and on Emacs 29+ eglot integration with the language server that ships in the compiler (`pip install pyfun-lang` puts `pyfun` on PATH; the mode registers `pyfun lsp` with eglot).

### Direct link to the package repository

https://github.com/simontreanor/Pyfun

The package is `editors/emacs/pyfun-mode.el`, selected by the recipe's `:files` spec. Apache-2.0, with the boilerplate in the file header.

### Your association with the package

Author and maintainer of both the package and the Pyfun compiler.

### The one month gate

`pyfun-mode.el` has been public since 2026-07-14, so 46 days as of today. History: https://github.com/simontreanor/Pyfun/commits/main/editors/emacs/pyfun-mode.el

### On the monorepo

You also noted a preference for packages not to live in monorepos, because your build machinery has to pull the whole thing. I looked at splitting it out and decided against it, so I want to be straight about the tradeoff rather than quietly ignore the point.

A full bare clone of the repository is **3.3 MB** today (1.4 MiB packed), which is the whole compiler, its tests, the docs site and every editor integration. It is a Rust compiler with no vendored dependencies, so it stays small, and the mode's version is bumped in lockstep with the compiler on every release by a documented release process. Splitting the file into its own repository would mean two repositories to keep in step for one file whose version has to match the compiler it fronts, and it would have reset the very soak time this PR is waiting on.

If 3.3 MB is still more than you want to pull, say so and I will split it out and come back.

### What changed since #10094

Four things, all in the file itself:

- an `Assisted-by:` header line, as CONTRIBUTING.org asks
- `Version:` moved 0.1.0 to 0.6.0, tracking the compiler
- the `opaque` keyword added to the keyword list
- font-lock for computation-expression builders (`async`/`seq`/`result`/`option` before an opening brace) and for the bang forms `let!`/`do!`/`return!`/`yield!`

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (Apache-2.0)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and the `Assisted-by:` line is in the file header
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback. One remaining warning, unchanged since #10094: `with-eval-after-load` at the eglot registration. It only registers the server command for `pyfun-mode` buffers and changes nothing for users who never invoke eglot, but I am glad to take a different approach if you prefer one.
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in CONTRIBUTING.org

One caveat on those last four, in the same spirit as last time: they were run against the file as submitted to #10094, on Emacs 30.2, including the `emacs --batch` expansion of the `recipes/<NAME>` make target, since `make` is not available on this Windows machine. I have not re-run them against the four changes listed above, which are additive font-lock rules and header lines. Say the word if you would like them re-run before you review.