### PR TITLE
Remove recipe for smilefjes.el

### DIFF
--- a/recipes/smilefjes
+++ b/recipes/smilefjes
@@ -1,1 +1,0 @@
-(smilefjes :fetcher github :repo "themkat/smilefjes.el")


### PR DESCRIPTION
smilefjes.el no longer works, as the API it used is decommissioned. Sorry for not sending in this PR earlier; I was hoping that we would get a new candidate API. Think the best course of action is to remove it, so people don't download a non-working package.


I'm the maintainer and owner.


Sorry again, I have postponed this for far too long....