### PR TITLE
Add recipe for perinf

### DIFF
--- a/recipes/perinf
+++ b/recipes/perinf
@@ -1,0 +1,2 @@
+(perinf :fetcher github :repo "algon236/perinf"
+        :files ("perinf*.el" (:exclude "perinf-pkg.el")))


### PR DESCRIPTION
### Brief summary of what the package does

PerInf is an Org-backed personal work and information manager for Emacs. It connects tasks, meetings, participants, decisions, documents, audio, transcripts and reviewed minutes through stable IDs in ordinary Org files. It includes persistent task timers and five UI languages. The reviewed-minutes workflow requires explicit human approval before minutes become final.

It can supplement Org Agenda while keeping meeting evidence, review history and resulting work in one interface. It requires Emacs 29.1 and Org 9.6 and has no mandatory doct or org-roam dependency.

### Direct link to the package repository

https://github.com/algon236/perinf

### Your association with the package

I am the package maintainer, Niels Søndergaard (algon236). This submission was prepared with Codex at my request.

### Relevant communications with the upstream package maintainer

None needed; this is my repository. Packaging and compatibility changes are merged in https://github.com/algon236/perinf/pull/9.

### Checklist

- [x] The package is released under a GPL-compatible free software license (GPL-3.0-or-later).
- [x] I've read CONTRIBUTING.org.
- [x] LLMs were used to generate some of the code, and an `Assisted-by:` line is included in the runtime source files.
- [x] The package has been maintained in a public repository for 1 month or more (since July 2026).
- [x] I've used the latest package-lint to check packaging and addressed its feedback.
- [x] The Lisp byte-compiles cleanly.
- [x] I've used checkdoc to check the documentation strings and addressed its findings.
- [x] I've built and installed the package using the instructions in CONTRIBUTING.org.

Validation used Emacs 32.0.50: 42 ERT tests passed, including an additional run with org-roam autosync enabled against a temporary database. The actual MELPA recipe fetched upstream commit 7b12b66f55e48e8f0b8c6672b198e9377e57def0 and built `perinf-20260911.750.tar`; package-install-file, command autoloading and opening the Danish UI passed in a fresh package directory.

On macOS the optional badge renderer needed a font that was not installed, so the successful recipe build used `CONFIG="(setq package-build-badge-data nil)"`. No package-build code or recipe behavior was bypassed. Emacs 31 was not independently tested.
