### PR TITLE
Add mode-line-path

### DIFF
--- a/recipes/mode-line-path
+++ b/recipes/mode-line-path
@@ -1,0 +1,1 @@
+(mode-line-path :fetcher github :repo "arthurgleckler/mode-line-path")


### PR DESCRIPTION
### Brief summary of what the package does

Display an abbreviated file path in the GNU Emacs mode line.  Shorten long paths using the values of short environment variable names (three characters or fewer) as prefixes.  If a path is still too long, truncate it with an ellipsis.

I'm re-posting this pull request, which was originally [10116](https://github.com/melpa/melpa/pull/10116), because the project has now been maintained in a public repository for more than one month.  That was the only thing missing originally.

### Direct link to the package repository

https://github.com/arthurgleckler/mode-line-path

### Your association with the package

I wrote this in 2013, and have used it every day since.  Being able to see an abbreviated version of the full path of each buffer in the mode line is great for context.  Preparing this package for MELPA, I cleaned it up extensively, hoping to make it useful to others.  I added caching, customizations, and tests.  (Even without caching, it has always been fast, but I added it in case some users have enormous numbers of environment variables, for example.  The one-second cache TTL means that caching isn't noticeable.)

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)