### PR TITLE
Add recipe for modern-tab

### DIFF
--- a/recipes/modern-tab
+++ b/recipes/modern-tab
@@ -1,0 +1,1 @@
+(modern-tab :fetcher github :repo "MArpogaus/modern-tabs")

--- a/recipes/modern-tab
+++ b/recipes/modern-tab
@@ -1,1 +1,1 @@
-(modern-tab :fetcher github :repo "MArpogaus/modern-tabs")
+(modern-tab :fetcher github :repo "MArpogaus/modern-tab")


### PR DESCRIPTION
### Brief summary of what the package does

modern-tab gives the two rows of tabs Emacs has the look of the editors
people come here from: `modern-tab-bar-mode` dresses the tab bar, one
tab per tab group, and `modern-tab-line-mode` the tab line, one tab per
buffer of a window. A coloured indicator beside the selected tab, an
icon on every tab (from nerd-icons where it is installed, plain
characters otherwise), buttons of one glyph family, a tab line that
hides itself where a window shows one buffer, and every variable a mode
borrows from `tab-bar` and `tab-line` given back when it is turned off.
The two modes are independent.

The package is `modern-tab`, after its main file and the prefix of every
symbol; the repository is `modern-tabs`, after the two rows it dresses.
The tarball holds `modern-tab.el`, `modern-tab-bar.el` and
`modern-tab-line.el`.

### Direct link to the package repository

https://github.com/MArpogaus/modern-tabs

### Your association with the package

I am the author and the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [ ] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Notes on the boxes above:

The repository itself is new: the code was split out of
[auto-tab-groups](https://github.com/MArpogaus/auto-tab-groups) (#10157),
where it lived as `auto-tab-groups-eyecandy.el` since 2024, and out of my
configuration, on 2026-09-03. If a month in its own repository is what
the rule means, I am happy for this PR to wait until then.

`make` in the repository runs byte-compilation with warnings as errors,
package-lint with `package-lint-main-file` set to `modern-tab.el`,
relint and 48 ERT tests; CI runs the same on Emacs 29.1, 30.1, 30.2,
31.1 and snapshot, plus melpazoid and the checkdoc and indentation
hooks on every push. The repository is at version 1.0 (tag `v1.0`). I
built the recipe in a fresh melpa checkout with `make recipes/modern-tab`
and installed it with `make sandbox INSTALL=modern-tab`.
