### PR TITLE
Rename pi-coding-agent to piem

### DIFF
--- a/recipes/pi-coding-agent
+++ b/recipes/pi-coding-agent
@@ -1,1 +1,0 @@
-(pi-coding-agent :fetcher github :repo "dnouri/pi-coding-agent")

--- a/recipes/piem
+++ b/recipes/piem
@@ -1,0 +1,2 @@
+(piem :fetcher github :repo "dnouri/piem"
+      :old-names (pi-coding-agent))


### PR DESCRIPTION
pi-coding-agent has been renamed to **piem**.

When the package was added in #9757, "pi.el" alone was too ambiguous, and so I chose "pi-coding-agent". In hindsight that wasn't a great name after all. For one, it clashes with upstream which contains a package called "pi-coding-agent" [itself](https://github.com/earendil-works/pi/tree/main/packages/coding-agent).

There have also been new Emacs support packages since, for example the vterm frontend in #10055, so "pi-coding-agent" seems like a poor fit today. It's why I did the rename to the less awkward and more unique "piem", which stands for "Pi for Emacs"; also piems are [a fun concept on their own](https://maths-from-the-past.org/pi-piem-and-piphilology-2/).

The package side of the rename is complete:

- `v3.0.0` is tagged and matches the `Version` header (per the stable-channel requirement, as in #9539)
- All old entry points keep working as deprecated aliases (scheduled for removal in 4.0), and old-name `setq`/`customize` settings migrate automatically on load
- The README has an "Upgrading from pi-coding-agent" section, and piem itself warns users to `M-x package-delete` the old package if it's still installed
- Development was assisted by the `pi` coding agent, recorded via `Assisted-by:` lines in `piem.el`

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Recipe change: the recipe file moves from `recipes/pi-coding-agent` to `recipes/piem`:

```elisp
(piem :fetcher github :repo "dnouri/piem"
      :old-names (pi-coding-agent))
```

Thanks!
