### PR TITLE
Rename pi-coding-agent -> pilish

### DIFF
--- a/recipes/pi-coding-agent
+++ b/recipes/pi-coding-agent
@@ -1,1 +1,0 @@
-(pi-coding-agent :fetcher github :repo "dnouri/piem")

--- a/recipes/pilish
+++ b/recipes/pilish
@@ -1,0 +1,1 @@
+(pilish :fetcher github :repo "dnouri/pilish" :old-names (pi-coding-agent))

--- a/recipes/pilish
+++ b/recipes/pilish
@@ -1,1 +1,2 @@
-(pilish :fetcher github :repo "dnouri/pilish" :old-names (pi-coding-agent))
+(pilish :fetcher github :repo "dnouri/pilish" :old-names (pi-coding-agent)
+        :files (:defaults ("assets" "assets/pilish-logo.svg")))


### PR DESCRIPTION
# Rename pi-coding-agent -> pilish

Sorry for the shuffle around this recipe. The repo was renamed to `piem` at first (#10197, closed after the clash with Kyle Meyer's `piem`), rolled back, and is now https://github.com/dnouri/pilish

I checked `pilish` against MELPA, GNU ELPA, NonGNU ELPA, and emacsmirror — the name is free.

```diff
-(pi-coding-agent :fetcher github :repo "dnouri/piem")
+(pilish :fetcher github :repo "dnouri/pilish" :old-names (pi-coding-agent))
```

`:old-names` keeps the download counts and shows "Renamed from: pi-coding-agent" on the site.

For users it's a clean break: install `pilish`, `M-x package-delete RET pi-coding-agent`, then rename `pi-coding-agent` to `pilish` in their init. The README covers the details.

### Brief summary of what the package does

Emacs frontend for the pi coding agent (https://pi.dev): a two-window UI with a rendered-Markdown chat buffer and a separate prompt buffer, plus disk-backed session and conversation-tree browsers.

### Direct link to the package repository

https://github.com/dnouri/pilish

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
