### PR TITLE
Point react-snippets recipe to new repo

### DIFF
--- a/recipes/react-snippets
+++ b/recipes/react-snippets
@@ -1,4 +1,4 @@
 (react-snippets
  :fetcher github
- :repo "johnmastro/react-snippets.el"
+ :repo "svjson/react-snippets.el"
  :files ("*.el" "snippets"))


### PR DESCRIPTION
Point the react-snippets recipe to the repo owned by @svjson, where he's [agreed to take over maintainership](https://github.com/johnmastro/react-snippets.el/issues/13).

[moving to https://github.com/svjson/react-snippets.el --riscy]