### PR TITLE
Add recipe for el remoto

### DIFF
--- a/recipes/remoto
+++ b/recipes/remoto
@@ -1,0 +1,1 @@
+(remoto :fetcher github :repo "agzam/remoto.el")


### PR DESCRIPTION
### Brief summary of what the package does

It allows you to browse any GH repo with `C-x f /gh:org/repo` 

### Direct link to the package repository

https://github.com/agzam/remoto.el

### Your association with the package

Author and maintainer.

### Relevant communications with the upstream package maintainer

**None needed.**

This is a resubmission of #9978, which I withdrew in May because I wanted to redesign the package rather than have you review a moving target. That redesign is done: the lookup architecture was reworked, issue and PR browsing was added, and so was the optional Embark layer. All the feedback from the first review is in: the `dired-get-filename` declaration, the double negations melpazoid reported, the checkdoc quoting, and `:fetcher` before `:repo` in the recipe. @riscy said at the time to open a new pull request rather than ask for a reopen.

Two things melpazoid still reports on the current tip, both deliberate:

- `Loading a package should rarely add hooks` (three) and `Avoid top-level advice or ensure you support (unload-feature) support` (one). The file-name handler, the hooks and the advice are what the package is; there is nothing to defer them behind. `remoto-unload-function` removes every one of them, and a test covers that.
- The GitHub release tag trails `Version:` by one patch. I will tag once this settles.

### Checklist

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [X] The package has been maintained in a public repository for 1 month or more
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)

One note on package-lint. Every `(any ...)` in an `rx` form is reported as a call to the function Emacs 31.1 added under that name, since package-lint 20260903 regenerated its stdlib data. The sources now use `in`, the `rx` synonym, so the run is clean, but the false positive will hit other packages using `rx`.
