### PR TITLE
Remove recipe magik-company, deprecated by upstream author

### DIFF
--- a/recipes/magik-company
+++ b/recipes/magik-company
@@ -1,3 +1,0 @@
-(magik-company
- :fetcher github
- :repo "reinierkof/magik-company")


### PR DESCRIPTION
### Reason

Magik-company was an external package to complement magik-mode.

A proper completion framework is now integrated into magik-mode, making this package redundant.


### Brief summary of what the package does

Completion package

### Direct link to the package repository

https://github.com/reinierkof/magik-company

### Your association with the package

I am the author.

