### PR TITLE
Add recipe for donkey

### DIFF
--- a/recipes/donkey
+++ b/recipes/donkey
@@ -1,0 +1,1 @@
+(donkey :fetcher github :repo "YardQuit/donkey")


### PR DESCRIPTION
### Brief summary of what the package does

An opinionated modal editing layer for Emacs in a single file. It adds a Normal state entered with `C-g`, with vi-style motions and counts, text-object marks (word, symbol, sentence, paragraph, delimiter pairs, balanced expressions), a "mark run" mode, line banking for non-contiguous selections, rectangles, wrapping, undo/redo and an in-package tutor (`M-x donkey-tutor`). It leans on native Emacs commands wherever possible and adds custom ones only where the behavior must differ. Optional Smartparens integration.

### Direct link to the package repository

https://github.com/YardQuit/donkey

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

Notes: GPL-3.0 with a LICENSE file GitHub detects. Public since the 1.0.0 release on 2026-07-21; current release 1.7.1, tagged, and `CHANNEL=stable make recipes/donkey` picks the tag up as 1.7.1. Byte-compiled with warnings as errors, checkdoc and package-lint (2026-09-03) clean; CI runs the test suite on Emacs 29.1, 30.1 and 31.1.
