### PR TITLE
Add recipe for latex-to-svg-frontend

### DIFF
--- a/recipes/latex-to-svg-frontend
+++ b/recipes/latex-to-svg-frontend
@@ -1,0 +1,4 @@
+(latex-to-svg-frontend
+ :fetcher github
+ :repo "alberti42/latex-to-svg"
+ :files ("latex-to-svg-frontend.el"))


### PR DESCRIPTION
**AI disclaimer:** This PR was composed by me, aided by Opus 5.

### Brief summary of what the package does

`latex-to-svg-frontend` renders LaTeX math in a buffer as SVG images overlaid on the source, which stays in place so copy and save round-trip renderable LaTeX. It handles math detection, overlay lifecycle, equation numbering, `\ref` / `\eqref` resolution, reveal-on-cursor, and refreshing on theme and font changes. It is markup-agnostic: it never parses a specific markup itself, but asks the buffer's adaptor (two other "thin" packages, which are hosted in the same GitHub repo and which will be submitted as MELPA recipes in the future; more on this later) for the delimiters and the regions to skip.

The engine compiles each equation once and caches an SVG that is independent of color and size; a theme switch re-tints and a font change rescales straight from the cache. This ensures a very fast refresh of the equations on the buffer, without lengthy LaTeX recompilation when the theme or font size has changed.

### Short description on how it relates to other packages in MELPA

This is the frontend core of the latex-to-svg family whose engine, [`latex-to-svg-backend`](https://melpa.org/#/latex-to-svg-backend), you reviewed and merged in [#10152](https://github.com/melpa/melpa/pull/10152); this front-end package is different from [`agent-shell-math-renderer`](https://melpa.org/#/agent-shell-math-renderer), which was developed as an extension to [`agent-shell`](https://github.com/xenodium/agent-shell) and which you reviewed and merged in [#10198](https://github.com/melpa/melpa/pull/10198).

### Direct link to the package repository

https://github.com/alberti42/latex-to-svg

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed.** The package uses only public Emacs API.

### Two more recipes to follow

The same repository holds two thin mode adaptors, `latex-to-svg-for-org` and `latex-to-svg-for-markdown`, which supply this core with a buffer's math delimiters and the regions to skip (source blocks, code fences) and turn it on. Since the math delimiters and rules for what needs to be skipped (e.g., comment regions) depend on the mode (Org, Markdown, etc.), I decided to split responsibilities between the core `latex-to-svg-frontend` and the mode-specific adaptors, without trying to create a universal front-end that aims at fitting to any kind of mode. 

I am submitting this one first and will open pull requests for the adaptors once the core is merged, per `CONTRIBUTING.org`.

**If you want to see it working**, note that this package on its own renders nothing: it is the markup-agnostic core, and an adaptor is what tells it where the math is and turns it on. So a live test needs one adaptor from the same repository alongside it. Independently of the package manager:

```elisp
;; latex-to-svg-backend comes from MELPA; latex and dvisvgm must be on exec-path
(add-to-list 'load-path "/path/to/clone/of/latex-to-svg")
(require 'latex-to-svg-for-org)        ; or latex-to-svg-for-markdown
(add-hook 'org-mode-hook #'latex-to-svg-for-org-mode)
```

Then open an Org file with `$x^2$` or a `\begin{equation}` block. The README shows the same with `straight`, `elpaca` and `package-vc-install`.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses) (GPL-3.0-or-later)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more (public since 2026-08-01)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

melpazoid is clean, and `CHANNEL=stable` detects the current release, 0.15.2.

The `ignore-errors` pattern you flagged in #10152 is gone here too.