### PR TITLE
Add recipe for evil-twin

### DIFF
--- a/recipes/evil-twin
+++ b/recipes/evil-twin
@@ -1,0 +1,1 @@
+(evil-twin :fetcher github :repo "teeann/evil-twin")


### PR DESCRIPTION
### Brief summary of what the package does

`evil-twin` makes [key-chord](https://github.com/emacsorphanage/key-chord) work correctly with [evil](https://github.com/emacs-evil/evil): two-key chords bound directly into evil's per-state keymaps (normal/motion by default), with `key-chord-mode` left on permanently. This avoids the common-but-fragile approach of toggling the global `key-chord-mode` from evil state-change hooks, and adds zero latency in states (e.g. insert) where no chord is bound.

### Direct link to the package repository

https://github.com/teeann/evil-twin

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

N/A — I am the upstream maintainer.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html) (GPL-3.0-or-later; `LICENSE` included).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org).
- [x] I've used the latest version of `package-lint` to check for packaging issues, and addressed its feedback.
- [x] My elisp byte-compiles cleanly.
- [x] `M-x checkdoc` is happy with my docstrings.
- [x] I've built the package (`make recipes/evil-twin`) and it builds without errors; the generated metadata (summary, `Package-Requires`, URL) is correct.