### PR TITLE
Add recipe for nonogram

### DIFF
--- a/recipes/nonogram
+++ b/recipes/nonogram
@@ -1,0 +1,4 @@
+(nonogram
+ :fetcher git
+ :url "https://git.andros.dev/andros/nonogram.el.git"
+ :files (:defaults ("puzzles" "puzzles/*.non")))


### PR DESCRIPTION
### Brief summary of what the package does

nonogram is a player for nonogram puzzles (also known as picross, griddlers or hanjie) inside Emacs. Fill the grid so each row and column matches its clue numbers and a hidden picture appears. The whole board, clue numbers included, is drawn with SVG on a solid background so it stays legible under any theme. It ships 33 bundled puzzles ordered from easiest to hardest, and can download and update more from a remote source.

### Direct link to the package repository

https://git.andros.dev/andros/nonogram.el

### Your association with the package

I am the author and maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] LLMs were used to generate some of the code, and if so, I've added an `Assisted-by:` line as described in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#attribution-for-ai-generated-code)
- [x] The package has been maintained in a public repository for 1 month or more
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#test-your-recipe)
