### PR TITLE
Add recipe for journalctl

### DIFF
--- a/recipes/journalctl
+++ b/recipes/journalctl
@@ -1,0 +1,1 @@
+(journalctl :repo "WJCFerguson/journalctl" :fetcher github)


### PR DESCRIPTION
### Brief summary of what the package does

Major mode for viewing and `--follow`ing journald logs via `journalctl` on Linux systems (including remote hosts over TRAMP). It parses `--output json` records, giving:

- Formatted, prioritized-highlighted output with wrapped messages
- Multiple simultaneous `journalctl` queries interleaved and de-duplicated in timestamp order into one buffer — e.g. a broad `--priority warning` query alongside a narrow `--grep` query
- Region-based drill-down: an active region yields a ready-made `--since`/`--until` string for follow-up queries
- Timestamps rendered in the queried system's timezone, so they remain valid in further `--since`/`--until` arguments
- Jump-to-source (`M-.`) when records carry `CODE_FILE`/`CODE_LINE`
- Buffer capped at `journalctl-buffer-maximum-lines` so a long `--follow` cannot grow without bound

##### Direct link to the package repository

https://github.com/WJCFerguson/journalctl

##### Your association with the package

Author and maintainer.

##### Relationship to the existing `journalctl-mode` package (raising this upfront)

MELPA already hosts [`journalctl-mode`](https://github.com/SebastianMeisel/journalctl-mode), which is unrelated and takes a different approach: it provides a query-building UI with synchronous chunked loading, while this package interleaves multiple asynchronous JSON queries. The naming overlap is unfortunate history, and both packages currently define the commands `journalctl` and `journalctl-mode`, so they cannot be co-installed — this package's README documents the conflict prominently and tells users to install only one. Let me know if the recipe name is too close or the symbol clash disqualifying.

##### Checklist

- [x] The package is released under a GPL-compatible license (GPLv3; `COPYING` included)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] `package-lint` reports no issues
- [x] Byte-compiles cleanly on Emacs 29.1 (the declared minimum)
- [x] `checkdoc` reports no issues
- [x] ERT test suite included upstream (`journalctl-tests.el`, excluded from the package by the default files spec)
- [x] I am the upstream maintainer

**Recipe** (`recipes/journalctl`):
```elisp
(journalctl :fetcher github :repo "WJCFerguson/journalctl")
```