### PR TITLE
Use default value for package-build-build-function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,6 @@ ifeq ($(CHANNEL), unstable)
   HTMLDIR := html
   CHANNEL_CONFIG := "(progn\
   (setq package-build-releases nil)\
-  (setq package-build-build-function 'package-build--build-multi-file-package)\
   (setq package-build-snapshot-version-functions '(package-build-timestamp-version))\
   (setq package-build-badge-data '(\"MELPA\" \"\#922793\")))"
 
@@ -107,7 +106,6 @@ else ifeq ($(CHANNEL), stable)
   CHANNEL_CONFIG := "(progn\
   (setq package-build-releases t)\
   (setq package-build-all-publishable nil)\
-  (setq package-build-build-function 'package-build--build-multi-file-package)\
   (setq package-build-release-version-functions '(package-build-tag-version))\
   (setq package-build-badge-data '(\"MELPA Stable\" \"\#3e999f\")))"
 


### PR DESCRIPTION
Hi, this PR fixes #10200.
Package-Build 5.0.2 removed `package-build--build-multi-file-package` and now defaults to `package-build--build-package`.
So I dropped the two `setq` lines from the Makefile and verified that a package builds successfully.

Thank you.
